### PR TITLE
docs: mark v10.0.0 specs RELEASED and update roadmap

### DIFF
--- a/docs/ROADMAP-2026-03-23.md
+++ b/docs/ROADMAP-2026-03-23.md
@@ -459,3 +459,27 @@
 - [x] P1 §3.3 Date/Time/Timestamp format: fields + set/get attr + test done; get_col formatting pending
 - [x] Registered all custom PDO constants in MINIT (TXN_ISOLATION_LEVEL, WRITABLE_TRANSACTION, DATE/TIME/TIMESTAMP_FORMAT, FETCH_TABLE_NAMES)
 - [x] Full test matrix: 222 tests, 215 passed, 7 skipped, 0 failed (100% pass rate)
+
+### Milestone v10.0.0 — Typed API + Modernization ✅ RELEASED 2026-03-27
+
+**Status:** RELEASED — all CI checks green · [GitHub Release](https://github.com/satwareAG/php-firebird/releases/tag/v10.0.0) · PR #133 merged to satware-main
+
+| Feature | Status |
+|---------|--------|
+| spec-132: Legacy wrappers build fix | ✅ SHIPPED |
+| spec-120: Typed connection objects (Firebird\Connection etc.) | ✅ SHIPPED |
+| spec-legacy-removal: void* / ibase_* / dead-code removal | ✅ SHIPPED |
+| spec-void-star: firebird_utils_typed.h type-safe wrappers | ✅ SHIPPED |
+| spec-features: DECFLOAT/INT128 native support + PDO batch DML | ✅ SHIPPED |
+
+**Test Results:**
+- CI matrix: PHP 8.2/8.3/8.4/8.5 × Firebird 3.0/4.0/5.0 — ALL GREEN (12/12)
+- ASan + UBSan + LeakSan: PASS
+- Windows (8 NTS/TS builds): PASS
+- Code coverage: 54.7% (gate: 54%)
+- Stubs sync: 89/89 functions (PHP_FE = stubs/ = phpstan/)
+
+**Deferred to v11.0.0:**
+- `ISC_TEB` removal / multi-db transaction modernization
+- `fbird_events.c` OO API migration
+- `isc_array_*` modernization (no Firebird OO API replacement)

--- a/docs/plans/spec-implementation-plan.md
+++ b/docs/plans/spec-implementation-plan.md
@@ -174,3 +174,28 @@ All v10.0.0 development branches consolidated into single `dev/v10` branch.
 - Full report: `docs/plans/v10-test-report.txt`
 
 **Status:** `dev/v10` branch created locally. Not pushed. Build failures are expected - these are pre-existing issues from the modernization work that need to be resolved in subsequent development.
+
+## Release Outcome (2026-03-27) - ✅ COMPLETE
+
+All phases shipped to `satware-main` via PR #133. Tag `v10.0.0` pushed.
+
+> **Note**: The "Branch Consolidation" section above describes an intermediate working state
+> (2026-03-27 morning) when build failures existed. All issues were resolved before release.
+
+| Phase | Status | Shipped |
+|-------|--------|---------|
+| 0: Build Fix (#132) | ✅ RELEASED | `firebird_legacy_wrappers.h/.c`, `config.m4` |
+| 1A: Legacy Cleanup | ✅ RELEASED | `src/php_fbird_compat.h`, dead code removed |
+| 1B: Typed Objects (#120) | ✅ RELEASED | `Firebird\Connection`, `fbird_connect_typed_001.phpt` |
+| 2A: void* Elimination | ✅ RELEASED | `firebird_utils_typed.h` (12 typed structs) |
+| 2B: DECFLOAT/INT128 | ✅ RELEASED | `fbird_query_bind.c`, `fbird_metadata.c` |
+| 2C: PDO Batch | ✅ RELEASED | `pdo_fbird_driver.c`, `pdo_fbird_batch_dml.phpt` |
+| 3: Release | ✅ RELEASED | VERSION=10.0.0, CHANGELOG, README badge, stubs synced |
+
+**Final CI gate (all green):**
+- PHP 8.2/8.3/8.4/8.5 × Firebird 3.0/4.0/5.0: 12/12 ✅
+- ASan + UBSan + LeakSan: ✅
+- Windows NTS/TS × PHP 8.2/8.3/8.4/8.5: 8/8 ✅
+- PHPStan Level 8: ✅
+- Stubs sync (89/89): ✅
+- Code coverage: 54.7% ≥ 54% gate ✅

--- a/specs/spec-120-typed-connection.md
+++ b/specs/spec-120-typed-connection.md
@@ -6,7 +6,7 @@ tags: [v10, breaking-change, issue-120, typed-objects]
 priority: 2
 ---
 
-> **Status: RESOLVED in v10.0.0** (2026-03-27)
+> **Status: RELEASED in v10.0.0** (2026-03-27)
 > Firebird\Connection OOP class provides typed connection objects.
 > fbird_connect() and fbird_pconnect() return Firebird\Connection objects.
 > All three API layers (procedural, OOP, PDO) are fully functional.

--- a/specs/spec-v10-features.md
+++ b/specs/spec-v10-features.md
@@ -6,7 +6,7 @@ tags: [v10, features, pdo, decfloat, int128]
 priority: 5
 ---
 
-> **Status: RESOLVED in v10.0.0** (2026-03-27)
+> **Status: RELEASED in v10.0.0** (2026-03-27)
 > - Part 1 (DECFLOAT/INT128): Verified complete — procedural and PDO APIs handle all types
 > - Part 2 (PDO Batch DML): Implemented in `pdo_fbird_driver.c` with state-machine SQL splitter
 > - Part 3 (Modern Defaults): Already complete in v9

--- a/specs/spec-v10-legacy-removal.md
+++ b/specs/spec-v10-legacy-removal.md
@@ -6,7 +6,7 @@ tags: [v10, cleanup, legacy-removal, deprecation]
 priority: 4
 ---
 
-> **Status: RESOLVED in v10.0.0** (2026-03-27)
+> **Status: RELEASED in v10.0.0** (2026-03-27)
 > - FBIRD_API_MODE_LEGACY dead code removed from src/php_fbird_compat.h
 > - get_statement_interface dead global removed from php_fbird_includes.h / firebird.c
 > - firebird_legacy_wrappers.c excluded from build (linker fix)

--- a/specs/spec-v10-void-star-elimination.md
+++ b/specs/spec-v10-void-star-elimination.md
@@ -6,7 +6,7 @@ tags: [v10, type-safety, refactoring, firebird-utils]
 priority: 3
 ---
 
-> **Status: RESOLVED in v10.0.0** (2026-03-27)
+> **Status: RELEASED in v10.0.0** (2026-03-27)
 > firebird_utils_typed.h created with 12 typed opaque struct wrappers.
 > Call sites can migrate incrementally using the zero-overhead inline wrappers.
 


### PR DESCRIPTION
Post-release documentation update:
- All v10.0.0 spec files: RESOLVED → RELEASED
- ROADMAP-2026-03-23.md: v10.0.0 milestone section added with final test results
- spec-implementation-plan.md: Release Outcome section corrects outdated BUILD FAILURE note

No code changes. Pure documentation.