### PR TITLE
feat(ci): PHP 8.5 day-1 support — 12 combinations (#98)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Matrix: PHP 8.2/8.3/8.4 × FB 3.0/4.0/5.0 = 9 combinations
+          # Matrix: PHP 8.2/8.3/8.4/8.5 × FB 3.0/4.0/5.0 = 12 combinations
           # PHP 8.2: Minimum supported (PHP 8.1 dropped in v7.2.0)
           # PHP 8.3: Intermediate — full row (FB 3.0, 4.0, 5.0) as of issue #97
           # PHP 8.4: Current recommended
+          # PHP 8.5: Day-1 support (RC phase, php:8.5-cli-bookworm available) — issue #98
           # FB 3.0: Stable with modern auth (Srp) — actively supported
           # FB 4.0: Batch ops, time zones, DECFLOAT, INT128 (FB_API_VER=40) — actively supported
           # FB 5.0: Latest features, scrollable cursors — actively supported
@@ -70,6 +71,23 @@ jobs:
             fb-client-version: '4.0'
             db-path: '/var/lib/firebird/data/test.fdb'
           - php-version: '8.4'
+            firebird-version: '5.0'
+            firebird-image: 'firebirdsql/firebird:5'
+            fb-client-version: '5.0'
+            db-path: '/var/lib/firebird/data/test.fdb'
+
+          # PHP 8.5 combinations (day-1 support — issue #98)
+          - php-version: '8.5'
+            firebird-version: '3.0'
+            firebird-image: 'firebirdsql/firebird:3'
+            fb-client-version: '3.0'
+            db-path: '/var/lib/firebird/data/test.fdb'
+          - php-version: '8.5'
+            firebird-version: '4.0'
+            firebird-image: 'firebirdsql/firebird:4'
+            fb-client-version: '4.0'
+            db-path: '/var/lib/firebird/data/test.fdb'
+          - php-version: '8.5'
             firebird-version: '5.0'
             firebird-image: 'firebirdsql/firebird:5'
             fb-client-version: '5.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           # PHP 8.2: Minimum supported (PHP 8.1 dropped in v7.2.0)
           # PHP 8.3: Intermediate — full row (FB 3.0, 4.0, 5.0) as of issue #97
           # PHP 8.4: Current recommended
-          # PHP 8.5: Day-1 support (RC phase, php:8.5-cli-bookworm available) — issue #98
+          # PHP 8.5: Current latest stable (released 2025-11-20, active support until 2027-12-31) — issue #98
           # FB 3.0: Stable with modern auth (Srp) — actively supported
           # FB 4.0: Batch ops, time zones, DECFLOAT, INT128 (FB_API_VER=40) — actively supported
           # FB 5.0: Latest features, scrollable cursors — actively supported
@@ -76,7 +76,7 @@ jobs:
             fb-client-version: '5.0'
             db-path: '/var/lib/firebird/data/test.fdb'
 
-          # PHP 8.5 combinations (day-1 support — issue #98)
+          # PHP 8.5 combinations (stable since 2025-11-20 — issue #98)
           - php-version: '8.5'
             firebird-version: '3.0'
             firebird-image: 'firebirdsql/firebird:3'

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -67,13 +67,13 @@ This is NON-NEGOTIABLE.
 
 ## Article V: Multi-Version Compatibility
 
-- **MUST**: Extension compiles and tests pass on PHP 8.2, 8.3, 8.4
+- **MUST**: Extension compiles and tests pass on PHP 8.2, 8.3, 8.4, 8.5
 - **MUST**: Extension compiles and tests pass on Firebird 3.0, 4.0, and 5.0 (all actively supported)
 - **MUST**: Firebird 4.0+ features guarded with `#if FB_API_VER >= 40`
 - **MUST**: Tests for FB4+ features include `--SKIPIF--` with server version check
 - **SHALL NOT**: Use PHP version-specific APIs without a compatibility shim
 
-*Rationale*: The CI matrix covers PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 (9 combinations).
+*Rationale*: The CI matrix covers PHP 8.2/8.3/8.4/8.5 × Firebird 3.0/4.0/5.0 (12 combinations).
 All three Firebird versions are actively supported as of 2026. Each client version must be
 tested independently because `FB_API_VER` determines which code paths compile.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,13 +153,14 @@ Project Brief: `docs/product/project-brief.md`
 
 ## CI Matrix
 
-PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 = **9 combinations**
+PHP 8.2/8.3/8.4/8.5 × Firebird 3.0/4.0/5.0 = **12 combinations**
 
 | PHP | FB 3.0 | FB 4.0 | FB 5.0 |
 |-----|--------|--------|--------|
 | 8.2 (min) | ✅ | ✅ | ✅ |
 | 8.3 | ✅ | ✅ | ✅ |
 | 8.4 (current) | ✅ | ✅ | ✅ |
+| 8.5 (day-1) | ✅ | ✅ | ✅ |
 
 All three Firebird versions (3.0, 4.0, 5.0) are actively supported as of 2026.
 FB 4.0 entries compile with `FB_API_VER=40`, enabling batch ops, time zones, DECFLOAT, INT128.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ PHP 8.2/8.3/8.4/8.5 × Firebird 3.0/4.0/5.0 = **12 combinations**
 | 8.2 (min) | ✅ | ✅ | ✅ |
 | 8.3 | ✅ | ✅ | ✅ |
 | 8.4 (current) | ✅ | ✅ | ✅ |
-| 8.5 (day-1) | ✅ | ✅ | ✅ |
+| 8.5 (latest stable) | ✅ | ✅ | ✅ |
 
 All three Firebird versions (3.0, 4.0, 5.0) are actively supported as of 2026.
 FB 4.0 entries compile with `FB_API_VER=40`, enabling batch ops, time zones, DECFLOAT, INT128.

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -29,7 +29,8 @@ gh pr checks --repo satwareAG/php-firebird
 ```
 
 **Notes:**
-- `php:8.5-cli-bookworm` confirmed available on Docker Hub (PHP 8.5.3 stable)
+- `php:8.5-cli-bookworm` confirmed available on Docker Hub (PHP 8.5.3 stable, released 2025-11-20)
+- PHP 8.5 is the current latest stable release — active support until 2027-12-31
 - No custom image needed — CI uses `php:${{ matrix.php-version }}-cli-bookworm` directly
 - 3 new matrix entries added: PHP 8.5 × FB 3.0, FB 4.0, FB 5.0
 - Matrix now 12 combinations (was 9)

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -6,26 +6,33 @@
 
 ---
 
-## Status: v7.2.0 Released ✅ | PR #96 Merged ✅ | Issue #97 in progress
+## Status: v7.2.0 Released ✅ | PR #100 Merged ✅ | Issue #98 in progress
 
 | Item | Status |
 |------|--------|
 | v7.2.0 release | ✅ Published |
 | Stubs v7.2.0 (Packagist) | ✅ Tagged |
 | PR #96: CI matrix 4→7 combinations (FB4 + PHP 8.3) | ✅ Merged (commit 6458694) |
-| Issue #97: PHP 8.3 full CI row (FB 3.0 + FB 5.0) | 🔄 In progress (feat/097-php83-full-ci-row) |
+| Issue #97: PHP 8.3 full CI row (FB 3.0 + FB 5.0) | ✅ Merged (PR #100, commit ae42a5c) |
+| Issue #98: PHP 8.5 day-1 support | 🔄 In progress (feat/098-php85-day1-support) |
 
 ---
 
-## Priority 1 — Issue #97: PHP 8.3 Full CI Row
+## Priority 1 — Issue #98: PHP 8.5 Day-1 Support
 
 ```bash
-# PR open — verify all 9 CI jobs pass
+# PR open — verify all 12 CI jobs pass
 gh pr checks --repo satwareAG/php-firebird
 
 # On transient CDN 504 failures:
 # gh run rerun <id> --repo satwareAG/php-firebird --failed
 ```
+
+**Notes:**
+- `php:8.5-cli-bookworm` confirmed available on Docker Hub (PHP 8.5.3 stable)
+- No custom image needed — CI uses `php:${{ matrix.php-version }}-cli-bookworm` directly
+- 3 new matrix entries added: PHP 8.5 × FB 3.0, FB 4.0, FB 5.0
+- Matrix now 12 combinations (was 9)
 
 ---
 
@@ -35,15 +42,24 @@ gh pr checks --repo satwareAG/php-firebird
 
 | Issue | Title | Priority |
 |-------|-------|----------|
-| #97 | feat(ci): PHP 8.3 full CI row (FB 3.0 + FB 5.0) | High — complete the matrix |
-| #98 | feat(ci): PHP 8.5 day-1 support | Medium — Dockerfile-8.5 exists |
+| #97 | feat(ci): PHP 8.3 full CI row (FB 3.0 + FB 5.0) | ✅ Done |
+| #98 | feat(ci): PHP 8.5 day-1 support | High — in progress |
 | #99 | chore(ci): update pinned FB client versions to latest patch | Low — maintenance |
-
-**Start with #97** — extends PR #96 work, adds PHP 8.3 × FB 3.0 and PHP 8.3 × FB 5.0 entries.
 
 ---
 
-## Priority 3 — doctrine-firebird-driver v3.11.0
+## Priority 3 — Issue #99 (after #98): Update Pinned FB Client Versions
+
+Current pinned versions in `ci.yml`:
+- FB 3.0: `3.0.12` (build `33787-0`)
+- FB 4.0: `4.0.6` (build `3221-0`)
+- FB 5.0: `5.0.2` (build `1613-0`)
+
+Check latest patch releases: https://github.com/FirebirdSQL/firebird/releases
+
+---
+
+## Priority 4 — doctrine-firebird-driver v3.11.0
 
 **Milestone**: https://github.com/satwareAG/doctrine-firebird-driver/milestone/7
 
@@ -64,7 +80,7 @@ gh pr checks --repo satwareAG/php-firebird
 
 ---
 
-## Priority 4 — doctrine-firebird-driver v4.0.0-planning
+## Priority 5 — doctrine-firebird-driver v4.0.0-planning
 
 **Milestone**: https://github.com/satwareAG/doctrine-firebird-driver/milestone/8
 
@@ -75,7 +91,7 @@ gh pr checks --repo satwareAG/php-firebird
 
 ---
 
-## Milestone State (post-2026-03-05 hygiene)
+## Milestone State (post-2026-03-05)
 
 ### php-firebird
 
@@ -83,7 +99,7 @@ gh pr checks --repo satwareAG/php-firebird
 |-----------|-------|--------|
 | v7.0.0 | ✅ Closed | 26 closed |
 | v7.2.0 | ✅ Closed | 6 closed |
-| v7.3.0 | 🔄 Open | 3 open (#97, #98, #99) |
+| v7.3.0 | 🔄 Open | 2 open (#98, #99) |
 
 ### doctrine-firebird-driver
 
@@ -101,6 +117,7 @@ gh pr checks --repo satwareAG/php-firebird
 - **php-firebird release:** https://github.com/satwareAG/php-firebird/releases/tag/v7.2.0
 - **Stubs release:** https://github.com/satwareAG/php-firebird-stubs/releases/tag/v7.2.0
 - **PR #96:** https://github.com/satwareAG/php-firebird/pull/96
+- **PR #100:** https://github.com/satwareAG/php-firebird/pull/100 (merged)
 - **v7.3.0 milestone:** https://github.com/satwareAG/php-firebird/milestone/3
 - **doctrine v3.11.0 milestone:** https://github.com/satwareAG/doctrine-firebird-driver/milestone/7
 - **doctrine v4.0.0-planning:** https://github.com/satwareAG/doctrine-firebird-driver/milestone/8

--- a/docs/product/project-brief.md
+++ b/docs/product/project-brief.md
@@ -30,7 +30,7 @@ extension, renamed to `fbird_*` prefix. The `ibase_*` aliases were fully removed
 | **Language** | C (Zend Engine API), C++ (internal wrappers only) |
 | **Build System** | `config.m4` (autoconf/phpize), `config.w32` (Windows) |
 | **Database** | Firebird 3.0, 4.0, 5.0 (via `ibase.h` / FB API) |
-| **PHP Versions** | 8.2, 8.3, 8.4, 8.5 (day-1 support) — CI: 8.2/8.3/8.4/8.5 |
+| **PHP Versions** | 8.2, 8.3, 8.4, 8.5 (stable since 2025-11-20) — CI: 8.2/8.3/8.4/8.5 |
 | **Testing** | `.phpt` files via `make test` / `run-tests.php` |
 | **Coverage** | gcov + lcov (inside Docker) |
 | **Sanitizers** | AddressSanitizer, UndefinedBehaviorSanitizer, Valgrind |
@@ -145,7 +145,7 @@ PHP 8.2/8.3/8.4/8.5 × Firebird 3.0/4.0/5.0 = **12 combinations**
 | 8.2 (min) | ✅ | ✅ | ✅ |
 | 8.3 | ✅ | ✅ | ✅ |
 | 8.4 (current) | ✅ | ✅ | ✅ |
-| 8.5 (day-1) | ✅ | ✅ | ✅ |
+| 8.5 (latest stable) | ✅ | ✅ | ✅ |
 
 All three Firebird versions (3.0, 4.0, 5.0) are actively supported as of 2026.
 Each client version is tested independently because `FB_API_VER` determines which

--- a/docs/product/project-brief.md
+++ b/docs/product/project-brief.md
@@ -30,7 +30,7 @@ extension, renamed to `fbird_*` prefix. The `ibase_*` aliases were fully removed
 | **Language** | C (Zend Engine API), C++ (internal wrappers only) |
 | **Build System** | `config.m4` (autoconf/phpize), `config.w32` (Windows) |
 | **Database** | Firebird 3.0, 4.0, 5.0 (via `ibase.h` / FB API) |
-| **PHP Versions** | 8.2, 8.3, 8.4 (8.5 day-1 support planned) — CI: 8.2/8.3/8.4 |
+| **PHP Versions** | 8.2, 8.3, 8.4, 8.5 (day-1 support) — CI: 8.2/8.3/8.4/8.5 |
 | **Testing** | `.phpt` files via `make test` / `run-tests.php` |
 | **Coverage** | gcov + lcov (inside Docker) |
 | **Sanitizers** | AddressSanitizer, UndefinedBehaviorSanitizer, Valgrind |
@@ -138,13 +138,14 @@ Firebird server (3.0 / 4.0 / 5.0)
 
 ## CI Matrix
 
-PHP 8.2/8.3/8.4 × Firebird 3.0/4.0/5.0 = **9 combinations**
+PHP 8.2/8.3/8.4/8.5 × Firebird 3.0/4.0/5.0 = **12 combinations**
 
 | PHP | FB 3.0 | FB 4.0 | FB 5.0 |
 |-----|--------|--------|--------|
 | 8.2 (min) | ✅ | ✅ | ✅ |
 | 8.3 | ✅ | ✅ | ✅ |
 | 8.4 (current) | ✅ | ✅ | ✅ |
+| 8.5 (day-1) | ✅ | ✅ | ✅ |
 
 All three Firebird versions (3.0, 4.0, 5.0) are actively supported as of 2026.
 Each client version is tested independently because `FB_API_VER` determines which


### PR DESCRIPTION
## Summary

Adds PHP 8.5 to the CI matrix, completing day-1 support for the upcoming PHP release.

Closes #98

## Changes

- `.github/workflows/ci.yml`: Add 3 matrix entries for PHP 8.5 × FB 3.0, FB 4.0, FB 5.0
- `AGENTS.md`: Update CI matrix table (9 → 12 combinations, add PHP 8.5 row)
- `.specify/memory/constitution.md`: Update Article V — PHP 8.5 added to MUST list
- `docs/product/project-brief.md`: Update Technology Stack and CI Matrix sections
- `NEXT_STEPS.md`: Mark #97 done, set #98 in-progress

## Matrix after this PR

| PHP | FB 3.0 | FB 4.0 | FB 5.0 |
|-----|--------|--------|--------|
| 8.2 (min) | ✅ | ✅ | ✅ |
| 8.3 | ✅ | ✅ | ✅ |
| 8.4 (current) | ✅ | ✅ | ✅ |
| 8.5 (day-1) | ✅ | ✅ | ✅ |

**12 combinations total** (was 9)

## Docker image

`php:8.5-cli-bookworm` is available on Docker Hub (PHP 8.5.3 stable). No custom image needed — the existing `container: image: php:${{ matrix.php-version }}-cli-bookworm` pattern works directly.