### PR TITLE
feat(pdo-fbird): Layer 3 PDO driver with fbird: DSN prefix

### DIFF
--- a/pdo_fbird/config.m4
+++ b/pdo_fbird/config.m4
@@ -1,0 +1,62 @@
+dnl pdo_fbird — PDO driver for Firebird (fbird: DSN prefix)
+dnl Separate shared extension depending on the firebird extension.
+
+PHP_ARG_WITH([pdo-fbird],
+  [for Firebird PDO support (fbird: DSN)],
+  [AS_HELP_STRING([--with-pdo-fbird],
+    [Include PDO Firebird driver using fbird: DSN prefix])])
+
+if test "$PHP_PDO_FBIRD" != "no"; then
+
+  dnl Require PDO headers (PDO may be built-in or shared)
+  ifdef([PHP_CHECK_PDO_INCLUDES],
+    [PHP_CHECK_PDO_INCLUDES],
+    [AC_MSG_CHECKING([for PDO includes])
+     if test -f "$abs_srcdir/ext/pdo/php_pdo_driver.h"; then
+       pdo_inc_path="$abs_srcdir/ext/pdo"
+     elif test -f "$phpincludedir/ext/pdo/php_pdo_driver.h"; then
+       pdo_inc_path="$phpincludedir/ext/pdo"
+     else
+       AC_MSG_ERROR([Cannot find php_pdo_driver.h. Make sure PDO is available.])
+     fi
+     PHP_ADD_INCLUDE([$pdo_inc_path])
+     AC_MSG_RESULT([$pdo_inc_path])])
+
+  dnl Find Firebird client library
+  FIREBIRD_INCDIR=""
+  FIREBIRD_LIBDIR=""
+
+  for i in /usr /usr/local /opt/firebird; do
+    if test -f "$i/include/firebird/Interface.h"; then
+      FIREBIRD_INCDIR="$i/include"
+      FIREBIRD_LIBDIR="$i/lib"
+      break
+    fi
+    if test -f "$i/include/ibase.h"; then
+      FIREBIRD_INCDIR="$i/include"
+      FIREBIRD_LIBDIR="$i/lib"
+      break
+    fi
+  done
+
+  if test -z "$FIREBIRD_INCDIR"; then
+    AC_MSG_ERROR([Firebird client headers not found. Install libfbclient-dev.])
+  fi
+
+  PHP_ADD_INCLUDE($FIREBIRD_INCDIR)
+  PHP_ADD_LIBRARY_WITH_PATH(fbclient, $FIREBIRD_LIBDIR, PDO_FBIRD_SHARED_LIBADD)
+
+  dnl Also include the parent extension headers
+  PHP_ADD_INCLUDE([$srcdir/..])
+
+  PHP_NEW_EXTENSION(pdo_fbird,
+    pdo_fbird.c \
+    pdo_fbird_driver.c \
+    pdo_fbird_stmt.c \
+    pdo_fbird_error.c,
+    $ext_shared,, [-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -I$FIREBIRD_INCDIR])
+
+  PHP_ADD_EXTENSION_DEP(pdo_fbird, pdo)
+  PHP_ADD_EXTENSION_DEP(pdo_fbird, firebird)
+  PHP_SUBST(PDO_FBIRD_SHARED_LIBADD)
+fi

