### PR TITLE
feat(version): centralized version management via VERSION file (#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Ensure VERSION file
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Ensure VERSION file
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "${GITHUB_REF#refs/tags/v}" > VERSION
+            echo "Updated VERSION file from tag: $(cat VERSION)"
+          elif [ ! -f VERSION ]; then
+            VERSION=$(grep -E '#define PHP_FIREBIRD_VERSION_STRING' php_firebird.h | sed 's/.*"\([^"]*\)".*/\1/' | head -1)
+            echo "${VERSION:-7.0.0}" > VERSION
+            echo "Created VERSION file from header/default: $(cat VERSION)"
+          fi
+
       - name: Install system dependencies
         run: |
           set -eu

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -35,7 +35,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock', '**/composer.json') }}
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check stubs are in sync with firebird.c PHP_FE registrations
         run: |
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install analysis tools
         run: |
@@ -195,7 +195,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install build dependencies
         run: |
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install system dependencies (lcov included)
         run: |
@@ -472,7 +472,7 @@ jobs:
           rm -f coverage/*.info test_output.txt
 
       - name: Upload Coverage Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
           path: coverage/html/

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -65,15 +65,23 @@ jobs:
       - name: Get Extension Version
         id: get-version
         run: |
-          # Look for PHP_FIREBIRD_VERSION_STRING (set by configure) or fallback
-          VERSION=$(grep -E '#define PHP_FIREBIRD_VERSION_STRING' php_firebird.h | sed 's/.*"\([^"]*\)".*/\1/' | head -1)
-          # If empty or contains "unknown", use fallback from git tag or default
-          if [ -z "$VERSION" ] || [[ "$VERSION" == *"unknown"* ]]; then
-            if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-              VERSION="${GITHUB_REF#refs/tags/v}"
-            else
+          # Priority 1: Git tag (for immutable release builds)
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            # Update VERSION file if it exists or create it
+            echo "${VERSION}" > VERSION
+            echo "Updated VERSION file from tag: ${VERSION}"
+          # Priority 2: VERSION file (source of truth for development)
+          elif [ -f VERSION ]; then
+            VERSION=$(cat VERSION | tr -d '[:space:]')
+          # Fallback: php_firebird.h or static default
+          else
+            VERSION=$(grep -E '#define PHP_FIREBIRD_VERSION_STRING' php_firebird.h | sed 's/.*"\([^"]*\)".*/\1/' | head -1)
+            if [ -z "$VERSION" ] || [[ "$VERSION" == *"unknown"* ]]; then
               VERSION="7.0.0"
             fi
+            # Ensure VERSION file exists for subsequent steps
+            echo "${VERSION}" > VERSION
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extension version: ${VERSION}"

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -60,7 +60,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Get Extension Version
         id: get-version
@@ -134,7 +134,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Install Build Dependencies
         run: |
@@ -387,7 +387,7 @@ jobs:
           ls -la dist/
       
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ steps.bundle.outputs.bundle_name }}
           path: |
@@ -412,7 +412,7 @@ jobs:
     
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
       
@@ -505,7 +505,7 @@ jobs:
 
     steps:
       - name: Download PHP ${{ matrix.php }} NTS Bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: '*php${{ matrix.php }}-nts*'
           path: bundle

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -23,6 +23,7 @@ on:
       - '*.c'
       - '*.h'
       - 'config.w32'
+      - 'VERSION'
       - '.github/workflows/release-windows.yml'
   pull_request:
   release:
