### PR TITLE
fix(test): include firebird.inc in batch no-params test (#180)

### DIFF
--- a/tests/fbird_batch_no_params_001.phpt
+++ b/tests/fbird_batch_no_params_001.phpt
@@ -7,7 +7,7 @@ if (!function_exists('fbird_batch_create')) die("skip IBatch API not available (
 ?>
 --FILE--
 <?php
-require_once('config.inc');
+require_once('firebird.inc');
 require_once('common.inc');
 
 $conn = fbird_connect($test_base, $user, $password, $charset);


### PR DESCRIPTION
Fixes CI failure across all 9 matrix jobs.

The test included `config.inc` instead of `firebird.inc`, leaving `$test_base` and `$charset` undefined. This caused `fbird_connect()` to receive null for the database path.

**Affected workflows**: CI, Linux Code Coverage (both red on `1fdefac`).