### PR TITLE
fix(ci): resolve Windows artifact upload conflict (Issue #41)

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -83,6 +83,7 @@ jobs:
           ts: ${{ matrix.ts }}
           args: --with-firebird=${{ env.FIREBIRD_HOME }}
           run-tests: 'false'
+          artifact-name: php_firebird-${{ matrix.php-version }}-${{ matrix.ts }}-${{ matrix.arch }}-fb${{ matrix.firebird-version }}
 
       - name: Rename DLL with metadata
         shell: pwsh


### PR DESCRIPTION
## Summary
Fixes artifact upload conflict in Windows DLLs release workflow.

## Root Cause
The `php/php-windows-builder/extension@v1` action auto-uploads artifacts with a name that doesn't include the Firebird version. When building multiple FB versions (3.0, 4.0, 5.0) for the same PHP/ts/arch combination, all jobs tried to create artifacts with the same name, causing 409 Conflict errors.

## Fix
Added `artifact-name` parameter to the builder step that includes the Firebird version:
```yaml
artifact-name: php_firebird-${{ matrix.php-version }}-${{ matrix.ts }}-${{ matrix.arch }}-fb${{ matrix.firebird-version }}
```

## Testing
Workflow will be tested on merge via manual workflow_dispatch trigger.

Closes #41