### PR TITLE
docs: v7.0.0-final documentation update and project structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Coverage Phase 1 test suite** (`tests/coverage/`, 9 new `.phpt` files): Targeted tests to
-  raise line coverage on Firebird 3 (FB3 OO-API baseline = `php84-fb3-dev` container)
-  - `execute_procedure_returning.phpt` — DML RETURNING path (INSERT/UPDATE with RETURNING clause)
-  - `exec_set_transaction.phpt` — `SET TRANSACTION` / `COMMIT` / `ROLLBACK` via `fbird_query()`,
-    covering `isc_info_sql_stmt_start_trans` OO API path in `fbird_query_exec.c` lines 120-154
-  - `phpinfo_ini_display.phpt` — `phpinfo(INFO_MODULES)` triggering `php_fbird_password_displayer_cb`
-    and `php_fbird_trans_displayer` callbacks in `firebird.c`
-  - Plus 6 additional coverage tests for datetime, bind, and exec code paths
-- **Coverage baseline** raised from **61.8% → 65.2%** (5,089 / 7,802 lines on FB3 build)
+- **`fbird_query_params_tx($link, $trans, $sql, ?$params)`** — New function for explicit
+  link+transaction+parameterized query execution. Designed for Doctrine DBAL integration where
+  the ORM manages connection and transaction handles separately. Fixes the Doctrine DBAL blocker
+  where no single function accepted all three: link, transaction, and array parameters.
+  (Issue #84, `fbird_query_exec.c` line 1691)
+
+- **Missing stubs added** to both `stubs/firebird-stubs.php` and `phpstan/fbird.stub.php`:
+  - `fbird_execute_statement` — Execute a prepared statement resource
+  - `fbird_execute_query` — Execute SQL string with optional parameters
+  - `fbird_execute_auto` — Auto-commit execution helper
+  - `fbird_query_params_tx` — New Doctrine integration function
+
+- **Batch API** (`fbird_batch_create`, `fbird_batch_add`, `fbird_batch_execute`,
+  `fbird_batch_cancel`) — High-throughput multi-row DML using Firebird 4.0+ native batch
+  interface. Implemented in `firebird_utils.cpp` with C++ RAII wrappers. Requires
+  `FB_API_VER >= 40`. (See `docs/OO_WRAPPER_IMPLEMENTATION.md`)
+
 - **Three new Batch API functions** completing the Firebird 4.0+ IBatch PHP surface:
   - `fbird_batch_append_blob_data(resource $batch, string $data): bool` — append a data chunk
     to the BLOB currently being constructed in the batch (multi-part BLOB assembly)
@@ -30,14 +38,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Stubs count: **82 → 85** functions; both `stubs/firebird-stubs.php` and
     `phpstan/fbird.stub.php` updated; `scripts/check-stubs-sync.sh` exits 0
 
+- **Limbo transaction recovery**: `fbird_get_limbo_transactions`, `fbird_reconnect_transaction` —
+  Enumerate and resolve two-phase commit limbo transactions.
+
+- **Seekable BLOB API**: `fbird_blob_create_seekable`, `fbird_blob_open_seekable`,
+  `fbird_blob_seek` — Random-access BLOB operations using Firebird's seekable blob streams.
+
+- **Exception mode API**: `fbird_set_exception_mode`, `fbird_get_exception_mode` — PDO-style
+  runtime-switchable error handling (SILENT / THROW modes). Allows per-connection exception
+  behavior without changing global INI settings.
+
+- **Savepoint API**: `fbird_trans_start`, `fbird_savepoint`, `fbird_rollback_savepoint`,
+  `fbird_release_savepoint` — Full savepoint lifecycle management within Firebird transactions.
+
+- **Connection introspection**: `fbird_connection_info`, `fbird_trans_info` — Query live
+  connection and transaction metadata from Firebird's monitoring tables.
+
+- **Maintenance helpers**: `fbird_list_table_blockers`, `fbird_kill_attachment`,
+  `fbird_drop_table_force` — Administrative functions for lock diagnostics and forced cleanup.
+
+- **Coverage Phase 1 test suite** (`tests/coverage/`, 9 new `.phpt` files): Targeted tests to
+  raise line coverage on Firebird 3 (FB3 OO-API baseline = `php84-fb3-dev` container)
+  - `execute_procedure_returning.phpt` — DML RETURNING path (INSERT/UPDATE with RETURNING clause)
+  - `exec_set_transaction.phpt` — `SET TRANSACTION` / `COMMIT` / `ROLLBACK` via `fbird_query()`
+  - `phpinfo_ini_display.phpt` — `phpinfo(INFO_MODULES)` coverage for INI display callbacks
+  - Plus 6 additional coverage tests for datetime, bind, and exec code paths
+- **Coverage baseline** raised from **61.8% → 65.2%** (5,089 / 7,802 lines on FB3 build)
+
+### Changed
+
+- **OO API upgrade**: All core operations now use Firebird 3.0+ Object-Oriented C++ API
+  (`IStatement`, `IAttachment`, `ITransaction`) via RAII wrappers in `src/cpp/`. Legacy
+  `isc_dsql_*` C-API calls replaced throughout.
+
+- **`fbird_*` prefix unification**: All new functions use `fbird_*` prefix exclusively.
+  Legacy `ibase_*` aliases preserved as thin wrappers for backward compatibility — deprecated,
+  no new `ibase_*` symbols added.
+
+- **PHP 8.3/8.4 compatibility**: Extension verified against PHP 8.3 and 8.4 with full test pass.
+  Docker test matrix updated (`php83-fb3-dev`, `php84-fb3-dev`, `php84-fb5-dev`).
+
+- **Code cleanup**: Removed ~386 lines of legacy comment bloat (rc.35): `/* {{{ proto ... */`
+  and `/* }}} */` markers removed from all source files.
+
+### Fixed
+
+- **Issue #55 (SIGSEGV in PHPStan parallel workers)**: Fixed segfault when parallel analysis
+  tools exit — `_php_fbird_close_link()` now has `!IBG(in_mshutdown)` guard matching
+  `_php_fbird_close_plink()`. Enables PHPStan, Psalm, and PHPUnit parallel mode without crashes.
+
 ### Technical Notes
 
 - `_php_fbird_safe_copy_sqlvar_data()` in `fbird_query_bind.c` (lines 36–220) is dead code on
-  Firebird 3+ builds. It is only reachable via the legacy `isc_dsql` API (Firebird 2.5). This
-  accounts for ~87 lines of structurally-unreachable coverage gap.
-- `firebird_utils.cpp` batch API paths (281-line gap) require `#if FB_API_VER >= 40` guards;
-  running coverage on `php85-fb5-dev` expands measured total from 7,802 → 9,155 and lowers % —
-  the FB3 container remains the authoritative coverage target.
+  Firebird 3+ builds — only reachable via legacy `isc_dsql` API (Firebird 2.5). Accounts for
+  ~87 lines of structurally-unreachable coverage gap on FB3 containers.
+- `firebird_utils.cpp` batch API paths require `#if FB_API_VER >= 40` guards; coverage measured
+  on the `php84-fb3-dev` container (7,802 total lines) remains the authoritative target.
 
 ## [7.0.0-rc.35] - 2026-01-02
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/satwareAG/php-firebird/actions/workflows/ci.yml/badge.svg)](https://github.com/satwareAG/php-firebird/actions/workflows/ci.yml)
 [![License: PHP-3.01](https://img.shields.io/badge/License-PHP--3.01-blue.svg)](LICENSE)
 [![PHP 8.1+](https://img.shields.io/badge/PHP-8.1%2B-8892BF.svg)](https://www.php.net/)
+[![Version](https://img.shields.io/badge/version-7.0.0-brightgreen.svg)](CHANGELOG.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/satwareAG/php-firebird)
 
 A high-performance PHP extension providing native connectivity to Firebird databases. This modernized version targets PHP 8.1+ with C++17 standards and comprehensive development tooling.
@@ -764,9 +765,13 @@ Add to your `psalm.xml`:
 - `fbird_close()` - Close a database connection
 
 ### Query Functions
-- `fbird_query()` - Execute a query
+- `fbird_query()` - Execute a query (link or transaction as first arg)
+- `fbird_query_params_tx($link, $trans, $sql, ?$params)` - Execute with explicit link + transaction + params (Doctrine DBAL integration)
 - `fbird_prepare()` - Prepare a query for later execution
 - `fbird_execute()` - Execute a prepared query
+- `fbird_execute_statement()` - Execute a prepared statement resource
+- `fbird_execute_query()` - Execute SQL string with optional parameters
+- `fbird_execute_auto()` - Auto-commit execution helper
 - `fbird_free_query()` - Free memory allocated by a prepared query
 - `fbird_free_result()` - Free a result set
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -526,6 +526,59 @@ fbird_close($db);
 
 ### Doctrine DBAL Integration
 
+#### `fbird_query_params_tx` — Explicit Link + Transaction + Params (v7.0.0)
+
+Doctrine DBAL manages connection and transaction handles *separately*. The new
+`fbird_query_params_tx` function accepts all three at once, eliminating the previous
+limitation where no single function took a link resource, transaction resource, **and**
+a parameter array simultaneously:
+
+```php
+<?php
+// Doctrine-style: explicit link + transaction + parameterized query
+$link  = fbird_connect('/path/to/database.fdb', 'SYSDBA', 'masterkey');
+$trans = fbird_trans(FBIRD_WRITE | FBIRD_COMMITTED, $link);
+
+// Single call — link, transaction, SQL, and params all explicit
+$result = fbird_query_params_tx(
+    $link,
+    $trans,
+    'SELECT id, name FROM users WHERE active = ? AND role = ?',
+    [1, 'admin']
+);
+
+while ($row = fbird_fetch_assoc($result)) {
+    echo $row['NAME'] . "\n";
+}
+fbird_free_result($result);
+
+// DML with params — INSERT/UPDATE/DELETE
+fbird_query_params_tx(
+    $link,
+    $trans,
+    'UPDATE users SET last_login = CURRENT_TIMESTAMP WHERE id = ?',
+    [42]
+);
+
+fbird_commit($trans);
+fbird_close($link);
+?>
+```
+
+**Signature:** `fbird_query_params_tx(resource $link, resource $trans, string $sql, ?array $params): resource|false`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$link` | resource | Connection from `fbird_connect()` |
+| `$trans` | resource | Transaction from `fbird_trans()` |
+| `$sql` | string | SQL with `?` placeholders |
+| `$params` | array\|null | Positional parameter values (null = no params) |
+
+**When to use:** Any scenario where you hold both a link and a transaction resource and
+need parameterized queries — most commonly in Doctrine DBAL driver implementations.
+
+#### Exception Mode (Required for Doctrine DBAL 4.x)
+
 Doctrine DBAL 4.x requires exception mode for proper error handling:
 
 ```php

--- a/docs/plans/v7-implementation-plan.md
+++ b/docs/plans/v7-implementation-plan.md
@@ -1,0 +1,186 @@
+# Implementation Plan: Split firebird.c (Issue #57)
+
+[Overview]
+Split the 3668-line `firebird.c` into five focused compilation units (each ≤800 lines) while keeping the trimmed `firebird.c` ≤1250 lines, satisfying the v7.0.0 milestone target of ≤1500 lines.
+
+`firebird.c` is a monolithic 3668-line file containing: error-handling PHP functions, connection management internals, transaction management, batch operations (FB 4.0+), INI configuration, module lifecycle hooks (MINIT/MSHUTDOWN/MINFO), the `zend_function_entry` table, and utility functions (`gen_id`, limbo transactions). The file has grown beyond maintainability. The existing codebase already follows a per-concern split pattern (`fbird_service.c`, `fbird_blobs.c`, `fbird_events.c`, etc.), so this refactoring aligns with the existing architecture.
+
+**Key constraint**: This is a *source-level* refactoring only — no public API changes, no behaviour changes, zero test regressions. Every function that moves must be callable by the same callers after the move, using the same `#include` chain.
+
+**Dependency graph** (existing headers already handle most cross-file symbols):
+- `php_fbird_includes.h` already declares: `extern int le_link, le_plink, le_trans, le_query, le_batch`, `void _php_fbird_error(void)`, `void _php_fbird_module_error(...)`, `void _php_fbird_get_link_trans(...)`, all typedef structs
+- `php_firebird.h` already declares all `PHP_FUNCTION(...)` prototypes
+
+New headers are needed **only** for the 4 static resource destructor callbacks passed to `zend_register_list_destructors_ex` in `PHP_MINIT_FUNCTION` (which stays in `firebird.c`).
+
+---
+
+[Types]
+No new types; all structs (`fbird_db_link`, `fbird_transaction`, `fbird_query`, `fbird_batch`, etc.) remain in `php_fbird_includes.h`.
+
+All type definitions, enums (`php_fbird_option`), and module globals (`ZEND_BEGIN_MODULE_GLOBALS(fbird)`) remain in `php_fbird_includes.h` unchanged.
+
+---
+
+[Files]
+Five source files are created/modified; three new headers are required.
+
+### New `.c` files (extract from `firebird.c`)
+
+| New file | firebird.c source lines | Est. lines | Content |
+|----------|------------------------|------------|---------|
+| `fbird_error.c` | 588–795 | ~210 | `fbird_errmsg`, `fbird_errcode`, `fbird_sqlstate`, `fbird_escape_string`, `fbird_set_exception_mode`, `fbird_get_exception_mode`, `fbird_get_client_version/major/minor`, `_php_fbird_error`, `_php_fbird_module_error` |
+| `fbird_connection.c` | 797–1005, 1451–1966 | ~730 | `_php_fbird_get_link_trans`, `_php_fbird_commit_link`, `php_fbird_commit_link_rsrc`, `_php_fbird_close_link`, `_php_fbird_close_plink`, `_php_fbird_connect`, `_php_fbird_validate_link_resource`, `_php_fbird_adopt_new_default_link`, `_php_fbird_close_resource`, `fbird_connect`, `fbird_pconnect`, `fbird_close`, `fbird_drop_db` |
+| `fbird_transaction.c` | 1006–1051, 1967–2793 | ~875 | `_php_fbird_free_trans`, `fbird_trans_start`, `fbird_savepoint`, `fbird_rollback_savepoint`, `fbird_release_savepoint`, `fbird_trans_info`, `fbird_connection_info`, `fbird_trans`, `fbird_commit`, `fbird_rollback`, `fbird_commit_ret`, `fbird_rollback_ret` |
+| `fbird_batch.c` | 1052–1099, 3053–3668 | ~665 | `_php_fbird_free_batch`, `fbird_batch_create`, `fbird_batch_add`, `fbird_batch_execute`, `fbird_batch_cancel`, `fbird_batch_add_blob`, `fbird_batch_register_blob` |
+
+### New `.h` header files
+
+| New header | Declares |
+|------------|---------|
+| `php_fbird_connection.h` | `_php_fbird_commit_link(fbird_db_link*)`, `php_fbird_commit_link_rsrc(zend_resource*)`, `_php_fbird_close_link(zend_resource*)`, `_php_fbird_close_plink(zend_resource*)` |
+| `php_fbird_transaction.h` | `_php_fbird_free_trans(zend_resource*)` |
+| `php_fbird_batch.h` | (conditional `#if FB_API_VER >= 40`) `_php_fbird_free_batch(zend_resource*)` |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `firebird.c` | Remove lines 588–1005, 1451–2793, 3053–3668; add `#include` for 3 new headers; keep: license+includes+arginfo+function_entry_table (~537 lines), INI/GINIT (1100–1258), MINIT/MSHUTDOWN/RSHUTDOWN/MINFO (1259–1449), gen_id+limbo (2795–3052) |
+| `config.m4` | Append `fbird_error.c fbird_connection.c fbird_transaction.c fbird_batch.c` to `PHP_NEW_EXTENSION` source list (line 100) |
+
+**Each new `.c` file includes at minimum:**
+```c
+#include "php_fbird_includes.h"      /* types, globals, resource IDs */
+#include "php_firebird.h"             /* PHP_FUNCTION declarations */
+#include "php_fbird_<module>.h"       /* own header if needed */
+/* + any additional module-specific headers (e.g. fbird_datetime.h) */
+```
+
+`fbird_transaction.c` also needs `#include "php_fbird_connection.h"` (calls `_php_fbird_commit_link`).
+`fbird_error.c` does NOT need a new header (symbols already in `php_fbird_includes.h`).
+
+---
+
+[Functions]
+Functions are moved verbatim — no signature changes, no logic changes.
+
+### Functions moving to `fbird_error.c`
+
+| Function | Current location | Change |
+|----------|-----------------|--------|
+| `PHP_FUNCTION(fbird_errmsg)` | firebird.c:588 | Move — no signature change |
+| `PHP_FUNCTION(fbird_get_client_version)` | firebird.c:601 | Move |
+| `PHP_FUNCTION(fbird_get_client_major_version)` | firebird.c:606 | Move |
+| `PHP_FUNCTION(fbird_get_client_minor_version)` | firebird.c:611 | Move |
+| `PHP_FUNCTION(fbird_errcode)` | firebird.c:616 | Move |
+| `PHP_FUNCTION(fbird_sqlstate)` | firebird.c:628 | Move |
+| `PHP_FUNCTION(fbird_escape_string)` | firebird.c:654 | Move |
+| `PHP_FUNCTION(fbird_set_exception_mode)` | firebird.c:696 | Move |
+| `PHP_FUNCTION(fbird_get_exception_mode)` | firebird.c:714 | Move |
+| `void _php_fbird_error(void)` | firebird.c:744 | Move; declaration stays in php_fbird_includes.h |
+| `void _php_fbird_module_error(...)` | firebird.c:770 | Move; declaration stays in php_fbird_includes.h |
+
+### Functions moving to `fbird_connection.c`
+
+| Function | Current location | Change |
+|----------|-----------------|--------|
+| `void _php_fbird_get_link_trans(...)` | firebird.c:797 | Move; declaration stays in php_fbird_includes.h |
+| `static void _php_fbird_commit_link(fbird_db_link*)` | firebird.c:822 | Move; change from `static` → non-static; declare in php_fbird_connection.h |
+| `static void php_fbird_commit_link_rsrc(zend_resource*)` | firebird.c:882 | Move; change from `static` → non-static; declare in php_fbird_connection.h |
+| `static void _php_fbird_close_link(zend_resource*)` | firebird.c:889 | Move; change from `static` → non-static; declare in php_fbird_connection.h |
+| `static void _php_fbird_close_plink(zend_resource*)` | firebird.c:948 | Move; change from `static` → non-static; declare in php_fbird_connection.h |
+| `static void _php_fbird_connect(...)` | firebird.c:1451 | Move; remains static within fbird_connection.c |
+| `static int _php_fbird_validate_link_resource(...)` | firebird.c:1618 | Move; remains static |
+| `static void _php_fbird_adopt_new_default_link(...)` | firebird.c:1649 | Move; remains static |
+| `static void _php_fbird_close_resource(...)` | firebird.c:1662 | Move; remains static |
+| `PHP_FUNCTION(fbird_connect)` | firebird.c:1609 | Move |
+| `PHP_FUNCTION(fbird_pconnect)` | firebird.c:1614 | Move |
+| `PHP_FUNCTION(fbird_close)` | firebird.c:1674 | Move |
+| `PHP_FUNCTION(fbird_drop_db)` | firebird.c:1727 | Move |
+
+### Functions moving to `fbird_transaction.c`
+
+| Function | Current location | Change |
+|----------|-----------------|--------|
+| `static void _php_fbird_free_trans(zend_resource*)` | firebird.c:1006 | Move; change from `static` → non-static; declare in php_fbird_transaction.h |
+| `PHP_FUNCTION(fbird_trans_start)` | firebird.c:1967 | Move |
+| `PHP_FUNCTION(fbird_savepoint)` | firebird.c:2151 | Move |
+| `PHP_FUNCTION(fbird_rollback_savepoint)` | firebird.c:2156 | Move |
+| `PHP_FUNCTION(fbird_release_savepoint)` | firebird.c:2161 | Move |
+| `PHP_FUNCTION(fbird_trans_info)` | firebird.c:2166 | Move |
+| `PHP_FUNCTION(fbird_connection_info)` | firebird.c:2262 | Move |
+| `PHP_FUNCTION(fbird_trans)` | firebird.c:2384 | Move |
+| `PHP_FUNCTION(fbird_commit)` | firebird.c:2744 | Move |
+| `PHP_FUNCTION(fbird_rollback)` | firebird.c:2749 | Move |
+| `PHP_FUNCTION(fbird_commit_ret)` | firebird.c:2754 | Move |
+| `PHP_FUNCTION(fbird_rollback_ret)` | firebird.c:2759 | Move |
+
+### Functions moving to `fbird_batch.c`
+
+| Function | Current location | Change |
+|----------|-----------------|--------|
+| `static void _php_fbird_free_batch(zend_resource*)` (FB_API_VER >= 40) | firebird.c:1052 | Move; change from `static` → non-static; declare in php_fbird_batch.h |
+| `PHP_FUNCTION(fbird_batch_create)` | firebird.c:3053 | Move |
+| `PHP_FUNCTION(fbird_batch_add)` | firebird.c:3132 | Move |
+| `PHP_FUNCTION(fbird_batch_execute)` | firebird.c:3519 | Move |
+| `PHP_FUNCTION(fbird_batch_cancel)` | firebird.c:3569 | Move |
+| `PHP_FUNCTION(fbird_batch_add_blob)` | firebird.c:3597 | Move |
+| `PHP_FUNCTION(fbird_batch_register_blob)` | firebird.c:3629 | Move |
+
+### Functions staying in `firebird.c`
+
+`PHP_MINIT_FUNCTION(fbird)`, `PHP_MSHUTDOWN_FUNCTION(fbird)`, `PHP_RSHUTDOWN_FUNCTION(fbird)`, `PHP_MINFO_FUNCTION(fbird)`, `static PHP_GINIT_FUNCTION(fbird)`, `static PHP_INI_DISP(php_fbird_password_displayer_cb)`, `static PHP_INI_DISP(php_fbird_trans_displayer)`, `PHP_FUNCTION(fbird_gen_id)`, `PHP_FUNCTION(fbird_get_limbo_transactions)`, `PHP_FUNCTION(fbird_reconnect_transaction)`, `_fbird_res_type_name`, all arginfo (`ZEND_BEGIN_ARG_INFO`) declarations, `static const zend_function_entry firebird_functions[]`.
+
+---
+
+[Classes]
+No class changes; `Firebird\Exception` registration stays in `PHP_MINIT_FUNCTION` in `firebird.c`.
+
+---
+
+[Dependencies]
+No new external library dependencies; no changes to Firebird client linkage.
+
+Internal compilation dependencies change:
+- `fbird_transaction.c` gains a compile-time dependency on `php_fbird_connection.h` (to call `_php_fbird_commit_link`)
+- `firebird.c` gains `#include "php_fbird_connection.h"`, `#include "php_fbird_transaction.h"`, `#include "php_fbird_batch.h"` (for destructor callbacks in `PHP_MINIT_FUNCTION`)
+- `config.m4` PHP_NEW_EXTENSION source list gains 4 new `.c` files
+
+---
+
+[Testing]
+Full regression testing via the existing Docker-based `.phpt` test suite; no new test files needed for this refactoring.
+
+```bash
+# Full test run (no regressions expected)
+docker compose run --rm php83-dev make test
+
+# Build verification (catches linking errors)
+docker compose run --rm php83-dev phpize && ./configure --with-firebird && make -j$(nproc)
+
+# Coverage smoke-check (verifies gcov instrumentation still works)
+docker compose run --rm php83-dev /ext/scripts/coverage.sh
+```
+
+Verification criteria (all must pass):
+1. `make` exits 0 (no compiler errors or warnings)
+2. All existing `.phpt` tests pass (zero new failures)
+3. `fbird_errmsg()`, `fbird_connect()`, `fbird_trans()`, `fbird_batch_create()` callable from PHP (extension loads correctly)
+
+---
+
+[Implementation Order]
+Implement in 7 atomic steps, each independently compilable and committable.
+
+1. **Create `php_fbird_connection.h`** — declare 4 destructor callbacks that move out of firebird.c
+2. **Create `php_fbird_transaction.h`** — declare `_php_fbird_free_trans`
+3. **Create `php_fbird_batch.h`** — declare `_php_fbird_free_batch` (conditional on FB_API_VER >= 40)
+4. **Create `fbird_error.c`** — extract lines 588–795 from firebird.c; add `#include "php_fbird_includes.h"` + `#include "php_firebird.h"` at top
+5. **Create `fbird_connection.c`** — extract lines 797–1005 + 1451–1966; de-static 4 callbacks; add includes
+6. **Create `fbird_transaction.c`** — extract lines 1006–1051 + 1967–2793; de-static `_php_fbird_free_trans`; add `#include "php_fbird_connection.h"`
+7. **Create `fbird_batch.c`** — extract lines 1052–1099 + 3053–3668; de-static `_php_fbird_free_batch`
+8. **Modify `firebird.c`** — delete extracted line ranges; add `#include` for 3 new headers; verify remaining ~1200 lines compile
+9. **Modify `config.m4`** — add 4 new `.c` files to `PHP_NEW_EXTENSION` source list (line 100)
+10. **Build + test** — `docker compose run --rm php83-dev make test` → zero failures
+11. **Commit + PR** — branch `refactor/split-firebird-c`, target `satware-main`, closes #57

--- a/stubs/README.md
+++ b/stubs/README.md
@@ -52,6 +52,35 @@ Add to your `psalm.xml`:
 
 Most IDEs will automatically pick up the stubs via Composer autoloading. No additional configuration is typically required.
 
+## Included Functions (v7.0.0)
+
+All `fbird_*` functions are stubbed, including v7.0.0 additions:
+
+| Function | Description |
+|----------|-------------|
+| `fbird_query_params_tx($link, $trans, $sql, ?$params)` | Explicit link + transaction + params (Doctrine DBAL) |
+| `fbird_execute_statement($stmt)` | Execute a prepared statement resource |
+| `fbird_execute_query($link, $sql, ...$params)` | Execute SQL with optional params |
+| `fbird_execute_auto($link, $sql, ...$params)` | Auto-commit execution helper |
+| `fbird_set_exception_mode(int $mode)` | Set SILENT/THROW error mode |
+| `fbird_get_exception_mode()` | Get current error mode |
+| `fbird_trans_start($link, array $options)` | Full TPB transaction builder |
+| `fbird_savepoint($trans, string $name)` | Create named savepoint |
+| `fbird_rollback_savepoint($trans, string $name)` | Rollback to savepoint |
+| `fbird_release_savepoint($trans, string $name)` | Release savepoint |
+| `fbird_connection_info($link)` | Connection metadata |
+| `fbird_trans_info($trans)` | Transaction state info |
+| `fbird_blob_seek($blob, int $offset, int $whence)` | Seekable BLOB access |
+| `fbird_batch_create($stmt, $trans)` | Create batch (FB 4.0+) |
+| `fbird_batch_add($batch, ...$params)` | Add row to batch |
+| `fbird_batch_execute($batch)` | Execute batch |
+| `fbird_batch_cancel($batch)` | Cancel batch |
+| `fbird_escape_string(string $str)` | Escape string for SQL |
+
+All classic `fbird_connect`, `fbird_query`, `fbird_prepare`, `fbird_execute`,
+`fbird_fetch_*`, `fbird_trans`, `fbird_commit`, `fbird_rollback`, `fbird_blob_*`,
+`fbird_service_*`, and event functions are also stubbed.
+
 ## Version Compatibility
 
 | Stubs Version | Extension Version | PHP Version |


### PR DESCRIPTION
Replaces PR #85 with a clean branch directly on top of origin/satware-main (avoids rebase conflicts with f7ceaf0 batch API additions).

## Changes
- Expand CHANGELOG.md [7.0.0] with comprehensive Added/Changed/Fixed sections
- Add version badge to README.md
- Add `fbird_query_params_tx` + missing execute_* stubs to README Function Reference  
- Add `docs/EXAMPLES.md` with fbird_query_params_tx usage examples
- Add `stubs/README.md` with stubs package overview
- Add `docs/plans/v7-implementation-plan.md`

Closes #85