--- a/pdo_fbird/pdo_fbird.c
+++ b/pdo_fbird/pdo_fbird.c
@@ -1,0 +1,77 @@
+/*
+ * pdo_fbird — PDO driver for Firebird databases
+ * pdo_fbird.c — module init/shutdown, driver registration
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_ini.h"
+#include "ext/standard/info.h"
+#include "ext/pdo/php_pdo.h"
+#include "ext/pdo/php_pdo_driver.h"
+#include "php_pdo_fbird.h"
+#include "php_pdo_fbird_int.h"
+
+/* {{{ PHP_MINIT_FUNCTION */
+PHP_MINIT_FUNCTION(pdo_fbird)
+{
+	if (php_pdo_register_driver(&pdo_fbird_driver) == FAILURE) {
+		return FAILURE;
+	}
+
+	/* Register custom attribute constants into the PDO class */
+	zend_class_entry *pdo_ce = php_pdo_get_dbh_ce();
+	if (pdo_ce) {
+		zend_declare_class_constant_long(pdo_ce, "FBIRD_ATTR_DIALECT",
+			sizeof("FBIRD_ATTR_DIALECT") - 1, PDO_FBIRD_ATTR_DIALECT);
+		zend_declare_class_constant_long(pdo_ce, "FBIRD_ATTR_CHARSET",
+			sizeof("FBIRD_ATTR_CHARSET") - 1, PDO_FBIRD_ATTR_CHARSET);
+		zend_declare_class_constant_long(pdo_ce, "FBIRD_ATTR_ROLE",
+			sizeof("FBIRD_ATTR_ROLE") - 1, PDO_FBIRD_ATTR_ROLE);
+		zend_declare_class_constant_long(pdo_ce, "FBIRD_ATTR_PAGE_BUFFERS",
+			sizeof("FBIRD_ATTR_PAGE_BUFFERS") - 1, PDO_FBIRD_ATTR_PAGE_BUFFERS);
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_MSHUTDOWN_FUNCTION */
+PHP_MSHUTDOWN_FUNCTION(pdo_fbird)
+{
+	php_pdo_unregister_driver(&pdo_fbird_driver);
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_MINFO_FUNCTION */
+PHP_MINFO_FUNCTION(pdo_fbird)
+{
+	php_info_print_table_start();
+	php_info_print_table_header(2, "PDO Driver for Firebird", "enabled");
+	php_info_print_table_row(2, "PDO Firebird (fbird:) version", PHP_PDO_FBIRD_VERSION);
+	php_info_print_table_end();
+}
+/* }}} */
+
+/* {{{ pdo_fbird_module_entry */
+zend_module_entry pdo_fbird_module_entry = {
+	STANDARD_MODULE_HEADER,
+	PHP_PDO_FBIRD_EXTNAME,
+	NULL,                   /* functions */
+	PHP_MINIT(pdo_fbird),
+	PHP_MSHUTDOWN(pdo_fbird),
+	NULL,                   /* RINIT */
+	NULL,                   /* RSHUTDOWN */
+	PHP_MINFO(pdo_fbird),
+	PHP_PDO_FBIRD_VERSION,
+	STANDARD_MODULE_PROPERTIES
+};
+/* }}} */
+
+#ifdef COMPILE_DL_PDO_FBIRD
+ZEND_GET_MODULE(pdo_fbird)
+#endif

--- a/pdo_fbird/pdo_fbird_driver.c
+++ b/pdo_fbird/pdo_fbird_driver.c
@@ -1,0 +1,397 @@
+/*
+ * pdo_fbird — connection driver (T10, T11, T15)
+ * DSN parsing, handle factory/closer, transactions, attributes
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "ext/pdo/php_pdo.h"
+#include "ext/pdo/php_pdo_driver.h"
+#include "php_pdo_fbird.h"
+#include "php_pdo_fbird_int.h"
+#include <ibase.h>
+#include "../firebird_utils.h"
+#include "../php_firebird.h"
+
+extern const struct pdo_stmt_methods pdo_fbird_stmt_methods;
+
+/* Forward declarations */
+static void pdo_fbird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info);
+
+/* Helper: start a transaction using master + attachment */
+static void* _pdo_fbt_start(pdo_fbird_db_handle *H)
+{
+	void *att = fbc_get_attachment(H->fbc_conn);
+	return fbt_start(IBG(master_instance), att, 0, NULL, H->status);
+}
+
+/* {{{ pdo_fbird_handle_closer */
+static void pdo_fbird_handle_closer(pdo_dbh_t *dbh)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+	if (!H) return;
+
+	if (H->fbt_trans) {
+		fbt_rollback(H->fbt_trans, H->status);
+		fbt_free(H->fbt_trans);
+		H->fbt_trans = NULL;
+	}
+
+	if (H->fbc_conn) {
+		fbc_disconnect(H->fbc_conn, H->status);
+		H->fbc_conn = NULL;
+	}
+
+	if (H->charset) { efree(H->charset); H->charset = NULL; }
+	if (H->role)    { efree(H->role);    H->role    = NULL; }
+
+	efree(H);
+	dbh->driver_data = NULL;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_handle_preparer */
+static bool pdo_fbird_handle_preparer(pdo_dbh_t *dbh, zend_string *sql,
+	pdo_stmt_t *stmt, zval *driver_options)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+
+	pdo_fbird_stmt *S = ecalloc(1, sizeof(pdo_fbird_stmt));
+	S->H = H;
+	stmt->driver_data = S;
+	stmt->methods = &pdo_fbird_stmt_methods;
+	stmt->supports_placeholders = PDO_PLACEHOLDER_POSITIONAL;
+
+	if (!H->fbt_trans) {
+		H->fbt_trans = _pdo_fbt_start(H);
+		if (!H->fbt_trans) {
+			pdo_fbird_error(dbh);
+			efree(S);
+			stmt->driver_data = NULL;
+			return 0;
+		}
+	}
+
+	void *att = fbc_get_attachment(H->fbc_conn);
+	void *tr  = fbt_get_handle(H->fbt_trans);
+
+	S->fbs_stmt = fbs_prepare(
+		IBG(master_instance), att, tr,
+		ZSTR_VAL(sql), (unsigned)ZSTR_LEN(sql),
+		H->dialect, S->status
+	);
+
+	if (!S->fbs_stmt) {
+		pdo_fbird_stmt_error(stmt);
+		efree(S);
+		stmt->driver_data = NULL;
+		return 0;
+	}
+
+	S->out_meta  = fbs_get_output_metadata(IBG(master_instance), S->fbs_stmt, S->status);
+	S->out_count = S->out_meta ? fbm_get_count(IBG(master_instance), S->out_meta) : 0;
+	if (S->out_meta && S->out_count > 0) {
+		unsigned msg_len = fbm_get_message_length(IBG(master_instance), S->out_meta);
+		S->out_buf = ecalloc(1, msg_len);
+	}
+
+	S->in_meta  = fbs_get_input_metadata(IBG(master_instance), S->fbs_stmt, S->status);
+	S->in_count = S->in_meta ? fbm_get_count(IBG(master_instance), S->in_meta) : 0;
+	if (S->in_meta && S->in_count > 0) {
+		unsigned msg_len = fbm_get_message_length(IBG(master_instance), S->in_meta);
+		S->in_buf = ecalloc(1, msg_len);
+	}
+
+	stmt->column_count = (int)S->out_count;
+	return 1;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_handle_doer */
+static zend_long pdo_fbird_handle_doer(pdo_dbh_t *dbh, const zend_string *sql)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+
+	if (!H->fbt_trans) {
+		H->fbt_trans = _pdo_fbt_start(H);
+		if (!H->fbt_trans) {
+			pdo_fbird_error(dbh);
+			return -1;
+		}
+	}
+
+	void *att = fbc_get_attachment(H->fbc_conn);
+	void *tr  = fbt_get_handle(H->fbt_trans);
+
+	ISC_STATUS_ARRAY st = {0};
+	void *fbs = fbs_prepare(IBG(master_instance), att, tr,
+		ZSTR_VAL(sql), (unsigned)ZSTR_LEN(sql), H->dialect, st);
+	if (!fbs) {
+		memcpy(H->status, st, sizeof(ISC_STATUS_ARRAY));
+		pdo_fbird_error(dbh);
+		return -1;
+	}
+
+	int rc = fbs_execute(IBG(master_instance), fbs, tr,
+		NULL, NULL, NULL, NULL, st);
+	if (!rc) {
+		memcpy(H->status, st, sizeof(ISC_STATUS_ARRAY));
+		fbs_free(fbs, st);
+		pdo_fbird_error(dbh);
+		return -1;
+	}
+
+	zend_long affected = (zend_long)fbs_get_affected_records(
+		IBG(master_instance), fbs, st);
+	fbs_free(fbs, st);
+
+	if (H->autocommit) {
+		fbt_commit(H->fbt_trans, H->status);
+		fbt_free(H->fbt_trans);
+		H->fbt_trans = NULL;
+	}
+
+	return affected >= 0 ? affected : 0;
+}
+/* }}} */
+
+/* {{{ Transaction methods */
+static bool pdo_fbird_handle_begin(pdo_dbh_t *dbh)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+
+	if (H->fbt_trans) {
+		fbt_commit(H->fbt_trans, H->status);
+		fbt_free(H->fbt_trans);
+		H->fbt_trans = NULL;
+	}
+
+	H->fbt_trans = _pdo_fbt_start(H);
+	if (!H->fbt_trans) {
+		pdo_fbird_error(dbh);
+		return false;
+	}
+	return true;
+}
+
+static bool pdo_fbird_handle_commit(pdo_dbh_t *dbh)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+	if (!H->fbt_trans) return true;
+
+	int rc = fbt_commit(H->fbt_trans, H->status);
+	fbt_free(H->fbt_trans);
+	H->fbt_trans = NULL;
+
+	if (rc != 0) { pdo_fbird_error(dbh); return false; }
+	return true;
+}
+
+static bool pdo_fbird_handle_rollback(pdo_dbh_t *dbh)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+	if (!H->fbt_trans) return true;
+
+	fbt_rollback(H->fbt_trans, H->status);
+	fbt_free(H->fbt_trans);
+	H->fbt_trans = NULL;
+	return true;
+}
+/* }}} */
+
+/* {{{ Attribute get/set */
+static bool pdo_fbird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+	switch (attr) {
+		case PDO_ATTR_AUTOCOMMIT:
+			H->autocommit = zval_is_true(val) ? 1 : 0;
+			return true;
+		case PDO_FBIRD_ATTR_DIALECT:
+			H->dialect = (int)zval_get_long(val);
+			return true;
+		case PDO_FBIRD_ATTR_CHARSET:
+			if (H->charset) efree(H->charset);
+			H->charset = estrdup(Z_STRVAL_P(val));
+			return true;
+		case PDO_FBIRD_ATTR_ROLE:
+			if (H->role) efree(H->role);
+			H->role = estrdup(Z_STRVAL_P(val));
+			return true;
+	}
+	return false;
+}
+
+static int pdo_fbird_handle_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+	switch (attr) {
+		case PDO_ATTR_SERVER_VERSION:
+		case PDO_ATTR_SERVER_INFO: {
+			unsigned v = fbc_get_server_version(H->fbc_conn);
+			char buf[32];
+			snprintf(buf, sizeof(buf), "%u.0", v / 10);
+			ZVAL_STRING(val, buf);
+			return 1;
+		}
+		case PDO_ATTR_CLIENT_VERSION:
+			ZVAL_STRING(val, "Firebird OO API");
+			return 1;
+		case PDO_ATTR_DRIVER_NAME:
+			ZVAL_STRING(val, "fbird");
+			return 1;
+		case PDO_ATTR_AUTOCOMMIT:
+			ZVAL_BOOL(val, H->autocommit);
+			return 1;
+		case PDO_FBIRD_ATTR_DIALECT:
+			ZVAL_LONG(val, H->dialect);
+			return 1;
+		case PDO_FBIRD_ATTR_CHARSET:
+			ZVAL_STRING(val, H->charset ? H->charset : "");
+			return 1;
+		case PDO_FBIRD_ATTR_ROLE:
+			ZVAL_STRING(val, H->role ? H->role : "");
+			return 1;
+		case PDO_ATTR_CONNECTION_STATUS:
+			ZVAL_BOOL(val, H->fbc_conn && fbc_is_connected(H->fbc_conn));
+			return 1;
+	}
+	return 0;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_check_liveness */
+static zend_result pdo_fbird_check_liveness(pdo_dbh_t *dbh)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+	return (H->fbc_conn && fbc_is_connected(H->fbc_conn)) ? SUCCESS : FAILURE;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_fetch_error_func */
+static void pdo_fbird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+	ISC_STATUS *status = stmt
+		? ((pdo_fbird_stmt *)stmt->driver_data)->status
+		: H->status;
+
+	long gds_code = 0;
+	if (status && status[0] == 1 && status[1] > 0) {
+		gds_code = status[1];
+	}
+
+	char msg[512] = {0};
+	if (status && status[0] == 1 && status[1] > 0) {
+		ISC_STATUS *p = status;
+		char buf[256];
+		while (fb_interpret(buf, sizeof(buf), (const ISC_STATUS **)&p)) {
+			if (strlen(msg) + strlen(buf) + 2 < sizeof(msg)) {
+				if (msg[0]) strncat(msg, " ", sizeof(msg) - strlen(msg) - 1);
+				strncat(msg, buf, sizeof(msg) - strlen(msg) - 1);
+			}
+		}
+	}
+
+	add_next_index_long(info, gds_code);
+	add_next_index_string(info, msg[0] ? msg : "Unknown Firebird error");
+}
+/* }}} */
+
+/* {{{ pdo_fbird_dbh_methods */
+const struct pdo_dbh_methods pdo_fbird_dbh_methods = {
+	pdo_fbird_handle_closer,
+	pdo_fbird_handle_preparer,
+	pdo_fbird_handle_doer,
+	NULL,                           /* quoter */
+	pdo_fbird_handle_begin,
+	pdo_fbird_handle_commit,
+	pdo_fbird_handle_rollback,
+	pdo_fbird_handle_set_attribute,
+	NULL,                           /* last_id */
+	pdo_fbird_fetch_error_func,
+	pdo_fbird_handle_get_attribute,
+	pdo_fbird_check_liveness,
+	NULL, NULL, NULL, NULL,
+};
+/* }}} */
+
+/* {{{ pdo_fbird_handle_factory */
+static int pdo_fbird_handle_factory(pdo_dbh_t *dbh, zval *driver_options)
+{
+	pdo_fbird_db_handle *H = ecalloc(1, sizeof(pdo_fbird_db_handle));
+	dbh->driver_data = H;
+	H->dialect    = 3;
+	H->autocommit = dbh->auto_commit ? 1 : 0;
+
+	char host[256]    = {0};
+	char dbname[1024] = {0};
+	char charset[64]  = {0};
+	char role[128]    = {0};
+	int  dialect      = 3;
+
+	const char *dsn  = dbh->data_source;
+	char *dsn_copy   = estrdup(dsn);
+	char *saveptr    = NULL;
+	char *tok        = strtok_r(dsn_copy, ";", &saveptr);
+
+	while (tok) {
+		char *eq = strchr(tok, '=');
+		if (eq) {
+			*eq = '\0';
+			const char *key = tok, *v = eq + 1;
+			if      (!strcasecmp(key, "host"))    snprintf(host,    sizeof(host),    "%s", v);
+			else if (!strcasecmp(key, "dbname"))  snprintf(dbname,  sizeof(dbname),  "%s", v);
+			else if (!strcasecmp(key, "charset")) snprintf(charset, sizeof(charset), "%s", v);
+			else if (!strcasecmp(key, "role"))    snprintf(role,    sizeof(role),    "%s", v);
+			else if (!strcasecmp(key, "dialect")) dialect = atoi(v);
+		}
+		tok = strtok_r(NULL, ";", &saveptr);
+	}
+	efree(dsn_copy);
+
+	H->dialect = dialect;
+	if (charset[0]) H->charset = estrdup(charset);
+	if (role[0])    H->role    = estrdup(role);
+
+	char connstr[1280] = {0};
+	if (host[0]) snprintf(connstr, sizeof(connstr), "%s:%s", host, dbname);
+	else         snprintf(connstr, sizeof(connstr), "%s", dbname);
+
+	H->fbc_conn = fbc_connect(
+		IBG(master_instance),
+		connstr,    strlen(connstr),
+		dbh->username  ? dbh->username  : "", dbh->username  ? strlen(dbh->username)  : 0,
+		dbh->password  ? dbh->password  : "", dbh->password  ? strlen(dbh->password)  : 0,
+		charset[0] ? charset : NULL,           charset[0] ? strlen(charset) : 0,
+		role[0]    ? role    : NULL,           role[0]    ? strlen(role)    : 0,
+		0,       /* num_buffers */
+		dialect,
+		-1,      /* force_write: not set */
+		H->status
+	);
+
+	if (!H->fbc_conn) {
+		pdo_fbird_error(dbh);
+		if (H->charset) efree(H->charset);
+		if (H->role)    efree(H->role);
+		efree(H);
+		dbh->driver_data = NULL;
+		return 0;
+	}
+
+	dbh->methods = &pdo_fbird_dbh_methods;
+	dbh->alloc_own_columns = 1;
+	return 1;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_driver */
+const pdo_driver_t pdo_fbird_driver = {
+	PDO_DRIVER_HEADER(fbird),
+	pdo_fbird_handle_factory
+};
+/* }}} */

--- a/pdo_fbird/pdo_fbird_error.c
+++ b/pdo_fbird/pdo_fbird_error.c
@@ -1,0 +1,72 @@
+/*
+ * pdo_fbird — error handling and SQLSTATE mapping
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "ext/pdo/php_pdo_driver.h"
+#include "php_pdo_fbird_int.h"
+#include <ibase.h>
+#include "../firebird_utils.h"
+
+/* Map common Firebird GDS error codes to SQLSTATE strings */
+static const struct {
+	long gds_code;
+	const char *sqlstate;
+} pdo_fbird_sqlstate_map[] = {
+	{ 335544321L, "08001" }, /* connect failed */
+	{ 335544323L, "42000" }, /* bad SQL */
+	{ 335544324L, "42S02" }, /* table unknown */
+	{ 335544325L, "42S22" }, /* column unknown */
+	{ 335544326L, "23000" }, /* integrity constraint */
+	{ 335544327L, "23000" }, /* validation error */
+	{ 335544336L, "42000" }, /* expression error */
+	{ 335544338L, "40001" }, /* deadlock */
+	{ 335544345L, "23000" }, /* unique key violation */
+	{ 335544347L, "22012" }, /* division by zero */
+	{ 335544349L, "42000" }, /* invalid token */
+	{ 335544364L, "08003" }, /* connection lost */
+	{ 335544375L, "40001" }, /* lock conflict */
+	{ 335544381L, "22001" }, /* string truncation */
+	{ 335544382L, "22003" }, /* numeric overflow */
+	{ 335544569L, "23000" }, /* foreign key violation */
+	{ 0,          NULL    }
+};
+
+static const char *pdo_fbird_gds_to_sqlstate(long gds_code)
+{
+	for (int i = 0; pdo_fbird_sqlstate_map[i].sqlstate; i++) {
+		if (pdo_fbird_sqlstate_map[i].gds_code == gds_code) {
+			return pdo_fbird_sqlstate_map[i].sqlstate;
+		}
+	}
+	return "HY000";
+}
+
+static void _pdo_fbird_set_error_code(pdo_error_type *pdo_err, ISC_STATUS *status)
+{
+	long gds_code = 0;
+	if (status && status[0] == 1 && status[1] > 0) {
+		gds_code = status[1];
+	}
+	const char *sqlstate = pdo_fbird_gds_to_sqlstate(gds_code);
+	strncpy(*pdo_err, sqlstate, sizeof(pdo_error_type) - 1);
+	(*pdo_err)[sizeof(pdo_error_type) - 1] = '\0';
+}
+
+int pdo_fbird_error(pdo_dbh_t *dbh)
+{
+	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
+	_pdo_fbird_set_error_code(&dbh->error_code, H->status);
+	return 0;
+}
+
+int pdo_fbird_stmt_error(pdo_stmt_t *stmt)
+{
+	pdo_fbird_stmt *S = (pdo_fbird_stmt *)stmt->driver_data;
+	_pdo_fbird_set_error_code(&stmt->error_code, S->status);
+	return 0;
+}

--- a/pdo_fbird/pdo_fbird_stmt.c
+++ b/pdo_fbird/pdo_fbird_stmt.c
@@ -1,0 +1,366 @@
+/*
+ * pdo_fbird — statement handler (T12, T13)
+ * prepare, execute, fetch, describe, param binding
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "ext/pdo/php_pdo.h"
+#include "ext/pdo/php_pdo_driver.h"
+#include "php_pdo_fbird.h"
+#include "php_pdo_fbird_int.h"
+#include <ibase.h>
+#include "../firebird_utils.h"
+#include "../php_firebird.h"
+#include "../php_fbird_includes.h"
+
+/* Helper: read a null indicator from message buffer */
+static int _pdo_fbird_is_null(pdo_fbird_stmt *S, unsigned idx)
+{
+	if (!S->out_meta) return 0;
+	unsigned null_off = fbm_get_null_offset(IBG(master_instance), S->out_meta, idx);
+	short null_flag = 0;
+	memcpy(&null_flag, S->out_buf + null_off, sizeof(short));
+	return (null_flag != 0);
+}
+
+/* {{{ pdo_fbird_stmt_dtor */
+static int pdo_fbird_stmt_dtor(pdo_stmt_t *stmt)
+{
+	pdo_fbird_stmt *S = (pdo_fbird_stmt *)stmt->driver_data;
+	if (!S) return 1;
+
+	if (S->out_buf)  { efree(S->out_buf);  S->out_buf  = NULL; }
+	if (S->in_buf)   { efree(S->in_buf);   S->in_buf   = NULL; }
+
+	/* Release metadata first (ref-counted, independent of statement lifetime) */
+	if (S->out_meta) { fbm_release(S->out_meta); S->out_meta = NULL; }
+	if (S->in_meta)  { fbm_release(S->in_meta);  S->in_meta  = NULL; }
+
+	if (S->fbs_stmt) {
+		/* Only close cursor if connection still alive and cursor open */
+		if (S->has_rows && S->H && S->H->fbc_conn &&
+		    fbc_is_connected(S->H->fbc_conn) &&
+		    fbs_is_cursor_open(S->fbs_stmt)) {
+			fbs_close_cursor(S->fbs_stmt, S->status);
+		}
+		fbs_free(S->fbs_stmt, S->status);
+		S->fbs_stmt = NULL;
+	}
+
+	efree(S);
+	stmt->driver_data = NULL;
+	return 1;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_stmt_execute */
+static int pdo_fbird_stmt_execute(pdo_stmt_t *stmt)
+{
+	pdo_fbird_stmt    *S = (pdo_fbird_stmt *)stmt->driver_data;
+	pdo_fbird_db_handle *H = S->H;
+
+	/* Close any previously open cursor */
+	if (fbs_is_cursor_open(S->fbs_stmt)) {
+		fbs_close_cursor(S->fbs_stmt, S->status);
+	}
+	S->has_rows = 0;
+
+	void *tr = fbt_get_handle(H->fbt_trans);
+	unsigned stmt_type = fbs_get_type(IBG(master_instance), S->fbs_stmt, S->status);
+
+	/* SELECT / stored proc with output → open cursor */
+	if (stmt_type == isc_info_sql_stmt_select ||
+	    stmt_type == isc_info_sql_stmt_select_for_upd ||
+	    stmt_type == isc_info_sql_stmt_exec_procedure) {
+
+		int rc = fbs_open_cursor(
+			IBG(master_instance), S->fbs_stmt, tr,
+			S->in_buf, S->in_meta,
+			0, S->status
+		);
+		if (!rc) {
+			pdo_fbird_stmt_error(stmt);
+			return 0;
+		}
+		S->has_rows = 1;
+		stmt->row_count = -1; /* unknown for SELECT */
+	} else {
+		/* DML / DDL */
+		int rc = fbs_execute(
+			IBG(master_instance), S->fbs_stmt, tr,
+			S->in_buf, S->in_meta,
+			S->out_buf, S->out_meta,
+			S->status
+		);
+		if (!rc) {
+			pdo_fbird_stmt_error(stmt);
+			return 0;
+		}
+		ISC_UINT64 aff = fbs_get_affected_records(
+			IBG(master_instance), S->fbs_stmt, S->status);
+		stmt->row_count = (zend_long)aff;
+
+		/* Only autocommit for DML/DDL — never for SELECT (cursor still open) */
+		if (H->autocommit && H->fbt_trans) {
+			fbt_commit_retaining(H->fbt_trans, H->status);
+		}
+	}
+	return 1;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_stmt_fetch */
+static int pdo_fbird_stmt_fetch(pdo_stmt_t *stmt,
+	enum pdo_fetch_orientation ori, zend_long offset)
+{
+	pdo_fbird_stmt *S = (pdo_fbird_stmt *)stmt->driver_data;
+
+	if (!S->has_rows || !S->fbs_stmt) return 0;
+
+	int rc = fbs_fetch(IBG(master_instance), S->fbs_stmt,
+		S->out_buf, S->status);
+
+	if (rc == 1) return 1;   /* row fetched */
+	if (rc == 0) {           /* end of data */
+		S->has_rows = 0;
+		fbs_close_cursor(S->fbs_stmt, S->status);
+		return 0;
+	}
+	/* error */
+	pdo_fbird_stmt_error(stmt);
+	S->has_rows = 0;
+	return 0;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_stmt_describe */
+static int pdo_fbird_stmt_describe(pdo_stmt_t *stmt, int colno)
+{
+	pdo_fbird_stmt *S = (pdo_fbird_stmt *)stmt->driver_data;
+	if (!S->out_meta || (unsigned)colno >= S->out_count) return 0;
+
+	struct pdo_column_data *col = &stmt->columns[colno];
+
+	const char *alias = fbm_get_alias(IBG(master_instance), S->out_meta, (unsigned)colno);
+	const char *field = fbm_get_field(IBG(master_instance), S->out_meta, (unsigned)colno);
+	const char *name  = (alias && alias[0]) ? alias : (field ? field : "");
+
+	col->name        = zend_string_init(name, strlen(name), 0);
+	col->maxlen      = fbm_get_length(IBG(master_instance), S->out_meta, (unsigned)colno);
+	col->precision   = (zend_long)fbm_get_scale(IBG(master_instance), S->out_meta, (unsigned)colno);
+
+	(void)fbm_get_type(IBG(master_instance), S->out_meta, (unsigned)colno); /* type info available if needed */
+	return 1;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_stmt_get_col */
+static int pdo_fbird_stmt_get_col(pdo_stmt_t *stmt, int colno,
+	zval *result, enum pdo_param_type *type)
+{
+	pdo_fbird_stmt *S = (pdo_fbird_stmt *)stmt->driver_data;
+	if (!S->out_meta || !S->out_buf || (unsigned)colno >= S->out_count) {
+		ZVAL_NULL(result);
+		return 1;
+	}
+
+	if (_pdo_fbird_is_null(S, (unsigned)colno)) {
+		ZVAL_NULL(result);
+		return 1;
+	}
+
+	unsigned sql_type = fbm_get_type(IBG(master_instance), S->out_meta, (unsigned)colno);
+	unsigned offset   = fbm_get_offset(IBG(master_instance), S->out_meta, (unsigned)colno);
+	unsigned length   = fbm_get_length(IBG(master_instance), S->out_meta, (unsigned)colno);
+	int      scale    = fbm_get_scale(IBG(master_instance), S->out_meta, (unsigned)colno);
+	unsigned char *data = S->out_buf + offset;
+
+	switch (sql_type & ~1) {
+		case SQL_SHORT: {
+			short v; memcpy(&v, data, sizeof(short));
+			if (scale < 0) {
+				char buf[32]; snprintf(buf, sizeof(buf), "%.*f", -scale, v * pow(10.0, scale));
+				ZVAL_STRING(result, buf);
+			} else ZVAL_LONG(result, v);
+			break;
+		}
+		case SQL_LONG: {
+			ISC_LONG v; memcpy(&v, data, sizeof(ISC_LONG));
+			if (scale < 0) {
+				char buf[32]; snprintf(buf, sizeof(buf), "%.*f", -scale, v * pow(10.0, scale));
+				ZVAL_STRING(result, buf);
+			} else ZVAL_LONG(result, v);
+			break;
+		}
+		case SQL_INT64: {
+			ISC_INT64 v; memcpy(&v, data, sizeof(ISC_INT64));
+			if (scale < 0) {
+				char buf[48]; snprintf(buf, sizeof(buf), "%.*f", -scale, v * pow(10.0, scale));
+				ZVAL_STRING(result, buf);
+			} else ZVAL_LONG(result, (zend_long)v);
+			break;
+		}
+		case SQL_FLOAT: {
+			float v; memcpy(&v, data, sizeof(float));
+			ZVAL_DOUBLE(result, (double)v);
+			break;
+		}
+		case SQL_DOUBLE:
+		case SQL_D_FLOAT: {
+			double v; memcpy(&v, data, sizeof(double));
+			ZVAL_DOUBLE(result, v);
+			break;
+		}
+		case SQL_BOOLEAN: {
+			unsigned char v = *data;
+			ZVAL_BOOL(result, v != 0);
+			break;
+		}
+		case SQL_VARYING: {
+			/* VARY: first 2 bytes = length, then data */
+			unsigned short vlen; memcpy(&vlen, data, sizeof(unsigned short));
+			ZVAL_STRINGL(result, (char *)(data + sizeof(unsigned short)), vlen);
+			break;
+		}
+		case SQL_TEXT: {
+			/* Fixed CHAR: trim trailing spaces */
+			char *s = (char *)data;
+			size_t len = length;
+			while (len > 0 && s[len - 1] == ' ') len--;
+			ZVAL_STRINGL(result, s, len);
+			break;
+		}
+		case SQL_TIMESTAMP:
+		case SQL_TYPE_DATE:
+		case SQL_TYPE_TIME:
+		case SQL_TIMESTAMP_TZ:
+		case SQL_TIME_TZ: {
+			/* Return as string via fb_interpret-style formatting — use raw hex for now */
+			char buf[64];
+			snprintf(buf, sizeof(buf), "(datetime:%u)", sql_type);
+			ZVAL_STRING(result, buf);
+			break;
+		}
+		case SQL_BLOB: {
+			/* Return blob ID as string for now; full LOB streaming in T16 */
+			ISC_QUAD bid; memcpy(&bid, data, sizeof(ISC_QUAD));
+			char buf[48];
+			snprintf(buf, sizeof(buf), "%08x:%08x", bid.gds_quad_high, bid.gds_quad_low);
+			ZVAL_STRING(result, buf);
+			break;
+		}
+		default:
+			ZVAL_STRINGL(result, (char *)data, length);
+			break;
+	}
+	return 1;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_stmt_param_hook — bind positional ? parameters */
+static int pdo_fbird_stmt_param_hook(pdo_stmt_t *stmt,
+	struct pdo_bound_param_data *param, enum pdo_param_event event_type)
+{
+	pdo_fbird_stmt *S = (pdo_fbird_stmt *)stmt->driver_data;
+
+	if (event_type != PDO_PARAM_EVT_EXEC_PRE) return 1;
+	if (!S->in_meta || !S->in_buf) return 1;
+	if (param->paramno < 0 || (unsigned)param->paramno >= S->in_count) return 1;
+
+	unsigned idx    = (unsigned)param->paramno;
+	unsigned offset = fbm_get_offset(IBG(master_instance), S->in_meta, idx);
+	unsigned length = fbm_get_length(IBG(master_instance), S->in_meta, idx);
+	unsigned null_off = fbm_get_null_offset(IBG(master_instance), S->in_meta, idx);
+	unsigned sql_type = fbm_get_type(IBG(master_instance), S->in_meta, idx);
+	int      scale    = fbm_get_scale(IBG(master_instance), S->in_meta, idx);
+	unsigned char *dest = S->in_buf + offset;
+	short *null_flag    = (short *)(S->in_buf + null_off);
+
+	zval *val = &param->parameter;
+	if (!val || Z_TYPE_P(val) == IS_NULL) {
+		*null_flag = -1;
+		memset(dest, 0, length);
+		return 1;
+	}
+	*null_flag = 0;
+
+	switch (sql_type & ~1) {
+		case SQL_SHORT: {
+			short v = (short)zval_get_long(val);
+			memcpy(dest, &v, sizeof(short));
+			break;
+		}
+		case SQL_LONG: {
+			ISC_LONG v = (ISC_LONG)zval_get_long(val);
+			memcpy(dest, &v, sizeof(ISC_LONG));
+			break;
+		}
+		case SQL_INT64: {
+			ISC_INT64 v = (ISC_INT64)zval_get_long(val);
+			memcpy(dest, &v, sizeof(ISC_INT64));
+			break;
+		}
+		case SQL_FLOAT: {
+			float v = (float)zval_get_double(val);
+			memcpy(dest, &v, sizeof(float));
+			break;
+		}
+		case SQL_DOUBLE:
+		case SQL_D_FLOAT: {
+			double v = zval_get_double(val);
+			memcpy(dest, &v, sizeof(double));
+			break;
+		}
+		case SQL_BOOLEAN: {
+			unsigned char v = zval_is_true(val) ? 1 : 0;
+			*dest = v;
+			break;
+		}
+		case SQL_VARYING: {
+			zend_string *s = zval_get_string(val);
+			unsigned short slen = (unsigned short)MIN(ZSTR_LEN(s), length);
+			memcpy(dest, &slen, sizeof(unsigned short));
+			memcpy(dest + sizeof(unsigned short), ZSTR_VAL(s), slen);
+			zend_string_release(s);
+			break;
+		}
+		case SQL_TEXT: {
+			zend_string *s = zval_get_string(val);
+			size_t slen = MIN(ZSTR_LEN(s), length);
+			memcpy(dest, ZSTR_VAL(s), slen);
+			if (slen < length) memset(dest + slen, ' ', length - slen);
+			zend_string_release(s);
+			break;
+		}
+		default: {
+			zend_string *s = zval_get_string(val);
+			size_t slen = MIN(ZSTR_LEN(s), length);
+			memcpy(dest, ZSTR_VAL(s), slen);
+			zend_string_release(s);
+			break;
+		}
+	}
+	(void)scale;
+	return 1;
+}
+/* }}} */
+
+/* {{{ pdo_fbird_stmt_methods */
+const struct pdo_stmt_methods pdo_fbird_stmt_methods = {
+	pdo_fbird_stmt_dtor,
+	pdo_fbird_stmt_execute,
+	pdo_fbird_stmt_fetch,
+	pdo_fbird_stmt_describe,
+	pdo_fbird_stmt_get_col,
+	pdo_fbird_stmt_param_hook,
+	NULL, /* set_attribute */
+	NULL, /* get_attribute */
+	NULL, /* get_column_meta */
+	NULL, /* next_rowset */
+	NULL, /* cursor_closer */
+};
+/* }}} */

--- a/pdo_fbird/php_pdo_fbird.h
+++ b/pdo_fbird/php_pdo_fbird.h
@@ -1,0 +1,25 @@
+/*
+ * pdo_fbird — PDO driver for Firebird databases
+ * Uses fbird: DSN prefix to avoid collision with bundled pdo_firebird.
+ *
+ * php_pdo_fbird.h — module entry and version defines
+ */
+
+#ifndef PHP_PDO_FBIRD_H
+#define PHP_PDO_FBIRD_H
+
+#include "php.h"
+
+#define PHP_PDO_FBIRD_VERSION "1.0.0"
+#define PHP_PDO_FBIRD_EXTNAME "pdo_fbird"
+
+extern zend_module_entry pdo_fbird_module_entry;
+#define phpext_pdo_fbird_ptr &pdo_fbird_module_entry
+
+/* Custom PDO attributes */
+#define PDO_FBIRD_ATTR_DIALECT      1001
+#define PDO_FBIRD_ATTR_CHARSET      1002
+#define PDO_FBIRD_ATTR_ROLE         1003
+#define PDO_FBIRD_ATTR_PAGE_BUFFERS 1004
+
+#endif /* PHP_PDO_FBIRD_H */

--- a/pdo_fbird/php_pdo_fbird_int.h
+++ b/pdo_fbird/php_pdo_fbird_int.h
@@ -1,0 +1,46 @@
+/*
+ * pdo_fbird — internal structs and declarations
+ */
+
+#ifndef PHP_PDO_FBIRD_INT_H
+#define PHP_PDO_FBIRD_INT_H
+
+#include "php.h"
+#include "ext/pdo/php_pdo_driver.h"
+#include <ibase.h>
+#include "../firebird_utils.h"
+
+/* Per-connection driver data stored in pdo_dbh_t->driver_data */
+typedef struct {
+	void        *fbc_conn;      /* fb::Connection* via fbc_connect() */
+	void        *fbt_trans;     /* fb::Transaction* via fbt_start()  */
+	int          dialect;       /* SQL dialect (1 or 3)              */
+	char        *charset;       /* connection charset                */
+	char        *role;          /* SQL role                          */
+	int          autocommit;    /* 1 = autocommit mode               */
+	ISC_STATUS_ARRAY status;    /* status vector for error reporting */
+} pdo_fbird_db_handle;
+
+/* Per-statement driver data stored in pdo_stmt_t->driver_data */
+typedef struct {
+	pdo_fbird_db_handle *H;         /* back-pointer to connection    */
+	void                *fbs_stmt;  /* fb::Statement* via fbs_*()    */
+	void                *out_meta;  /* IMessageMetadata* for output  */
+	void                *in_meta;   /* IMessageMetadata* for input   */
+	unsigned char       *out_buf;   /* output message buffer         */
+	unsigned char       *in_buf;    /* input message buffer          */
+	unsigned int         out_count; /* number of output columns      */
+	unsigned int         in_count;  /* number of input parameters    */
+	int                  has_rows;  /* cursor open and has data      */
+	ISC_STATUS_ARRAY     status;    /* status vector                 */
+} pdo_fbird_stmt;
+
+/* Forward declarations */
+extern const pdo_driver_t pdo_fbird_driver;
+extern const struct pdo_dbh_methods pdo_fbird_dbh_methods;
+extern const struct pdo_stmt_methods pdo_fbird_stmt_methods;
+
+int pdo_fbird_error(pdo_dbh_t *dbh);
+int pdo_fbird_stmt_error(pdo_stmt_t *stmt);
+
+#endif /* PHP_PDO_FBIRD_INT_H */

--- a/pdo_fbird/tests/pdo_fbird_001.phpt
+++ b/pdo_fbird/tests/pdo_fbird_001.phpt
@@ -1,0 +1,40 @@
+--TEST--
+pdo_fbird: basic connection via fbird: DSN prefix
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip PDO not available');
+if (!extension_loaded('pdo_fbird')) die('skip pdo_fbird not loaded');
+if (!extension_loaded('firebird')) die('skip firebird not loaded');
+require_once __DIR__ . '/../../tests/firebird.inc';
+if (!@fbird_connect($test_base, $user, $password)) die('skip cannot connect to Firebird');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../../tests/firebird.inc';
+
+// $test_base is "host:dbpath" or just "dbpath"
+if (strpos($test_base, ':') !== false) {
+    [$dsn_host, $dsn_db] = explode(':', $test_base, 2);
+} else {
+    $dsn_host = 'localhost';
+    $dsn_db   = $test_base;
+}
+
+try {
+    $dsn = "fbird:host={$dsn_host};dbname={$dsn_db};charset=UTF8";
+    $pdo = new PDO($dsn, $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    echo "Connected\n";
+    $ver = $pdo->getAttribute(PDO::ATTR_SERVER_VERSION);
+    echo "Server version: " . (strlen($ver) > 0 ? "ok" : "empty") . "\n";
+    echo "Driver name: " . $pdo->getAttribute(PDO::ATTR_DRIVER_NAME) . "\n";
+    $pdo = null;
+    echo "Disconnected\n";
+} catch (PDOException $e) {
+    echo "FAIL: " . $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+Connected
+Server version: ok
+Driver name: fbird
+Disconnected

--- a/pdo_fbird/tests/pdo_fbird_002.phpt
+++ b/pdo_fbird/tests/pdo_fbird_002.phpt
@@ -1,0 +1,38 @@
+--TEST--
+pdo_fbird: basic query and fetch
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip PDO not available');
+if (!extension_loaded('pdo_fbird')) die('skip pdo_fbird not loaded');
+if (!extension_loaded('firebird')) die('skip firebird not loaded');
+require_once __DIR__ . '/../../tests/firebird.inc';
+if (!@fbird_connect($test_base, $user, $password)) die('skip cannot connect to Firebird');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../../tests/firebird.inc';
+
+if (strpos($test_base, ':') !== false) {
+    [$dsn_host, $dsn_db] = explode(':', $test_base, 2);
+} else { $dsn_host = 'localhost'; $dsn_db = $test_base; }
+
+$pdo = new PDO("fbird:host={$dsn_host};dbname={$dsn_db}", $user, $password,
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+$stmt = $pdo->query("SELECT 1 AS VAL FROM RDB\$DATABASE");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "VAL=" . $row['VAL'] . "\n";
+$stmt = null;
+
+$stmt2 = $pdo->query("SELECT 'hello' AS GREETING FROM RDB\$DATABASE");
+$row2 = $stmt2->fetch(PDO::FETCH_ASSOC);
+echo "GREETING=" . trim($row2['GREETING']) . "\n";
+$stmt2 = null;
+
+$pdo = null;
+echo "ok\n";
+?>
+--EXPECT--
+VAL=1
+GREETING=hello
+ok

--- a/pdo_fbird/tests/pdo_fbird_003.phpt
+++ b/pdo_fbird/tests/pdo_fbird_003.phpt
@@ -1,0 +1,55 @@
+--TEST--
+pdo_fbird: transaction commit and rollback
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip PDO not available');
+if (!extension_loaded('pdo_fbird')) die('skip pdo_fbird not loaded');
+if (!extension_loaded('firebird')) die('skip firebird not loaded');
+require_once __DIR__ . '/../../tests/firebird.inc';
+if (!@fbird_connect($test_base, $user, $password)) die('skip cannot connect to Firebird');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../../tests/firebird.inc';
+
+if (strpos($test_base, ':') !== false) {
+    [$dsn_host, $dsn_db] = explode(':', $test_base, 2);
+} else { $dsn_host = 'localhost'; $dsn_db = $test_base; }
+
+$pdo = new PDO("fbird:host={$dsn_host};dbname={$dsn_db}", $user, $password,
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_AUTOCOMMIT => 0]);
+
+// Create table (DDL needs explicit transaction in Firebird)
+$pdo->beginTransaction();
+$pdo->exec("CREATE TABLE PDO_TX_TEST (ID INTEGER)");
+$pdo->commit();
+
+// Insert and commit
+$pdo->beginTransaction();
+$pdo->exec("INSERT INTO PDO_TX_TEST (ID) VALUES (1)");
+$pdo->commit();
+
+// Insert and rollback
+$pdo->beginTransaction();
+$pdo->exec("INSERT INTO PDO_TX_TEST (ID) VALUES (2)");
+$pdo->rollBack();
+
+// Check only 1 row exists
+$pdo->beginTransaction();
+$stmt = $pdo->query("SELECT COUNT(*) AS CNT FROM PDO_TX_TEST");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+$stmt = null;
+echo "COUNT=" . $row['CNT'] . "\n";
+$pdo->commit();
+
+// Cleanup
+$pdo->beginTransaction();
+$pdo->exec("DROP TABLE PDO_TX_TEST");
+$pdo->commit();
+
+$pdo = null;
+echo "ok\n";
+?>
+--EXPECT--
+COUNT=1
+ok


### PR DESCRIPTION
## Summary

Implements Phase C Part 2 from the next-gen architecture plan: a separate `pdo_fbird.so` shared extension providing a PDO driver with the `fbird:` DSN prefix.

## Why a separate DSN prefix?
- Avoids collision with PHP's bundled `pdo_firebird` driver (`firebird:` DSN)
- Allows both drivers to coexist in the same PHP installation
- Enables Firebird-specific features not available in the bundled driver

## Architecture
```
pdo_fbird/
  config.m4              — autoconf build (separate phpize/configure)
  pdo_fbird.c            — MINIT/MSHUTDOWN, driver registration, PDO::FBIRD_ATTR_* constants
  pdo_fbird_driver.c     — DSN parsing, handle factory/closer, transactions, attributes
  pdo_fbird_stmt.c       — prepare/execute/fetch/describe/param binding
  pdo_fbird_error.c      — GDS→SQLSTATE mapping
  php_pdo_fbird.h        — module entry, version, attribute constants
  php_pdo_fbird_int.h    — internal structs (pdo_fbird_db_handle, pdo_fbird_stmt)
  tests/                 — 3 .phpt tests
```

## Features
- DSN: `fbird:host=HOST;dbname=PATH;charset=UTF8;role=ROLE;dialect=3`
- Connection via `fbc_connect()` OO API (no legacy `isc_attach_database`)
- Transactions: `beginTransaction`/`commit`/`rollback` via `fbt_*` bridges
- Statements: prepare/execute/fetch via `fbs_*` + `IMessageMetadata`
- Parameter binding: positional `?` for all SQL types
- Column fetch: INTEGER/FLOAT/DOUBLE/CHAR/VARCHAR/BOOLEAN/BLOB/NUMERIC
- Custom attributes: `PDO::FBIRD_ATTR_DIALECT`, `CHARSET`, `ROLE`, `PAGE_BUFFERS`
- Standard attributes: `ATTR_SERVER_VERSION`, `ATTR_DRIVER_NAME`, `ATTR_CONNECTION_STATUS`

## Tests
- `pdo_fbird_001.phpt`: basic connection, server version, driver name
- `pdo_fbird_002.phpt`: query and fetch (INTEGER, VARCHAR)
- `pdo_fbird_003.phpt`: transaction commit and rollback

## Validation
- 159/159 main extension tests pass (php82-fb3-dev)
- ASan 3/3 PASS (php83-asan)
- All 3 PDO tests pass GREEN