### PR TITLE
chore(ci): update pinned FB client versions to latest patch releases (#99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,8 +181,8 @@ jobs:
           # Select client tarball based on version
           case "${FB_CLIENT_VERSION}" in
             '3.0')
-              FB_VERSION="3.0.12"
-              FB_BUILD="33787-0"
+              FB_VERSION="3.0.13"
+              FB_BUILD="33818-0"
               FB_TARBALL="Firebird-${FB_VERSION}.${FB_BUILD}.amd64.tar.gz"
               FB_URL="https://github.com/FirebirdSQL/firebird/releases/download/v${FB_VERSION}/${FB_TARBALL}"
               FB_EXTRACT_DIR="Firebird-${FB_VERSION}.${FB_BUILD}.amd64"
@@ -195,8 +195,8 @@ jobs:
               FB_EXTRACT_DIR="Firebird-${FB_VERSION}.${FB_BUILD}.amd64"
               ;;
             '5.0')
-              FB_VERSION="5.0.2"
-              FB_BUILD="1613-0"
+              FB_VERSION="5.0.3"
+              FB_BUILD="1683-0"
               FB_TARBALL="Firebird-${FB_VERSION}.${FB_BUILD}-linux-x64.tar.gz"
               FB_URL="https://github.com/FirebirdSQL/firebird/releases/download/v${FB_VERSION}/${FB_TARBALL}"
               FB_EXTRACT_DIR="Firebird-${FB_VERSION}.${FB_BUILD}-linux-x64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: Updated pinned Firebird client versions to latest patch releases** — FB 3.0.12 (build
+  33787-0) updated to FB 3.0.13 (build 33818-0); FB 5.0.2 (build 1613-0) updated to FB 5.0.3
+  (build 1683-0). FB 4.0.6 (build 3221-0) unchanged (already latest).
+  Closes [#99](https://github.com/satwareAG/php-firebird/issues/99).
+
 ---
 
 ## [7.2.0] - 2026-03-04


### PR DESCRIPTION
## Summary

Updates pinned Firebird client library versions in CI to latest patch releases.

## Changes

| Version | Old | New | Build |
|---------|-----|-----|-------|
| FB 3.0 | 3.0.12 (33787-0) | **3.0.13 (33818-0)** | Updated |
| FB 4.0 | 4.0.6 (3221-0) | 4.0.6 (3221-0) | Unchanged (already latest) |
| FB 5.0 | 5.0.2 (1613-0) | **5.0.3 (1683-0)** | Updated |

## Verification

- FB 3.0.13 released 2025-07-15: https://github.com/FirebirdSQL/firebird/releases/tag/v3.0.13
- FB 5.0.3 released 2025-07-14: https://github.com/FirebirdSQL/firebird/releases/tag/v5.0.3
- Tarball names verified from release assets (amd64 for 3.0/4.0, linux-x64 for 5.0)

Closes #99