### PR TITLE
chore(deps): add Dependabot for GitHub Actions auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` to enable weekly automated dependency updates for the `github-actions` ecosystem.

### Configuration
- **Schedule**: Weekly on Mondays (Europe/Berlin)
- **Grouping**: All action updates grouped into a single PR
- **Labels**: `dependencies`, `github-actions`
- **Commit prefix**: `chore(deps)`

### Context
All workflow actions are already SHA-pinned (SLSA requirement). Dependabot will propose PRs when new versions are available, keeping the pins current without manual monitoring.

Closes #162