### PR TITLE
chore(qa): set php84-fb3-dev as primary test container (amicron-platform baseline)

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -2,7 +2,7 @@
 set -e
 
 # This script is meant to be run INSIDE the docker container.
-# Example usage from host: docker compose run --rm php83-dev /ext/docker/scripts/coverage.sh
+# Example usage from host: docker compose run --rm php84-fb3-dev /ext/scripts/coverage.sh
 
 echo "Starting Code Coverage generation..."
 

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -4,7 +4,7 @@
 # Usage: ./scripts/qa.sh [options]
 #
 # Options:
-#   --container NAME   Container to use (default: php83-dev)
+#   --container NAME   Container to use (default: php84-fb3-dev — amicron-platform baseline)
 #   --mode MODE        fast|standard|full|security|fuzz|matrix (default: standard)
 #   --valgrind         Run Valgrind memory analysis (can combine with --container)
 #   --asan             Run AddressSanitizer tests (uses php83-asan container)
@@ -35,8 +35,8 @@
 
 set -e
 
-# Defaults
-CONTAINER="php83-dev"
+# Defaults — php84-fb3-dev is the amicron-platform baseline (PHP 8.4 + Firebird 3)
+CONTAINER="php84-fb3-dev"
 MODE="standard"
 SKIP_BUILD=false
 PHP_ONLY=false


### PR DESCRIPTION
## Summary

Sets **PHP 8.4 + Firebird 3** (`php84-fb3-dev`) as the default container for all primary QA runs, aligning the development baseline with the amicron-platform stack.

## Changes

| File | Change |
|------|--------|
| `scripts/qa.sh` | `CONTAINER` default: `php83-dev` → `php84-fb3-dev`; header comment updated |
| `scripts/coverage.sh` | Usage example updated to `php84-fb3-dev` |

## Behaviour

| Mode | Before | After |
|------|--------|-------|
| `./scripts/qa.sh` (no args) | php83-dev + firebird40 | php84-fb3-dev + firebird30 |
| `./scripts/qa.sh --mode matrix` | php81-fb3 + php84-fb3 + php85-fb5 | unchanged |
| `./scripts/qa.sh --asan` | php83-asan | unchanged |
| `docker compose run --rm … coverage.sh` | example showed php83-dev | now shows php84-fb3-dev |

## Testing
Matrix mode was not changed — it already included `php84-fb3-dev` as the amicron tier. No logic changed; only defaults.