### PR TITLE
feat(ci): PHP 8.3 full CI row (FB 3.0 + FB 5.0) — 9 combinations (#97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Matrix: PHP 8.2/8.3/8.4 × FB 3.0/4.0/5.0 = 7 combinations
+          # Matrix: PHP 8.2/8.3/8.4 × FB 3.0/4.0/5.0 = 9 combinations
           # PHP 8.2: Minimum supported (PHP 8.1 dropped in v7.2.0)
-          # PHP 8.3: Intermediate — tested against FB 4.0 (constitution Article V)
+          # PHP 8.3: Intermediate — full row (FB 3.0, 4.0, 5.0) as of issue #97
           # PHP 8.4: Current recommended
           # FB 3.0: Stable with modern auth (Srp) — actively supported
           # FB 4.0: Batch ops, time zones, DECFLOAT, INT128 (FB_API_VER=40) — actively supported
@@ -41,11 +41,21 @@ jobs:
             fb-client-version: '5.0'
             db-path: '/var/lib/firebird/data/test.fdb'
 
-          # PHP 8.3 combinations (intermediate — FB 4.0 only)
+          # PHP 8.3 combinations (full row — FB 3.0, 4.0, 5.0)
+          - php-version: '8.3'
+            firebird-version: '3.0'
+            firebird-image: 'firebirdsql/firebird:3'
+            fb-client-version: '3.0'
+            db-path: '/var/lib/firebird/data/test.fdb'
           - php-version: '8.3'
             firebird-version: '4.0'
             firebird-image: 'firebirdsql/firebird:4'
             fb-client-version: '4.0'
+            db-path: '/var/lib/firebird/data/test.fdb'
+          - php-version: '8.3'
+            firebird-version: '5.0'
+            firebird-image: 'firebirdsql/firebird:5'
+            fb-client-version: '5.0'
             db-path: '/var/lib/firebird/data/test.fdb'
 
           # PHP 8.4 combinations

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -73,7 +73,7 @@ This is NON-NEGOTIABLE.
 - **MUST**: Tests for FB4+ features include `--SKIPIF--` with server version check
 - **SHALL NOT**: Use PHP version-specific APIs without a compatibility shim
 
-*Rationale*: The CI matrix covers PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 (7 combinations).
+*Rationale*: The CI matrix covers PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 (9 combinations).
 All three Firebird versions are actively supported as of 2026. Each client version must be
 tested independently because `FB_API_VER` determines which code paths compile.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,12 +153,12 @@ Project Brief: `docs/product/project-brief.md`
 
 ## CI Matrix
 
-PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 = **7 combinations**
+PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 = **9 combinations**
 
 | PHP | FB 3.0 | FB 4.0 | FB 5.0 |
 |-----|--------|--------|--------|
 | 8.2 (min) | ✅ | ✅ | ✅ |
-| 8.3 | - | ✅ | - |
+| 8.3 | ✅ | ✅ | ✅ |
 | 8.4 (current) | ✅ | ✅ | ✅ |
 
 All three Firebird versions (3.0, 4.0, 5.0) are actively supported as of 2026.

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -6,24 +6,25 @@
 
 ---
 
-## Status: v7.2.0 Released ✅ | PR #96 in flight
+## Status: v7.2.0 Released ✅ | PR #96 Merged ✅ | Issue #97 in progress
 
 | Item | Status |
 |------|--------|
 | v7.2.0 release | ✅ Published |
 | Stubs v7.2.0 (Packagist) | ✅ Tagged |
-| PR #96: CI matrix 4→7 combinations (FB4 + PHP 8.3) | 🔄 CI passing, ready to merge |
+| PR #96: CI matrix 4→7 combinations (FB4 + PHP 8.3) | ✅ Merged (commit 6458694) |
+| Issue #97: PHP 8.3 full CI row (FB 3.0 + FB 5.0) | 🔄 In progress (feat/097-php83-full-ci-row) |
 
 ---
 
-## Priority 1 — Merge PR #96
+## Priority 1 — Issue #97: PHP 8.3 Full CI Row
 
 ```bash
-# Verify all 7 CI jobs pass first
-gh pr checks 96 --repo satwareAG/php-firebird | grep -E "^PHP"
+# PR open — verify all 9 CI jobs pass
+gh pr checks --repo satwareAG/php-firebird
 
-# Merge
-gh pr merge 96 --repo satwareAG/php-firebird --squash --delete-branch
+# On transient CDN 504 failures:
+# gh run rerun <id> --repo satwareAG/php-firebird --failed
 ```
 
 ---

--- a/docs/product/project-brief.md
+++ b/docs/product/project-brief.md
@@ -138,12 +138,12 @@ Firebird server (3.0 / 4.0 / 5.0)
 
 ## CI Matrix
 
-PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 = **7 combinations**
+PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 = **9 combinations**
 
 | PHP | FB 3.0 | FB 4.0 | FB 5.0 |
 |-----|--------|--------|--------|
 | 8.2 (min) | ✅ | ✅ | ✅ |
-| 8.3 | - | ✅ | - |
+| 8.3 | ✅ | ✅ | ✅ |
 | 8.4 (current) | ✅ | ✅ | ✅ |
 
 All three Firebird versions (3.0, 4.0, 5.0) are actively supported as of 2026.


### PR DESCRIPTION
## Summary

Completes the CI matrix by adding PHP 8.3 × FB 3.0 and PHP 8.3 × FB 5.0, bringing the total from 7 to 9 combinations.

Closes #97

## Changes

- `.github/workflows/ci.yml`: Add two matrix entries for PHP 8.3 × FB 3.0 and PHP 8.3 × FB 5.0
- `AGENTS.md`: Update CI matrix table (7 → 9 combinations)
- `.specify/memory/constitution.md`: Update Article V rationale (7 → 9 combinations)
- `docs/product/project-brief.md`: Update CI matrix section
- `NEXT_STEPS.md`: Mark PR #96 merged, issue #97 in progress

## CI Matrix After This PR

| PHP | FB 3.0 | FB 4.0 | FB 5.0 |
|-----|--------|--------|--------|
| 8.2 (min) | ✅ | ✅ | ✅ |
| 8.3 | ✅ | ✅ | ✅ |
| 8.4 (current) | ✅ | ✅ | ✅ |

## Notes

- No new Dockerfile needed — CI uses `php:${{ matrix.php-version }}-cli-bookworm` image directly
- FB client version selection (3.0.12 / 4.0.6 / 5.0.2) handled by existing `case` block in workflow
- Transient CDN 504 on FB client download: `gh run rerun <id> --repo satwareAG/php-firebird --failed`