### PR TITLE
fix(ci): fix release-linux.yml workflow file parse error

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -664,7 +664,7 @@ jobs:
       - name: Download PHP ${{ matrix.php }} NTS Bundle
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
-          pattern: '*php${{ matrix.php }}-nts*${{ matrix.bundle_suffix || "" }}*'
+          pattern: "*php${{ matrix.php }}-nts*${{ matrix.bundle_suffix || '' }}*"
           path: bundle
       
       - name: Test on ${{ matrix.distro }}


### PR DESCRIPTION
## Problem

After merging PR #201 (Alpine/musl builds), the `release-linux.yml` workflow fails immediately with a "workflow file issue" error - 0 jobs are created.

## Root Cause

Line 667 used double quotes (`""`) inside a GitHub Actions expression `${{ }}`, but GitHub Actions expressions only support **single quotes** for string literals:

```yaml
# Broken: YAML single-quoted string with '' interpreted as escaped literal quote
pattern: '*php${{ matrix.php }}-nts*${{ matrix.bundle_suffix || "" }}*'

# Fixed: YAML double-quoted string preserves '' as GitHub Actions empty string
pattern: "*php${{ matrix.php }}-nts*${{ matrix.bundle_suffix || '' }}*"
```

The first attempt to fix by changing `""` to `''` didn't work because inside a YAML single-quoted string, `''` is an escape sequence for a literal single quote character - not two separate quote characters.

## Fix

Switch the outer YAML string delimiter from single quotes to double quotes, so the inner `''` is preserved as a valid GitHub Actions empty string literal.

## Validation

- `actionlint` passes with no expression errors (only shellcheck info warnings)
- 1 file changed, 1 insertion, 1 deletion

## Context

Part of v10.6.0 Platform Expansion milestone. This regression was introduced in PR #201 commit `6fc0532`.