### PR TITLE
breaking(docker): drop Firebird 2.5 server support (#91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           # PHP 8.4: Current recommended
           # FB 3.0: Stable with modern auth (Srp)
           # FB 5.0: Latest features
-          # Note: FB 2.5 removed - EOL and Docker image broken
           # Note: Can expand to PHP 8.2/8.3 and FB 4.0 once CI is green
 
           # PHP 8.1 combinations
@@ -49,9 +48,6 @@ jobs:
             db-path: '/var/lib/firebird/data/test.fdb'
 
     # Run Firebird as a service container
-    # Note: Environment variables differ between jacobalberty/firebird (2.5) and firebirdsql/firebird (3+)
-    # - jacobalberty/firebird:2.5-ss uses ISC_PASSWORD only (SYSDBA already exists)
-    # - firebirdsql/firebird:3+ uses FIREBIRD_DATABASE, ISC_PASSWORD
     services:
       firebird:
         image: ${{ matrix.firebird-image }}
@@ -286,7 +282,7 @@ jobs:
           # AuthClient: Order of authentication plugins to try
           # - Srp256: Secure Remote Password (SHA-256) - Firebird 3.0+
           # - Srp: Secure Remote Password (SHA-1) - Firebird 3.0+
-          # - Legacy_Auth: Legacy authentication - Firebird 2.5 compatibility
+          # - Legacy_Auth: Legacy authentication (retained for compatibility)
           AuthClient = Srp256, Srp, Legacy_Auth
 
           # WireCrypt: Wire encryption setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tests/fbird_alias_check_002.phpt` (misnamed files that tested `fbird_*` functions, not
   `ibase_*` aliases). Updated `constitution.md` Article IV and `AGENTS.md` to reflect removal.
   Closes [#92](https://github.com/satwareAG/php-firebird/issues/92).
+- **Firebird 2.5 server support removed** — deprecated in v7.1.0, EOL since September 2020.
+  Removed `firebird25` service and `fb25-data` volume from `docker/docker-compose.yml`.
+  Removed `depends_on: firebird25` from all PHP dev containers. Removed stale FB 2.5 comments
+  from `.github/workflows/ci.yml` (matrix was already clean). Updated `README.md` to reflect
+  supported server versions: 3.0, 4.0, 5.0+.
+  Closes [#91](https://github.com/satwareAG/php-firebird/issues/91).
 
 ---
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,7 +1,7 @@
 # Next Session Tasks — php-firebird
 
-**Last updated:** 2026-03-04 (updated 2026-03-04 — v7.2.0 milestone + issues created)  
-**Current version:** 7.1.0 (released)  
+**Last updated:** 2026-03-04 (PR #94 open — issue #91 awaiting CI)
+**Current version:** 7.1.0 (released)
 **Branch:** `satware-main`
 
 ---
@@ -40,7 +40,7 @@
 
 ---
 
-## Priority 3 — ✅ v7.2.0 planning complete
+## Priority 3 — v7.2.0 implementation in progress
 
 - [x] Milestone `v7.2.0` created on GitHub (milestone #2)
 - [x] Closed stale `v7.0.0` milestone (0 open issues)
@@ -49,13 +49,35 @@
 - [x] Issue [#91](https://github.com/satwareAG/php-firebird/issues/91) — `breaking: drop Firebird 2.5 server support`
 - [x] Issue [#92](https://github.com/satwareAG/php-firebird/issues/92) — `breaking: remove ibase_* function aliases`
 
-### v7.2.0 Implementation Order (recommended)
+### v7.2.0 Implementation Order
 
-1. **#92 — remove `ibase_*` aliases** ✅ PR [#93](https://github.com/satwareAG/php-firebird/pull/93) open — awaiting CI
-2. **#91 — drop Firebird 2.5** (remove compat shims + CI matrix reduction)
-3. **#90 — drop PHP 8.1** (CI matrix reduction, update constraints)
+1. **#92 — remove `ibase_*` aliases** ✅ PR [#93](https://github.com/satwareAG/php-firebird/pull/93) merged (2026-03-04, commit `1301bf5`)
+2. **#91 — drop Firebird 2.5** ✅ PR [#94](https://github.com/satwareAG/php-firebird/pull/94) open — awaiting CI
+   - Branch: `feat/drop-firebird-25-91` (commit `1ab7585`)
+   - Changes: docker-compose.yml, ci.yml, README.md, CHANGELOG.md
+   - No C source changes (all `FB_API_VER < 30` are already `#error` guards)
+3. **#90 — drop PHP 8.1** (next after PR #94 merges)
 
-Each issue should be a separate feature branch + PR targeting `satware-main`.
+---
+
+## Next immediate action (next session start)
+
+1. Check CI on PR #94: `gh pr checks 94 --repo satwareAG/php-firebird`
+2. If CI green: `gh pr merge 94 --repo satwareAG/php-firebird --squash --delete-branch`
+3. Sync local: `git checkout satware-main && git pull origin satware-main`
+4. Begin issue #90 (drop PHP 8.1):
+   - `git checkout -b feat/drop-php81-90 satware-main`
+
+### Issue #90 checklist (drop PHP 8.1)
+
+- [ ] Remove PHP 8.1 from Docker build matrix (`docker/php/Dockerfile-8.1`, `docker/docker-compose.yml`)
+- [ ] Remove PHP 8.1 from CI test matrix (`.github/workflows/ci.yml`, `coverage.yml`, `sanitizers.yml`)
+- [ ] Update `composer.json` PHP constraint to `>=8.2`
+- [ ] Update `stubs/composer.json` PHP constraint to `>=8.2`
+- [ ] Update `README.md` supported PHP versions (remove 8.1 deprecation notice, update minimum)
+- [ ] Update `constitution.md` Article V (PHP 8.1 listed as supported)
+- [ ] Add entry to `CHANGELOG.md` under `[Unreleased]`
+- [ ] Run `bash scripts/check-stubs-sync.sh` — must exit 0
 
 ---
 
@@ -63,6 +85,6 @@ Each issue should be a separate feature branch + PR targeting `satware-main`.
 
 - **Release:** https://github.com/satwareAG/php-firebird/releases/tag/v7.1.0
 - **CHANGELOG:** https://github.com/satwareAG/php-firebird/blob/satware-main/CHANGELOG.md
-- **Test suite:** 173/173 pass (0 fail, 4 skipped)
+- **Test suite:** 173/173 pass (0 fail, 4 skipped) — as of v7.1.0
 - **Stubs:** 86/86 in sync
 - **v7.2.0 milestone:** https://github.com/satwareAG/php-firebird/milestone/2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A high-performance PHP extension providing native connectivity to Firebird datab
 ## Features
 
 - **Native Performance**: Direct fbclient library integration
-- **Full Firebird Support**: Connects to Firebird 2.5, 3.0, 4.0, 5.0+ servers (requires 3.0+ client library)
+- **Full Firebird Support**: Connects to Firebird 3.0, 4.0, 5.0+ servers (requires 3.0+ client library)
 - **Modern C++ OO API**: Uses Firebird 3.0+ Object-Oriented API with RAII wrappers
 - **Modern PHP**: Optimized for PHP 8.1+ with typed properties and attributes
 - **Exception Mode API**: PDO-style exception handling with runtime switchable error modes (SILENT/THROW)
@@ -59,7 +59,7 @@ Choosing between PDO\_Firebird and php-firebird depends on your project requirem
 - **Firebird**: 3.0+ client libraries (fbclient) and headers
 - **Build Tools**: autotools, make, pkg-config
 
-> **⚠️ Firebird 3.0+ Client Library Required**: This extension requires the Firebird 3.0+ client library (fbclient) for building, as it uses the modern OO API (FB_API_VER >= 30). However, newer client libraries can connect to older servers: FB 3.0 client → FB 2.5-3.0 servers, FB 4.0 client → FB 2.5-4.0 servers, FB 5.0 client → FB 2.5-5.0 servers.
+> **⚠️ Firebird 3.0+ Client Library Required**: This extension requires the Firebird 3.0+ client library (fbclient) for building, as it uses the modern OO API (FB_API_VER >= 30). Supported server versions: 3.0, 4.0, 5.0+.
 
 ### Supported Platforms
 - Linux (Ubuntu 20.04+, Debian 11+, Rocky/AlmaLinux 8+, openSUSE 15.3+)
@@ -920,11 +920,11 @@ See [EVENT_TIMEOUT_RFC.md](docs/development/EVENT_TIMEOUT_RFC.md) for implementa
 **Firebird Server Connectivity:**
 | Client Library | Server Versions Supported | Notes |
 |----------------|---------------------------|-------|
-| FB 3.0 client | FB 2.5, 3.0 | Legacy |
-| FB 4.0 client | FB 2.5, 3.0, 4.0 | Stable |
-| FB 5.0 client | FB 2.5, 3.0, 4.0, 5.0+ | **Recommended** |
+| FB 3.0 client | FB 3.0 | Legacy |
+| FB 4.0 client | FB 3.0, 4.0 | Stable |
+| FB 5.0 client | FB 3.0, 4.0, 5.0+ | **Recommended** |
 
-> **⚠️ Firebird 2.5 Server Deprecation**: Firebird 2.5 server support is **DEPRECATED** and will be removed in v7.1.0. Firebird 2.5 reached EOL in September 2020. The FB 5.x client includes backward compatibility, but this configuration is no longer tested. Please migrate to Firebird 4.0+ for security updates.
+> **ℹ️ Firebird 2.5 Server**: Firebird 2.5 reached EOL in September 2020 and is no longer supported as of v7.2.0. Please migrate to Firebird 3.0+.
 
 ### Precompiled Binaries (v7.0.0+)
 
@@ -948,7 +948,7 @@ php -m | grep firebird
 - **glibc 2.28+** required (Ubuntu 18.10+, Debian 11+, RHEL 8+)
 - **PHP 8.1+** required - use third-party repos if your distribution has an older default
 - **No system Firebird installation needed** - client libraries bundled via `$ORIGIN` rpath
-- **Connects to any Firebird server** (2.5-5.0) using bundled FB 5.x client
+- **Connects to any Firebird server** (3.0-5.0) using bundled FB 5.x client
 
 **Installing PHP 8.1+ on Older Distributions:**
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - firebird25
       - firebird30
       - firebird40
       - firebird50
@@ -51,7 +50,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - firebird25
       - firebird30
       - firebird40
       - firebird50
@@ -74,7 +72,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - firebird25
       - firebird30
       - firebird40
       - firebird50
@@ -104,7 +101,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - firebird25
       - firebird30
       - firebird40
       - firebird50
@@ -127,7 +123,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - firebird25
       - firebird30
       - firebird40
       - firebird50
@@ -159,7 +154,6 @@ services:
 
   # PHP 8.4 with Firebird 3.0 Client Library
   # For testing extension compilation against Firebird 3.0 client
-  # Compatible with Firebird 2.5 and 3.0 servers
   php84-fb3-dev:
     build:
       context: php
@@ -181,7 +175,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - firebird25
       - firebird30
 
   # PHP 8.5 with Firebird 5.x Client Library
@@ -234,17 +227,6 @@ services:
       - firebird40
 
   # Firebird Database Containers
-  firebird25:
-    image: "jacobalberty/firebird:2.5-ss"
-    environment:
-      ISC_PASSWORD: masterkey
-      FIREBIRD_DATABASE: test.fdb
-      FIREBIRD_USER: SYSDBA
-      FIREBIRD_PASSWORD: masterkey
-      TZ: Europe/Berlin
-    volumes:
-      - fb25-data:/firebird/data
-
   firebird30:
     image: firebirdsql/firebird:3
     environment:
@@ -282,7 +264,6 @@ services:
       - ./firebird/init-test-db.sh:/docker-entrypoint-initdb.d/init-test-db.sh:ro
 
 volumes:
-  fb25-data:
   fb30-data:
   fb40-data:
   fb50-data:


### PR DESCRIPTION
## Summary

Removes Firebird 2.5 server support from Docker infrastructure and documentation. Firebird 2.5 reached EOL in September 2020 and was already removed from the CI test matrix in a previous release.

## Changes

- **`docker/docker-compose.yml`**: Remove `firebird25` service, `fb25-data` volume, and `depends_on: firebird25` from all PHP dev containers
- **`.github/workflows/ci.yml`**: Remove stale FB 2.5 comments (matrix was already clean since rc.12)
- **`README.md`**: Update supported server versions to 3.0, 4.0, 5.0+ (4 locations)
- **`CHANGELOG.md`**: Add `[Unreleased]` entry

## No C source changes

All `FB_API_VER < 30` occurrences in C source are already compile-time `#error` directives — they enforce the minimum requirement, not compatibility shims. Nothing to remove.

## Verification

- Stubs: 86/86 in sync ✓
- `bash scripts/check-stubs-sync.sh` exits 0 ✓
- Diff: 4 files, 14 insertions, 31 deletions ✓

Closes #91