### PR TITLE
fix(test): remove undefined $charset variable from batch no-params test

### DIFF
--- a/tests/fbird_batch_no_params_001.phpt
+++ b/tests/fbird_batch_no_params_001.phpt
@@ -10,7 +10,7 @@ if (!function_exists('fbird_batch_create')) die("skip IBatch API not available (
 require_once('firebird.inc');
 require_once('common.inc');
 
-$conn = fbird_connect($test_base, $user, $password, $charset);
+$conn = fbird_connect($test_base, $user, $password);
 $tx = fbird_trans($conn);
 
 // Test 1: SELECT with no parameters must return false (not SIGFPE)


### PR DESCRIPTION
Removes undefined $charset variable from `fbird_batch_no_params_001.phpt` that caused all 8 Firebird 4.0/5.0 CI matrix jobs to fail.

The test used `$charset` which is not exported by `firebird.inc`, causing undefined variable warnings that pollute PHPT expected output on PHP 8.2+.

**Fix**: Remove the `$charset` argument from the `fbird_connect()` call (default charset is sufficient for this test).