### PR TITLE
fix(transaction): guard _php_fbird_free_trans() against MSHUTDOWN UAF/SIGABRT (#78, #79)

### DIFF
--- a/fbird_transaction.c
+++ b/fbird_transaction.c
@@ -43,21 +43,32 @@ void _php_fbird_free_trans(zend_resource *rsrc)
 		fbt_free(trans->fbt_transaction);
 		trans->fbt_transaction = NULL;
 		trans->handle.ptr = 0;
-		if (res) {
+		/* Fix #78: _php_fbird_error() calls php_error_docref()/zend_throw_exception()
+		 * which access EG() globals that may already be destroyed during MSHUTDOWN.
+		 * Guard with in_mshutdown to prevent SIGABRT. */
+		if (res && !IBG(in_mshutdown)) {
 			_php_fbird_error();
 		}
 	}
 
-	/* now remove this transaction from all the connection-transaction lists */
-	for (i = 0; i < trans->link_cnt; ++i) {
-		if (trans->db_link[i] != NULL) {
-			fbird_tr_list **l;
-			for (l = &trans->db_link[i]->tr_list; *l != NULL; l = &(*l)->next) {
-				if ( (*l)->trans == trans) {
-					fbird_tr_list *p = *l;
-					*l = p->next;
-					efree(p);
-					break;
+	/* Fix #79: During MSHUTDOWN, db_link[] pointers may be dangling — the
+	 * connection resource (le_plink) destructor can run before the transaction
+	 * resource destructor, freeing the fbird_db_link struct that db_link[i]
+	 * points to. Traversing tr_list through a freed pointer is a Use-After-Free.
+	 * Skip the tr_list cleanup entirely during shutdown; the connection struct
+	 * is already gone (or about to be freed), so the list nodes will be
+	 * reclaimed with the request pool anyway. */
+	if (!IBG(in_mshutdown)) {
+		for (i = 0; i < trans->link_cnt; ++i) {
+			if (trans->db_link[i] != NULL) {
+				fbird_tr_list **l;
+				for (l = &trans->db_link[i]->tr_list; *l != NULL; l = &(*l)->next) {
+					if ( (*l)->trans == trans) {
+						fbird_tr_list *p = *l;
+						*l = p->next;
+						efree(p);
+						break;
+					}
 				}
 			}
 		}

--- a/tests/coverage/transaction_mshutdown_guard.phpt
+++ b/tests/coverage/transaction_mshutdown_guard.phpt
@@ -1,0 +1,76 @@
+--TEST--
+fbird_transaction: _php_fbird_free_trans() must not crash during MSHUTDOWN (issues #78, #79)
+--SKIPIF--
+<?php
+if (!extension_loaded('firebird')) die('skip firebird extension not loaded');
+$conn = @fbird_connect(
+    getenv('FBIRD_TEST_DB') ?: '127.0.0.1/3050:/var/lib/firebird/data/test.fdb',
+    getenv('FBIRD_TEST_USER') ?: 'SYSDBA',
+    getenv('FBIRD_TEST_PASS') ?: 'masterkey'
+);
+if (!$conn) die('skip cannot connect to Firebird');
+fbird_close($conn);
+?>
+--FILE--
+<?php
+/**
+ * Regression test for issues #78 and #79:
+ *
+ * #78: Missing in_mshutdown guard in _php_fbird_free_trans() causes
+ *      SIGABRT when _php_fbird_error() accesses EG() during MSHUTDOWN.
+ *
+ * #79: Use-After-Free in _php_fbird_free_trans() — db_link[] traversal
+ *      during MSHUTDOWN accesses freed connection data (dangling pointer).
+ *
+ * The test verifies that a script which:
+ *   1. Opens a persistent connection (le_plink)
+ *   2. Starts an explicit transaction linked to that connection
+ *   3. Lets both resources go out of scope without explicit commit/rollback
+ *
+ * ...exits cleanly (exit code 0, no SIGSEGV/SIGABRT).
+ *
+ * If the bug is present, PHP will crash with exit code 139 (SIGSEGV)
+ * or exit code 134 (SIGABRT) during MSHUTDOWN resource cleanup.
+ */
+
+$db = getenv('FBIRD_TEST_DB') ?: '127.0.0.1/3050:/var/lib/firebird/data/test.fdb';
+$user = getenv('FBIRD_TEST_USER') ?: 'SYSDBA';
+$pass = getenv('FBIRD_TEST_PASS') ?: 'masterkey';
+
+// Use a persistent connection so le_plink is registered.
+// During MSHUTDOWN, le_plink destructors run before le_trans destructors
+// in some orderings, creating the dangling pointer condition (#79).
+$conn = fbird_pconnect($db, $user, $pass);
+if (!$conn) {
+    die('FAIL: could not connect');
+}
+
+// Start an explicit transaction linked to the persistent connection.
+// This transaction will NOT be committed/rolled back explicitly —
+// _php_fbird_free_trans() must handle cleanup safely during MSHUTDOWN.
+$tx = fbird_trans(FBIRD_DEFAULT, $conn);
+if (!$tx) {
+    die('FAIL: could not start transaction');
+}
+
+// Verify the transaction is functional before we let it go out of scope.
+$result = fbird_query($tx, 'SELECT 1 FROM RDB$DATABASE');
+if (!$result) {
+    die('FAIL: query failed');
+}
+$row = fbird_fetch_row($result);
+if (!$row || $row[0] != 1) {
+    die('FAIL: unexpected query result');
+}
+fbird_free_result($result);
+
+// Intentionally do NOT commit or rollback $tx.
+// Let PHP's MSHUTDOWN handle cleanup — this is the crash scenario.
+// Both $conn (le_plink) and $tx (le_trans) will be destroyed by the
+// resource destructor during shutdown.
+
+echo "ok\n";
+// Script ends here — MSHUTDOWN will run _php_fbird_free_trans()
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
## Summary

Fixes two related MSHUTDOWN crash bugs in `_php_fbird_free_trans()` (`fbird_transaction.c`).

## Fixes

### #78 — Missing `in_mshutdown` guard (SIGABRT)

`_php_fbird_error()` calls `php_error_docref()`/`zend_throw_exception()` which access `EG()` globals that may already be destroyed during MSHUTDOWN. Added `!IBG(in_mshutdown)` guard — mirrors the existing fix in `fbird_connection.c::_php_fbird_close_plink()`.

### #79 — Use-After-Free in `db_link[]` traversal (SIGSEGV)

The `le_plink` connection resource destructor can run **before** the `le_trans` transaction resource destructor during MSHUTDOWN, freeing the `fbird_db_link` struct that `trans->db_link[i]` points to. Traversing `tr_list` through that freed pointer is a UAF. The entire `db_link[]` loop is now skipped during MSHUTDOWN — the request pool reclaims all `emalloc`'d memory anyway.

## Changes

| File | Change |
|------|--------|
| `fbird_transaction.c` | Guard `_php_fbird_error()` + skip `db_link[]` loop during MSHUTDOWN |
| `tests/coverage/transaction_mshutdown_guard.phpt` | Regression test: pconnect + uncommitted trans → clean exit |

## Test

```bash
docker compose -f docker/docker-compose.yml run --rm php84-fb3-dev /ext/scripts/test.sh tests/coverage/transaction_mshutdown_guard.phpt
```

Closes #78
Closes #79