### PR TITLE
build(release): add LTO for precompiled release builds

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -339,7 +339,9 @@ jobs:
           # Clean any previous builds
           phpize --clean 2>/dev/null || true
           
-          # Build
+          # Build with LTO for optimized release binaries
+          export CFLAGS="${CFLAGS:-} -flto=auto"
+          export LDFLAGS="${LDFLAGS:-} -flto=auto"
           phpize
           ./configure --with-firebird="${FB_ROOT}"
           make -j$(nproc)

--- a/scripts/build-precompiled.sh
+++ b/scripts/build-precompiled.sh
@@ -453,7 +453,9 @@ if [ "$SKIP_BUILD" = false ]; then
         log_info "Running phpize..."
         phpize
         
-        log_info "Configuring..."
+        log_info "Configuring with LTO..."
+        export CFLAGS="${CFLAGS:-} -flto=auto"
+        export LDFLAGS="${LDFLAGS:-} -flto=auto"
         ./configure --with-firebird="${FB_ROOT}"
         
         log_info "Compiling..."


### PR DESCRIPTION
## Summary

Enable Link-Time Optimization (`-flto=auto`) for precompiled release builds to produce optimized binaries.

## Changes

- **`scripts/build-precompiled.sh`**: Export `CFLAGS` and `LDFLAGS` with `-flto=auto` before configure
- **`.github/workflows/release-linux.yml`**: Add LTO flags in the Build Extension step

## Rationale

LTO enables cross-translation-unit optimizations (inlining, dead code elimination) producing smaller, faster release binaries. Applied only to release builds - user builds via `phpize && ./configure && make` are unaffected.

Closes #167