@@ -75,6 +76,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Ensure VERSION file
+        shell: pwsh
+        run: |
+          if ("${{ github.ref }}" -like "refs/tags/v*") {
+            $version = "${{ github.ref }}".Substring(11)
+            Set-Content -Path "VERSION" -Value $version
+            Write-Host "Updated VERSION file from tag: $version"
+          } elseif (-not (Test-Path "VERSION")) {
+            # Extract from php_firebird.h as fallback
+            $header = Get-Content "php_firebird.h"
+            $match = $header | Select-String -Pattern '#define PHP_FIREBIRD_VERSION_STRING "([^"]+)"'
+            if ($match) {
+              $version = $match.Matches[0].Groups[1].Value
+            } else {
+              $version = "7.0.0"
+            }
+            Set-Content -Path "VERSION" -Value $version
+            Write-Host "Created VERSION file from header/default: $version"
+          } else {
+            Write-Host "Using existing VERSION file: $(Get-Content VERSION)"
+          }
 
       - name: Cache Firebird SDK
         uses: actions/cache@v4

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -51,7 +51,7 @@ jobs:
       matrix: ${{ steps.extension-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get the extension matrix
         id: extension-matrix
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Ensure VERSION file
         shell: pwsh
@@ -100,7 +100,7 @@ jobs:
           }
 
       - name: Cache Firebird SDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-fb-sdk
         with:
           path: C:\firebird-sdk

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install build dependencies
         run: |
@@ -368,7 +368,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/split-stubs.yml
+++ b/.github/workflows/split-stubs.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history required for subtree split
       

--- a/config.m4
+++ b/config.m4
@@ -8,13 +8,13 @@ if test "$PHP_FIREBIRD" != "no"; then
 
   dnl Detect php-firebird version from git or VERSION file
   AC_MSG_CHECKING([for php-firebird version])
-  if test -d "$srcdir/.git" -a -x "`which git 2>/dev/null`"; then
+  if test -f "$srcdir/VERSION"; then
+    PHP_FIREBIRD_VERSION=`cat "$srcdir/VERSION" | tr -d '[:space:]'`
+  elif test -d "$srcdir/.git" -a -x "`which git 2>/dev/null`"; then
     PHP_FIREBIRD_VERSION=`cd "$srcdir" && git describe --tags --always --dirty 2>/dev/null | sed 's/^v//'`
     if test -z "$PHP_FIREBIRD_VERSION"; then
       PHP_FIREBIRD_VERSION="0.0.0-unknown"
     fi
-  elif test -f "$srcdir/VERSION"; then
-    PHP_FIREBIRD_VERSION=`cat "$srcdir/VERSION"`
   else
     PHP_FIREBIRD_VERSION="0.0.0-unknown"
   fi

--- a/config.m4
+++ b/config.m4
@@ -9,7 +9,7 @@ if test "$PHP_FIREBIRD" != "no"; then
   dnl Detect php-firebird version from git or VERSION file
   AC_MSG_CHECKING([for php-firebird version])
   if test -f "$srcdir/VERSION"; then
-    PHP_FIREBIRD_VERSION=`cat "$srcdir/VERSION" | tr -d '[:space:]'`
+    PHP_FIREBIRD_VERSION=`cat "$srcdir/VERSION" | tr -d ' \n\r\t'`
   elif test -d "$srcdir/.git" -a -x "`which git 2>/dev/null`"; then
     PHP_FIREBIRD_VERSION=`cd "$srcdir" && git describe --tags --always --dirty 2>/dev/null | sed 's/^v//'`
     if test -z "$PHP_FIREBIRD_VERSION"; then
@@ -23,16 +23,17 @@ if test "$PHP_FIREBIRD" != "no"; then
 
   dnl Check for minimum PHP version (8.1+)
   AC_MSG_CHECKING([for minimum PHP version 8.1])
+  PHP_FIREBIRD_PHP_VERSION=`$PHP_CONFIG --version`
   old_IFS=$IFS
   IFS=.
-  set -- $PHP_VERSION
+  set -- $PHP_FIREBIRD_PHP_VERSION
   IFS=$old_IFS
   php_major=$1
   php_minor=$2
   if test "$php_major" -lt 8 -o \( "$php_major" -eq 8 -a "$php_minor" -lt 1 \); then
-    AC_MSG_ERROR([PHP Firebird extension requires PHP 8.1 or later. Current version: $PHP_VERSION])
+    AC_MSG_ERROR([PHP Firebird extension requires PHP 8.1 or later. Current version: $PHP_FIREBIRD_PHP_VERSION])
   fi
-  AC_MSG_RESULT([yes (PHP $PHP_VERSION)])
+  AC_MSG_RESULT([yes (PHP $PHP_FIREBIRD_PHP_VERSION)])
 
   AC_PATH_PROG(FB_CONFIG, fb_config, no)
 

--- a/config.w32
+++ b/config.w32
@@ -4,6 +4,19 @@
 ARG_WITH('firebird', 'Firebird database support', 'no');
 
 if (PHP_FIREBIRD != 'no') {
+    // Detect php-firebird version from VERSION file
+    var version = "0.0.0-unknown";
+    try {
+        var f = FSO.OpenTextFile(configure_module_directory + "\\VERSION", 1);
+        if (f) {
+            version = f.ReadLine().trim();
+            f.Close();
+        }
+    } catch (e) {
+        // Fallback to unknown version if reading file fails
+    }
+    AC_DEFINE('PHP_FIREBIRD_VERSION_STRING', version, 'PHP Firebird extension version');
+
     // Check for Firebird client library and header
     if (CHECK_LIB('fbclient_ms.lib', 'firebird', PHP_FIREBIRD + '\\lib') &&
         CHECK_HEADER_ADD_INCLUDE('ibase.h', 'CFLAGS_FIREBIRD', PHP_FIREBIRD + '\\include')) {

--- a/config.w32
+++ b/config.w32
@@ -6,17 +6,16 @@ ARG_WITH('firebird', 'Firebird database support', 'no');
 if (PHP_FIREBIRD != 'no') {
     // Detect php-firebird version from VERSION file
     var version = "0.0.0-unknown";
-    STDOUT.WriteLine("Checking for php-firebird version in " + configure_module_directory);
     try {
         var fso = new ActiveXObject("Scripting.FileSystemObject");
-        var versionFile = configure_module_directory + "\\VERSION";
+        var versionFile = ".\\VERSION";
         if (fso.FileExists(versionFile)) {
             var f = fso.OpenTextFile(versionFile, 1);
             version = f.AtEndOfStream ? "0.0.0-empty" : f.ReadLine().replace(/^\s+|\s+$/g, "");
             f.Close();
-            STDOUT.WriteLine("Found version: " + version);
+            STDOUT.WriteLine("Found php-firebird version: " + version);
         } else {
-            STDOUT.WriteLine("VERSION file not found at " + versionFile);
+            STDOUT.WriteLine("VERSION file not found at " + fso.GetAbsolutePathName(versionFile));
         }
     } catch (e) {
         STDOUT.WriteLine("Error reading VERSION file: " + e.message);

--- a/config.w32
+++ b/config.w32
@@ -7,9 +7,11 @@ if (PHP_FIREBIRD != 'no') {
     // Detect php-firebird version from VERSION file
     var version = "0.0.0-unknown";
     try {
-        var f = FSO.OpenTextFile(configure_module_directory + "\\VERSION", 1);
-        if (f) {
-            version = f.ReadLine().trim();
+        var fso = new ActiveXObject("Scripting.FileSystemObject");
+        var versionFile = configure_module_directory + "\\VERSION";
+        if (fso.FileExists(versionFile)) {
+            var f = fso.OpenTextFile(versionFile, 1);
+            version = f.ReadLine().replace(/^\s+|\s+$/g, "");
             f.Close();
         }
     } catch (e) {

--- a/config.w32
+++ b/config.w32
@@ -6,16 +6,20 @@ ARG_WITH('firebird', 'Firebird database support', 'no');
 if (PHP_FIREBIRD != 'no') {
     // Detect php-firebird version from VERSION file
     var version = "0.0.0-unknown";
+    STDOUT.WriteLine("Checking for php-firebird version in " + configure_module_directory);
     try {
         var fso = new ActiveXObject("Scripting.FileSystemObject");
         var versionFile = configure_module_directory + "\\VERSION";
         if (fso.FileExists(versionFile)) {
             var f = fso.OpenTextFile(versionFile, 1);
-            version = f.ReadLine().replace(/^\s+|\s+$/g, "");
+            version = f.AtEndOfStream ? "0.0.0-empty" : f.ReadLine().replace(/^\s+|\s+$/g, "");
             f.Close();
+            STDOUT.WriteLine("Found version: " + version);
+        } else {
+            STDOUT.WriteLine("VERSION file not found at " + versionFile);
         }
     } catch (e) {
-        // Fallback to unknown version if reading file fails
+        STDOUT.WriteLine("Error reading VERSION file: " + e.message);
     }
     AC_DEFINE('PHP_FIREBIRD_VERSION_STRING', version, 'PHP Firebird extension version');
 

--- a/scripts/build-precompiled.sh
+++ b/scripts/build-precompiled.sh
@@ -48,8 +48,10 @@ GENERATE_CHECKSUMS=true
 VERBOSE=false
 RUN_VERIFY=false
 
-# Auto-detect extension version from php_firebird.h
-if [ -f "php_firebird.h" ]; then
+# Auto-detect extension version
+if [ -f "VERSION" ]; then
+    DETECTED_VERSION=$(cat VERSION | tr -d '[:space:]')
+elif [ -f "php_firebird.h" ]; then
     # Look for PHP_FIREBIRD_VERSION_STRING (set by configure)
     # Use || true to prevent grep exit code 1 from failing under set -e
     DETECTED_VERSION=$(grep -E '#define PHP_FIREBIRD_VERSION_STRING' php_firebird.h 2>/dev/null | sed 's/.*"\([^"]*\)".*/\1/' | head -1 || true)
@@ -57,10 +59,10 @@ if [ -f "php_firebird.h" ]; then
     if [ -z "$DETECTED_VERSION" ] || [[ "$DETECTED_VERSION" == *"unknown"* ]]; then
         DETECTED_VERSION="7.0.0"
     fi
-    EXT_VERSION="${EXT_VERSION:-$DETECTED_VERSION}"
 else
-    EXT_VERSION="${EXT_VERSION:-7.0.0}"
+    DETECTED_VERSION="7.0.0"
 fi
+EXT_VERSION="${EXT_VERSION:-$DETECTED_VERSION}"
 
 FB_VERSION="5.0"
 FB_ROOT="${FB_ROOT:-/opt/firebird}"

--- a/tests/fbird_version.phpt
+++ b/tests/fbird_version.phpt
@@ -1,0 +1,47 @@
+--TEST--
+fbird_version: verify extension version information
+--SKIPIF--
+<?php
+require_once __DIR__ . '/config.inc';
+if (!extension_loaded('firebird')) die('skip firebird extension not loaded');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/config.inc';
+
+$extension_version = phpversion('firebird');
+$version_file = trim(file_get_contents(__DIR__ . '/../VERSION'));
+
+echo "Extension version: " . $extension_version . "\n";
+echo "VERSION file: " . $version_file . "\n";
+
+if (strpos($extension_version, $version_file) === 0) {
+    echo "Versions match (base version found)\n";
+} else {
+    echo "Versions do NOT match! Extension: $extension_version, VERSION file: $version_file\n";
+}
+
+// Check constants
+if (defined('FBIRD_VER')) {
+    echo "FBIRD_VER is defined: " . FBIRD_VER . "\n";
+} else {
+    echo "FBIRD_VER is NOT defined!\n";
+}
+
+// Check phpinfo() output
+ob_start();
+phpinfo(INFO_MODULES);
+$phpinfo = ob_get_clean();
+
+if (strpos($phpinfo, "Firebird extension version => " . $extension_version) !== false) {
+    echo "phpinfo contains correct version\n";
+} else {
+    echo "phpinfo does NOT contain correct version!\n";
+}
+?>
+--EXPECTF--
+Extension version: %s
+VERSION file: %s
+Versions match (base version found)
+FBIRD_VER is defined: %d
+phpinfo contains correct version


### PR DESCRIPTION
### Summary
This PR implements centralized version management to resolve issue #107.

### Changes
- Updated `config.m4` and `config.w32` to read version from the `VERSION` file.
- Synced `php_firebird.h` and `firebird.c` to use `PHP_FIREBIRD_VERSION_STRING`.
- Updated GitHub Actions to automatically sync `VERSION` with tags during releases.
- Added `tests/fbird_version.phpt` for regression testing.

### Verification
- Full matrix testing completed on all supported PHP (8.2-8.5) and Firebird (3.0-5.0) versions.
- All version-related tests passed.