### PR TITLE
[M4] Automate version stamp sync in stubs during release

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -189,6 +189,22 @@ jobs:
           done
 
   # ==========================================================================
+  # Version Stamp Check (stubs @version must match VERSION file)
+  # ==========================================================================
+  version-stamps:
+    name: Version Stamps Check
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Check stubs @version tags match VERSION file
+        run: |
+          chmod +x scripts/check-version-stamps.sh
+          bash scripts/check-version-stamps.sh
+
+  # ==========================================================================
   # Secret Detection (Gitleaks CLI - no license required)
   # ==========================================================================
   secrets-scan:
@@ -230,7 +246,7 @@ jobs:
   quality-summary:
     name: Quality Gate
     runs-on: ubuntu-24.04
-    needs: [php-analysis, stubs-sync, c-analysis, secrets-scan]
+    needs: [php-analysis, stubs-sync, c-analysis, version-stamps, secrets-scan]
     if: always()
 
     steps:
@@ -239,11 +255,13 @@ jobs:
           echo "PHP Analysis: ${{ needs.php-analysis.result }}"
           echo "Stubs Sync: ${{ needs.stubs-sync.result }}"
           echo "C/C++ Analysis: ${{ needs.c-analysis.result }}"
+          echo "Version Stamps: ${{ needs.version-stamps.result }}"
           echo "Secrets Scan: ${{ needs.secrets-scan.result }}"
 
           if [ "${{ needs.php-analysis.result }}" = "failure" ] || \
              [ "${{ needs.stubs-sync.result }}" = "failure" ] || \
              [ "${{ needs.c-analysis.result }}" = "failure" ] || \
+             [ "${{ needs.version-stamps.result }}" = "failure" ] || \
              [ "${{ needs.secrets-scan.result }}" = "failure" ]; then
             echo "❌ Quality gate failed"
             exit 1

--- a/scripts/check-version-stamps.sh
+++ b/scripts/check-version-stamps.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-version-stamps.sh - Validate @version tags in stubs match VERSION file
+# =============================================================================
+# Ensures stubs shipped via Composer (satwareag/php-firebird-stubs) carry the
+# correct version. Prevents stale @version tags from confusing consumers.
+#
+# Usage: bash scripts/check-version-stamps.sh
+# Exit:  0 = all match, 1 = mismatch found
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+VERSION_FILE="${ROOT_DIR}/VERSION"
+
+if [ ! -f "${VERSION_FILE}" ]; then
+  echo "ERROR: VERSION file not found at ${VERSION_FILE}" >&2
+  exit 1
+fi
+
+EXPECTED=$(tr -d '[:space:]' < "${VERSION_FILE}")
+
+if [ -z "${EXPECTED}" ]; then
+  echo "ERROR: VERSION file is empty" >&2
+  exit 1
+fi
+
+echo "Expected @version: ${EXPECTED}"
+echo ""
+
+STUBS_FILES=(
+  "stubs/firebird-stubs.php"
+  "stubs/firebird-classes.php"
+  "stubs/pdo-fbird-stubs.php"
+)
+
+ERRORS=0
+
+for file in "${STUBS_FILES[@]}"; do
+  FULL_PATH="${ROOT_DIR}/${file}"
+  if [ ! -f "${FULL_PATH}" ]; then
+    echo "WARN: ${file} not found, skipping"
+    continue
+  fi
+
+  # Extract @version value from PHPDoc header
+  ACTUAL=$(grep -m1 '@version' "${FULL_PATH}" | sed 's/.*@version[[:space:]]*//' | tr -d '[:space:]')
+
+  if [ "${ACTUAL}" = "${EXPECTED}" ]; then
+    echo "  OK: ${file} (@version ${ACTUAL})"
+  else
+    echo "  FAIL: ${file} (@version ${ACTUAL} != ${EXPECTED})"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+echo ""
+
+if [ "${ERRORS}" -gt 0 ]; then
+  echo "ERROR: ${ERRORS} stub(s) have mismatched @version tags."
+  echo "Fix: update @version in the listed files to match VERSION (${EXPECTED})."
+  exit 1
+fi
+
+echo "All stubs @version tags match VERSION file."

--- a/stubs/firebird-classes.php
+++ b/stubs/firebird-classes.php
@@ -7,7 +7,7 @@
  * C extension. These are used by static analysis tools and IDEs.
  *
  * @package   php-firebird-stubs
- * @version   8.0.0
+ * @version   10.3.9
  * @author    satware AG <info@satware.com>
  * @copyright 2025 satware AG
  * @license   PHP-3.01 https://www.php.net/license/3_01.txt

--- a/stubs/firebird-stubs.php
+++ b/stubs/firebird-stubs.php
@@ -10,7 +10,7 @@
  * This stub file does not contain any implementation.
  *
  * @package   php-firebird-stubs
- * @version   9.0.0
+ * @version   10.3.9
  * @author    satware AG <info@satware.com>
  * @copyright 2025-2026 satware AG
  * @license   PHP-3.01 https://www.php.net/license/3_01.txt

--- a/stubs/pdo-fbird-stubs.php
+++ b/stubs/pdo-fbird-stubs.php
@@ -15,7 +15,7 @@
  *                  'SYSDBA', 'masterkey');
  *
  * @package   php-firebird-stubs
- * @version   9.0.0
+ * @version   10.3.9
  * @author    satware AG <info@satware.com>
  * @copyright 2025-2026 satware AG
  * @license   PHP-3.01 https://www.php.net/license/3_01.txt


### PR DESCRIPTION
## Summary

Add automated validation that `@version` tags in stub files match the `VERSION` file, preventing stale version stamps from shipping to consumers via Composer.

## Changes

- **New**: `scripts/check-version-stamps.sh` - validates all 3 stub files' `@version` matches `VERSION`
- **Fix**: Updated stale `@version` tags (8.0.0/9.0.0 → 10.3.9) in:
  - `stubs/firebird-classes.php`
  - `stubs/firebird-stubs.php`
  - `stubs/pdo-fbird-stubs.php`
- **CI**: Added "Version Stamps Check" job to `code-quality.yml` quality gate

## Testing

```bash
bash scripts/check-version-stamps.sh
# Expected @version: 10.3.9
#   OK: stubs/firebird-stubs.php (@version 10.3.9)
#   OK: stubs/firebird-classes.php (@version 10.3.9)
#   OK: stubs/pdo-fbird-stubs.php (@version 10.3.9)
# All stubs @version tags match VERSION file.
```

Closes #163