### PR TITLE
test(coverage): Parameter binding comprehensive coverage (#62)

### DIFF
--- a/.specify/specs/062-parameter-binding-coverage/spec.md
+++ b/.specify/specs/062-parameter-binding-coverage/spec.md
@@ -1,0 +1,47 @@
+# Spec: Parameter Binding Test Coverage
+
+**Issue**: #62
+**Branch**: `test/parameter-binding-coverage`
+**Date**: 2026-03-02
+**Status**: Implementing
+
+---
+
+## Intent
+
+Achieve ≥80% line coverage on `fbird_query_bind.c` (41.8% → 80%).
+This file implements all parameter binding from PHP zval to Firebird XSQLDA/SQLVAR.
+
+---
+
+## Background
+
+| File | Estimated Coverage | Target |
+|------|--------------------|--------|
+| `fbird_query_bind.c` | 41.8% | ≥80% |
+
+**Existing coverage tests** (already on satware-main):
+- `bind_boolean_invalid_string.phpt` — string "invalid" rejected for BOOLEAN
+- `bind_boolean_must_be_boolean.phpt` — non-boolean types rejected
+- `bind_boolean_numeric_string.phpt` — numeric string rejected for BOOLEAN
+- `bind_edge_cases.phpt` — INT64 limits, empty string, large blob, explicit NULL (BIGINT/VARCHAR)
+- `bind_long_scaled_out_of_range.phpt` — DECIMAL out of range (long scaled)
+- `bind_short_scaled_out_of_range.phpt` — DECIMAL out of range (short scaled)
+
+**Gaps addressed by new tests:**
+
+| File | New Coverage |
+|------|-------------|
+| `bind_boolean_null.phpt` | Valid TRUE/FALSE/NULL roundtrip for BOOLEAN column |
+| `bind_temporal_types.phpt` | DATE/TIME/TIMESTAMP: ISO string, unix int, NULL, epoch, future |
+| `bind_numeric_types.phpt` | SMALLINT/INTEGER/BIGINT/FLOAT/DOUBLE/DECIMAL/NUMERIC zero/max/min/NULL |
+| `bind_error_paths.phpt` | Too many/few params, false handle, wrong resource type, VARCHAR truncation, num_params/param_info errors |
+
+---
+
+## Constitution Alignment
+
+| Article | Requirement |
+|---------|-------------|
+| I | C extension — `.phpt` tests |
+| VII | ≥80% for `fbird_query_bind.c` |

--- a/tests/coverage/bind_boolean_null.phpt
+++ b/tests/coverage/bind_boolean_null.phpt
@@ -68,9 +68,11 @@ while ($row = fbird_fetch_row($q)) {
 }
 fbird_free_result($q);
 
-// Cleanup
+// Cleanup: free prepared stmt and commit implicit tx before DDL.
+// Use @ on final commit — prepared statement handle may still hold the table.
+@fbird_commit($dbh);
 fbird_query($dbh, 'DROP TABLE BIND_BOOL_COV');
-fbird_commit($dbh);
+@fbird_commit($dbh);
 fbird_close($dbh);
 
 echo "Done\n";

--- a/tests/coverage/bind_boolean_null.phpt
+++ b/tests/coverage/bind_boolean_null.phpt
@@ -1,0 +1,91 @@
+--TEST--
+Coverage: BOOLEAN column binding — true/false/NULL roundtrip
+--EXTENSIONS--
+firebird
+--SKIPIF--
+<?php
+include __DIR__ . '/../skipif.inc';
+require_once __DIR__ . '/../firebird.inc';
+// BOOLEAN type requires Firebird 3.0+
+if (get_fb_version() < 3.0) {
+    die('skip BOOLEAN type requires Firebird 3.0+');
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/../firebird.inc';
+
+$dbh = fbird_connect($test_base);
+if (!$dbh) die('skip connect failed: ' . fbird_errmsg());
+
+fbird_query($dbh, "EXECUTE BLOCK AS BEGIN
+  IF (EXISTS(SELECT 1 FROM RDB\$RELATIONS WHERE RDB\$RELATION_NAME = 'BIND_BOOL_COV')) THEN
+    EXECUTE STATEMENT 'DROP TABLE BIND_BOOL_COV';
+END");
+fbird_commit($dbh);
+
+fbird_query($dbh, '
+    CREATE TABLE BIND_BOOL_COV (
+        ID    INTEGER NOT NULL PRIMARY KEY,
+        B     BOOLEAN,
+        V     VARCHAR(20)
+    )');
+fbird_commit($dbh);
+
+$stmt = fbird_prepare($dbh, 'INSERT INTO BIND_BOOL_COV (ID, B, V) VALUES (?, ?, ?)');
+
+// Test 1: true
+echo "Test 1: bind true\n";
+$r = fbird_execute($stmt, 1, true, 'yes');
+var_dump($r !== false);
+
+// Test 2: false
+echo "Test 2: bind false\n";
+$r = fbird_execute($stmt, 2, false, 'no');
+var_dump($r !== false);
+
+// Test 3: NULL
+echo "Test 3: bind NULL to BOOLEAN\n";
+$r = fbird_execute($stmt, 3, null, 'null');
+var_dump($r !== false);
+
+// Test 4: explicit NULL for VARCHAR alongside non-NULL BOOLEAN
+echo "Test 4: NULL varchar alongside BOOLEAN\n";
+$r = fbird_execute($stmt, 4, true, null);
+var_dump($r !== false);
+
+fbird_commit($dbh);
+
+// Verify roundtrip
+$q = fbird_query($dbh, 'SELECT ID, B, V FROM BIND_BOOL_COV ORDER BY ID');
+while ($row = fbird_fetch_row($q)) {
+    // Normalize: Firebird returns '1'/'0' or true/false depending on version
+    $b = $row[1];
+    if ($b === '1' || $b === true || $b === 1) $b = 'true';
+    elseif ($b === '0' || $b === false || $b === 0) $b = 'false';
+    else $b = 'null';
+    echo "ID={$row[0]} B=$b V=" . var_export($row[2], true) . "\n";
+}
+fbird_free_result($q);
+
+// Cleanup
+fbird_query($dbh, 'DROP TABLE BIND_BOOL_COV');
+fbird_commit($dbh);
+fbird_close($dbh);
+
+echo "Done\n";
+?>
+--EXPECTF--
+Test 1: bind true
+bool(true)
+Test 2: bind false
+bool(true)
+Test 3: bind NULL to BOOLEAN
+bool(true)
+Test 4: NULL varchar alongside BOOLEAN
+bool(true)
+ID=1 B=true V='yes'
+ID=2 B=false V='no'
+ID=3 B=null V='null'
+ID=4 B=true V=NULL
+Done

--- a/tests/coverage/bind_error_paths.phpt
+++ b/tests/coverage/bind_error_paths.phpt
@@ -1,0 +1,113 @@
+--TEST--
+Coverage: Parameter binding error paths — param count mismatch, bad prepared stmt, type errors
+--EXTENSIONS--
+firebird
+--SKIPIF--
+<?php include __DIR__ . '/../skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../firebird.inc';
+
+$dbh = fbird_connect($test_base);
+if (!$dbh) die('skip connect failed: ' . fbird_errmsg());
+
+fbird_query($dbh, "EXECUTE BLOCK AS BEGIN
+  IF (EXISTS(SELECT 1 FROM RDB\$RELATIONS WHERE RDB\$RELATION_NAME = 'BIND_ERR_COV')) THEN
+    EXECUTE STATEMENT 'DROP TABLE BIND_ERR_COV';
+END");
+fbird_commit($dbh);
+
+fbird_query($dbh, 'CREATE TABLE BIND_ERR_COV (ID INTEGER NOT NULL PRIMARY KEY, V VARCHAR(20))');
+fbird_commit($dbh);
+
+$stmt = fbird_prepare($dbh, 'INSERT INTO BIND_ERR_COV (ID, V) VALUES (?, ?)');
+
+// Test 1: too many parameters (3 bound, 2 expected)
+echo "Test 1: too many parameters\n";
+$r = @fbird_execute($stmt, 1, 'hello', 'extra');
+if ($r === false) {
+    echo "Rejected with error\n";
+} else {
+    echo "Executed (extra args ignored)\n";
+}
+fbird_commit($dbh);
+
+// Test 2: too few parameters (1 bound, 2 expected)
+echo "Test 2: too few parameters\n";
+$r = @fbird_execute($stmt, 2);
+if ($r === false) {
+    echo "Rejected with error\n";
+} else {
+    echo "Executed (missing arg)\n";
+}
+fbird_commit($dbh);
+
+// Test 3: fbird_execute with false (not a prepared statement resource)
+echo "Test 3: execute with false handle\n";
+$r = @fbird_execute(false, 1, 'x');
+var_dump($r === false);
+
+// Test 4: fbird_execute with connection resource (wrong type)
+echo "Test 4: execute with connection resource\n";
+$r = @fbird_execute($dbh, 1, 'x');
+var_dump($r === false);
+
+// Test 5: CHAR truncation — value longer than column allows
+echo "Test 5: VARCHAR truncation (value longer than VARCHAR(20))\n";
+$long = str_repeat('X', 100); // 100 chars into VARCHAR(20)
+$r = @fbird_execute($stmt, 5, $long);
+if ($r === false) {
+    $err = fbird_errmsg();
+    echo "Rejected: " . (strlen($err) > 0 ? "with error" : "unknown") . "\n";
+} else {
+    // Firebird may truncate silently or raise an error
+    echo "Accepted (may be truncated)\n";
+    fbird_commit($dbh);
+}
+
+// Test 6: fbird_num_params on valid and invalid statements
+echo "Test 6: fbird_num_params on valid stmt\n";
+$n = fbird_num_params($stmt);
+var_dump((int)$n === 2);
+
+echo "Test 7: fbird_num_params on false\n";
+$n = @fbird_num_params(false);
+var_dump($n === false || $n === null || $n === 0);
+
+// Test 8: fbird_param_info on invalid statement
+echo "Test 8: fbird_param_info on false\n";
+$info = @fbird_param_info(false, 0);
+var_dump($info === false || $info === null);
+
+// Test 9: fbird_param_info out-of-range index on valid stmt
+echo "Test 9: fbird_param_info out-of-range index\n";
+$info = @fbird_param_info($stmt, 99);
+var_dump($info === false || $info === null);
+
+// Cleanup
+fbird_query($dbh, 'DROP TABLE BIND_ERR_COV');
+fbird_commit($dbh);
+fbird_close($dbh);
+
+echo "Done\n";
+?>
+--EXPECTF--
+Test 1: too many parameters
+%s
+Test 2: too few parameters
+%s
+Test 3: execute with false handle
+bool(true)
+Test 4: execute with connection resource
+bool(true)
+Test 5: VARCHAR truncation (value longer than VARCHAR(20))
+%s
+Test 6: fbird_num_params on valid stmt
+bool(true)
+Test 7: fbird_num_params on false
+bool(true)
+Test 8: fbird_param_info on false
+bool(true)
+Test 9: fbird_param_info out-of-range index
+bool(true)
+Done

--- a/tests/coverage/bind_error_paths.phpt
+++ b/tests/coverage/bind_error_paths.phpt
@@ -40,12 +40,17 @@ if ($r === false) {
 } else {
     echo "Executed (missing arg)\n";
 }
-fbird_commit($dbh);
+// fbird_execute failure may roll back the implicit transaction; suppress stale-handle warning
+@fbird_commit($dbh);
 
-// Test 3: fbird_execute with false (not a prepared statement resource)
+// Test 3: fbird_execute with false — PHP 8 TypeError is NOT suppressed by @, use try/catch
 echo "Test 3: execute with false handle\n";
-$r = @fbird_execute(false, 1, 'x');
-var_dump($r === false);
+try {
+    $r = fbird_execute(false, 1, 'x');
+    var_dump($r === false);
+} catch (\TypeError $e) {
+    var_dump(true); // TypeError = invalid argument type rejected
+}
 
 // Test 4: fbird_execute with connection resource (wrong type)
 echo "Test 4: execute with connection resource\n";
@@ -70,23 +75,33 @@ echo "Test 6: fbird_num_params on valid stmt\n";
 $n = fbird_num_params($stmt);
 var_dump((int)$n === 2);
 
+// fbird_num_params/fbird_param_info throw TypeError in PHP 8 with false (@ doesn't suppress)
 echo "Test 7: fbird_num_params on false\n";
-$n = @fbird_num_params(false);
-var_dump($n === false || $n === null || $n === 0);
+try {
+    $n = fbird_num_params(false);
+    var_dump($n === false || $n === null || $n === 0);
+} catch (\TypeError $e) {
+    var_dump(true); // TypeError = invalid argument rejected
+}
 
 // Test 8: fbird_param_info on invalid statement
 echo "Test 8: fbird_param_info on false\n";
-$info = @fbird_param_info(false, 0);
-var_dump($info === false || $info === null);
+try {
+    $info = fbird_param_info(false, 0);
+    var_dump($info === false || $info === null);
+} catch (\TypeError $e) {
+    var_dump(true); // TypeError = invalid argument rejected
+}
 
 // Test 9: fbird_param_info out-of-range index on valid stmt
 echo "Test 9: fbird_param_info out-of-range index\n";
 $info = @fbird_param_info($stmt, 99);
 var_dump($info === false || $info === null);
 
-// Cleanup
+// Cleanup: @ on final commit — prepared stmt may still hold the table
+@fbird_commit($dbh);
 fbird_query($dbh, 'DROP TABLE BIND_ERR_COV');
-fbird_commit($dbh);
+@fbird_commit($dbh);
 fbird_close($dbh);
 
 echo "Done\n";

--- a/tests/coverage/bind_numeric_types.phpt
+++ b/tests/coverage/bind_numeric_types.phpt
@@ -1,0 +1,106 @@
+--TEST--
+Coverage: Numeric parameter binding — SMALLINT/INTEGER/BIGINT, FLOAT/DOUBLE, DECIMAL/NUMERIC
+--EXTENSIONS--
+firebird
+--SKIPIF--
+<?php include __DIR__ . '/../skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../firebird.inc';
+
+$dbh = fbird_connect($test_base);
+if (!$dbh) die('skip connect failed: ' . fbird_errmsg());
+
+fbird_query($dbh, "EXECUTE BLOCK AS BEGIN
+  IF (EXISTS(SELECT 1 FROM RDB\$RELATIONS WHERE RDB\$RELATION_NAME = 'BIND_NUM_COV')) THEN
+    EXECUTE STATEMENT 'DROP TABLE BIND_NUM_COV';
+END");
+fbird_commit($dbh);
+
+fbird_query($dbh, '
+    CREATE TABLE BIND_NUM_COV (
+        ID       INTEGER     NOT NULL PRIMARY KEY,
+        V_SMALL  SMALLINT,
+        V_INT    INTEGER,
+        V_BIG    BIGINT,
+        V_FLT    FLOAT,
+        V_DBL    DOUBLE PRECISION,
+        V_DEC    DECIMAL(15,4),
+        V_NUM    NUMERIC(10,2)
+    )');
+fbird_commit($dbh);
+
+$stmt = fbird_prepare($dbh,
+    'INSERT INTO BIND_NUM_COV (ID,V_SMALL,V_INT,V_BIG,V_FLT,V_DBL,V_DEC,V_NUM) VALUES (?,?,?,?,?,?,?,?)');
+
+// Test 1: zero values
+echo "Test 1: zero values\n";
+$r = fbird_execute($stmt, 1, 0, 0, 0, 0.0, 0.0, '0.0000', '0.00');
+var_dump($r !== false);
+
+// Test 2: MAX values
+echo "Test 2: max values\n";
+$r = fbird_execute($stmt, 2, 32767, PHP_INT_MAX, PHP_INT_MAX, 3.40282e+38, 1.79769e+308, '99999999999.9999', '99999999.99');
+var_dump($r !== false);
+
+// Test 3: MIN / negative values
+echo "Test 3: negative values\n";
+$r = fbird_execute($stmt, 3, -32768, PHP_INT_MIN, PHP_INT_MIN, -3.40282e+38, -1.79769e+308, '-99999999999.9999', '-99999999.99');
+var_dump($r !== false);
+
+// Test 4: NULL for all numeric columns
+echo "Test 4: NULL for all\n";
+$r = fbird_execute($stmt, 4, null, null, null, null, null, null, null);
+var_dump($r !== false);
+
+// Test 5: float string coercion (PHP string → numeric column)
+echo "Test 5: string numeric coercion\n";
+$r = fbird_execute($stmt, 5, '100', '200', '300', '1.5', '2.5', '3.1415', '9.99');
+var_dump($r !== false);
+
+// Test 6: PHP float → SMALLINT (truncation path in C)
+echo "Test 6: float to SMALLINT (truncation)\n";
+$r = @fbird_execute($stmt, 6, 3.7, null, null, null, null, null, null);
+var_dump($r !== false);
+
+fbird_commit($dbh);
+
+// Verify zero row
+$q = fbird_query($dbh, 'SELECT V_SMALL, V_INT, V_BIG FROM BIND_NUM_COV WHERE ID = 1');
+$row = fbird_fetch_row($q);
+fbird_free_result($q);
+echo "Test 7: zero row\n";
+var_dump((int)$row[0] === 0 && (int)$row[1] === 0 && (int)$row[2] === 0);
+
+// Verify NULL row
+$q = fbird_query($dbh, 'SELECT V_SMALL, V_INT, V_DEC FROM BIND_NUM_COV WHERE ID = 4');
+$row = fbird_fetch_row($q);
+fbird_free_result($q);
+echo "Test 8: NULL numeric row\n";
+var_dump($row[0] === null && $row[1] === null && $row[2] === null);
+
+// Cleanup
+fbird_query($dbh, 'DROP TABLE BIND_NUM_COV');
+fbird_commit($dbh);
+fbird_close($dbh);
+
+echo "Done\n";
+?>
+--EXPECTF--
+Test 1: zero values
+bool(true)
+Test 2: max values
+bool(true)
+Test 3: negative values
+bool(true)
+Test 4: NULL for all
+bool(true)
+Test 5: string numeric coercion
+bool(true)
+Test 6: float to SMALLINT (truncation)
+bool(true)
+Test 7: zero row
+bool(true)
+Test 8: NULL numeric row
+bool(true)
+Done

--- a/tests/coverage/bind_numeric_types.phpt
+++ b/tests/coverage/bind_numeric_types.phpt
@@ -79,9 +79,10 @@ fbird_free_result($q);
 echo "Test 8: NULL numeric row\n";
 var_dump($row[0] === null && $row[1] === null && $row[2] === null);
 
-// Cleanup
+// Cleanup: commit implicit tx, then DDL. Use @ on final commit (prepared stmt may hold table).
+@fbird_commit($dbh);
 fbird_query($dbh, 'DROP TABLE BIND_NUM_COV');
-fbird_commit($dbh);
+@fbird_commit($dbh);
 fbird_close($dbh);
 
 echo "Done\n";

--- a/tests/coverage/bind_temporal_types.phpt
+++ b/tests/coverage/bind_temporal_types.phpt
@@ -83,9 +83,10 @@ echo "Test 9: ISO date stored correctly\n";
 // Date may be returned as '2024-06-15' or Unix int — just check non-null
 var_dump($row[0] !== null);
 
-// Cleanup
+// Cleanup: commit implicit tx, then DDL. Use @ on final commit (prepared stmt may hold table).
+@fbird_commit($dbh);
 fbird_query($dbh, 'DROP TABLE BIND_TEMP_COV');
-fbird_commit($dbh);
+@fbird_commit($dbh);
 fbird_close($dbh);
 
 echo "Done\n";

--- a/tests/coverage/bind_temporal_types.phpt
+++ b/tests/coverage/bind_temporal_types.phpt
@@ -1,0 +1,112 @@
+--TEST--
+Coverage: DATE/TIME/TIMESTAMP parameter binding — string, unix int, NULL
+--EXTENSIONS--
+firebird
+--SKIPIF--
+<?php include __DIR__ . '/../skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../firebird.inc';
+
+$dbh = fbird_connect($test_base);
+if (!$dbh) die('skip connect failed: ' . fbird_errmsg());
+
+fbird_query($dbh, "EXECUTE BLOCK AS BEGIN
+  IF (EXISTS(SELECT 1 FROM RDB\$RELATIONS WHERE RDB\$RELATION_NAME = 'BIND_TEMP_COV')) THEN
+    EXECUTE STATEMENT 'DROP TABLE BIND_TEMP_COV';
+END");
+fbird_commit($dbh);
+
+fbird_query($dbh, '
+    CREATE TABLE BIND_TEMP_COV (
+        ID    INTEGER NOT NULL PRIMARY KEY,
+        D     DATE,
+        T     TIME,
+        TS    TIMESTAMP
+    )');
+fbird_commit($dbh);
+
+$stmt = fbird_prepare($dbh, 'INSERT INTO BIND_TEMP_COV (ID, D, T, TS) VALUES (?, ?, ?, ?)');
+
+// Test 1: ISO-8601 string format
+echo "Test 1: ISO string date/time/timestamp\n";
+$r = fbird_execute($stmt, 1, '2024-06-15', '14:30:00', '2024-06-15 14:30:00');
+var_dump($r !== false);
+
+// Test 2: Unix timestamp for all three (integer seconds since epoch)
+echo "Test 2: Unix timestamp integer\n";
+$ts = mktime(0, 0, 0, 1, 1, 2024); // 2024-01-01 00:00:00 UTC
+$r = fbird_execute($stmt, 2, $ts, $ts, $ts);
+var_dump($r !== false);
+
+// Test 3: NULL for all temporal columns
+echo "Test 3: NULL for all temporal columns\n";
+$r = fbird_execute($stmt, 3, null, null, null);
+var_dump($r !== false);
+
+// Test 4: Only DATE set, others NULL
+echo "Test 4: only DATE set\n";
+$r = fbird_execute($stmt, 4, '2024-03-15', null, null);
+var_dump($r !== false);
+
+// Test 5: Timestamp at epoch boundaries
+echo "Test 5: epoch boundary — 1970-01-01\n";
+$r = @fbird_execute($stmt, 5, '1970-01-01', '00:00:01', '1970-01-01 00:00:01');
+var_dump($r !== false);
+
+// Test 6: Far future date
+echo "Test 6: far future date\n";
+$r = @fbird_execute($stmt, 6, '2099-12-31', '23:59:59', '2099-12-31 23:59:59');
+var_dump($r !== false);
+
+fbird_commit($dbh);
+
+// Verify count
+$q = fbird_query($dbh, 'SELECT COUNT(*) FROM BIND_TEMP_COV');
+$row = fbird_fetch_row($q);
+fbird_free_result($q);
+echo "Test 7: 6 rows inserted\n";
+var_dump((int)$row[0] === 6);
+
+// Verify NULL row
+$q = fbird_query($dbh, 'SELECT D, T, TS FROM BIND_TEMP_COV WHERE ID = 3');
+$row = fbird_fetch_row($q);
+fbird_free_result($q);
+echo "Test 8: NULL temporal row\n";
+var_dump($row[0] === null && $row[1] === null && $row[2] === null);
+
+// Verify ISO string row has expected DATE
+$q = fbird_query($dbh, 'SELECT D FROM BIND_TEMP_COV WHERE ID = 1');
+$row = fbird_fetch_row($q);
+fbird_free_result($q);
+echo "Test 9: ISO date stored correctly\n";
+// Date may be returned as '2024-06-15' or Unix int — just check non-null
+var_dump($row[0] !== null);
+
+// Cleanup
+fbird_query($dbh, 'DROP TABLE BIND_TEMP_COV');
+fbird_commit($dbh);
+fbird_close($dbh);
+
+echo "Done\n";
+?>
+--EXPECTF--
+Test 1: ISO string date/time/timestamp
+bool(true)
+Test 2: Unix timestamp integer
+bool(true)
+Test 3: NULL for all temporal columns
+bool(true)
+Test 4: only DATE set
+bool(true)
+Test 5: epoch boundary — 1970-01-01
+bool(true)
+Test 6: far future date
+bool(true)
+Test 7: 6 rows inserted
+bool(true)
+Test 8: NULL temporal row
+bool(true)
+Test 9: ISO date stored correctly
+bool(true)
+Done


### PR DESCRIPTION
## Summary

Adds 4 `.phpt` test files targeting ≥80% coverage of `fbird_query_bind.c` (currently 41.8%).

## Tests Added

| File | Coverage Target |
|------|----------------|
| `tests/coverage/bind_boolean_null.phpt` | Valid TRUE/FALSE/NULL roundtrip for BOOLEAN column (FB 3.0+) |
| `tests/coverage/bind_temporal_types.phpt` | DATE/TIME/TIMESTAMP via ISO string, unix int, NULL, epoch boundary, far future |
| `tests/coverage/bind_numeric_types.phpt` | SMALLINT/INTEGER/BIGINT/FLOAT/DOUBLE/DECIMAL/NUMERIC — zero/max/min/NULL/coercion/truncation |
| `tests/coverage/bind_error_paths.phpt` | Too many/few params, false handle, wrong resource type, VARCHAR overflow, num_params/param_info errors |

## Complementary to Existing Tests

Existing coverage tests on satware-main already cover:
- Boolean rejection (invalid string, non-boolean, numeric string)
- INT64 limits, empty string, large blob, explicit NULL (BIGINT/VARCHAR)
- DECIMAL out-of-range (long and short scaled)

New tests cover the **happy paths** for temporal/numeric types plus additional error conditions.

## SDD Artifacts

- `.specify/specs/062-parameter-binding-coverage/spec.md`

Closes #62