### PR TITLE
feat(ci): macOS universal binary builds

### DIFF
--- a/.github/scripts/extract-firebird-macos.sh
+++ b/.github/scripts/extract-firebird-macos.sh
@@ -206,6 +206,36 @@ if [ -z "$FB_FRAMEWORK" ]; then
     FB_FRAMEWORK=$(find "$PKG_EXPANDED" -path "*/Firebird.framework" -type d 2>/dev/null | head -1)
 fi
 
+# If payload IS the framework content (has Versions/A/ structure) but no
+# Firebird.framework wrapper, create one. This happens when pkgutil
+# --expand-full extracts the payload directly.
+if [ -z "$FB_FRAMEWORK" ]; then
+    # Check in EXTRACT_DIR
+    if [ -d "$EXTRACT_DIR/Versions/A" ]; then
+        log_info "Detected bare framework structure in EXTRACT_DIR, wrapping..."
+        mkdir -p "$EXTRACT_DIR/Firebird.framework"
+        mv "$EXTRACT_DIR/Versions" "$EXTRACT_DIR/Firebird.framework/"
+        FB_FRAMEWORK="$EXTRACT_DIR/Firebird.framework"
+    fi
+    # Check in PKG_EXPANDED Payload directories
+    if [ -z "$FB_FRAMEWORK" ]; then
+        BARE_FW=$(find "$PKG_EXPANDED" -type d -name "Payload" 2>/dev/null | while read -r pdir; do
+            if [ -d "$pdir/Versions/A" ]; then echo "$pdir"; break; fi
+        done)
+        if [ -n "$BARE_FW" ]; then
+            log_info "Detected bare framework in expanded payload: $BARE_FW"
+            mkdir -p "$EXTRACT_DIR/Firebird.framework"
+            cp -a "$BARE_FW"/Versions "$EXTRACT_DIR/Firebird.framework/"
+            # Also copy top-level symlinks if present
+            for item in "$BARE_FW"/*; do
+                [ "$(basename "$item")" = "Versions" ] && continue
+                cp -a "$item" "$EXTRACT_DIR/Firebird.framework/" 2>/dev/null || true
+            done
+            FB_FRAMEWORK="$EXTRACT_DIR/Firebird.framework"
+        fi
+    fi
+fi
+
 if [ -z "$FB_FRAMEWORK" ]; then
     log_error "Firebird.framework not found in extracted payload"
     echo "Full payload tree:"

--- a/.github/scripts/extract-firebird-macos.sh
+++ b/.github/scripts/extract-firebird-macos.sh
@@ -191,7 +191,7 @@ if [ -d "$PKG_EXPANDED" ]; then
 fi
 
 echo "=== Extracted payload structure ==="
-find "$EXTRACT_DIR" -maxdepth 5 -type f | head -40
+find "$EXTRACT_DIR" -maxdepth 5 -type f 2>/dev/null | head -40 || true
 
 # =============================================================================
 # Locate Firebird Framework
@@ -209,8 +209,8 @@ fi
 if [ -z "$FB_FRAMEWORK" ]; then
     log_error "Firebird.framework not found in extracted payload"
     echo "Full payload tree:"
-    find "$EXTRACT_DIR" -type f | head -60
-    find "$PKG_EXPANDED" -type f | head -60
+    find "$EXTRACT_DIR" -type f 2>/dev/null | head -60 || true
+    find "$PKG_EXPANDED" -type f 2>/dev/null | head -60 || true
     die "Cannot proceed without Firebird.framework"
 fi
 
@@ -349,7 +349,7 @@ echo ""
 
 if [ -d "$OUTPUT_DIR/include/firebird" ]; then
     echo "=== Nested headers (firebird/) ==="
-    find "$OUTPUT_DIR/include/firebird" -type f | head -10
+    find "$OUTPUT_DIR/include/firebird" -type f 2>/dev/null | head -10 || true
     echo ""
 fi
 

--- a/.github/scripts/extract-firebird-macos.sh
+++ b/.github/scripts/extract-firebird-macos.sh
@@ -1,0 +1,400 @@
+#!/bin/bash
+# =============================================================================
+# Extract Firebird SDK from macOS .pkg
+# =============================================================================
+#
+# Downloads and extracts Firebird headers and libraries from the official
+# macOS .pkg installer for use in building the PHP Firebird extension.
+#
+# The macOS .pkg installs Firebird as a framework at:
+#   /Library/Frameworks/Firebird.framework/
+#
+# Key issue: The .pkg's Headers directory is flat - it does NOT include the
+# nested impl/ subdirectory containing types_pub.h. This script reconstructs
+# the full header tree required for compilation.
+#
+# Usage:
+#   ./extract-firebird-macos.sh --arch arm64|x64 [options]
+#
+# Options:
+#   --arch ARCH          Target architecture: arm64 or x64 (required)
+#   --fb-version VER     Firebird version [default: 5.0.3]
+#   --fb-build BUILD     Firebird build number [default: 1683]
+#   --output DIR         Output directory [default: /opt/firebird]
+#   --pkg-path PATH      Use local .pkg file instead of downloading
+#   --help               Show this help message
+#
+# Output structure:
+#   <output>/include/ibase.h
+#   <output>/include/iberror.h
+#   <output>/include/firebird/impl/types_pub.h  (critical - missing from .pkg)
+#   <output>/lib/libfbclient.dylib
+#
+# =============================================================================
+
+set -euo pipefail
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+ARCH=""
+FB_VERSION="${FB_VERSION:-5.0.3}"
+FB_BUILD="${FB_BUILD:-1683}"
+OUTPUT_DIR="/opt/firebird"
+PKG_PATH=""
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+usage() {
+    sed -n '3,30p' "$0" | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+log_info() {
+    echo ">>> $*"
+}
+
+log_error() {
+    echo "ERROR: $*" >&2
+}
+
+die() {
+    log_error "$@"
+    exit 1
+}
+
+# =============================================================================
+# Argument Parsing
+# =============================================================================
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --arch)       ARCH="$2"; shift 2 ;;
+        --fb-version) FB_VERSION="$2"; shift 2 ;;
+        --fb-build)   FB_BUILD="$2"; shift 2 ;;
+        --output)     OUTPUT_DIR="$2"; shift 2 ;;
+        --pkg-path)   PKG_PATH="$2"; shift 2 ;;
+        --help|-h)    usage ;;
+        *)            die "Unknown option: $1" ;;
+    esac
+done
+
+if [ -z "$ARCH" ]; then
+    die "Architecture required. Use --arch arm64 or --arch x64"
+fi
+
+# Map arch to Firebird .pkg suffix
+case "$ARCH" in
+    arm64)  FB_PKG_SUFFIX="macos-arm64" ;;
+    x64)    FB_PKG_SUFFIX="macos-x64" ;;
+    x86_64) FB_PKG_SUFFIX="macos-x64"; ARCH="x64" ;;
+    *)      die "Unsupported architecture: $ARCH (use arm64 or x64)" ;;
+esac
+
+FB_PKG_NAME="Firebird-${FB_VERSION}.${FB_BUILD}-0-${FB_PKG_SUFFIX}.pkg"
+
+# =============================================================================
+# Download .pkg (if not provided)
+# =============================================================================
+
+if [ -n "$PKG_PATH" ]; then
+    [ -f "$PKG_PATH" ] || die "Package not found: $PKG_PATH"
+    log_info "Using local package: $PKG_PATH"
+else
+    PKG_PATH="/tmp/firebird-cache/${FB_PKG_NAME}"
+
+    if [ -f "$PKG_PATH" ]; then
+        log_info "Using cached package: $PKG_PATH"
+    else
+        log_info "Downloading Firebird ${FB_VERSION} for ${FB_PKG_SUFFIX}..."
+        mkdir -p /tmp/firebird-cache
+
+        FB_URL="https://github.com/FirebirdSQL/firebird/releases/download/v${FB_VERSION}/${FB_PKG_NAME}"
+        DELAY=10
+
+        for attempt in 1 2 3 4 5; do
+            echo "Download attempt ${attempt}/5..."
+            if curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
+                ${GITHUB_TOKEN:+-H "Authorization: token ${GITHUB_TOKEN}"} \
+                "${FB_URL}" -o "$PKG_PATH"; then
+                FSIZE=$(stat -f%z "$PKG_PATH" 2>/dev/null || stat -c%s "$PKG_PATH" 2>/dev/null || echo "0")
+                if [ "${FSIZE}" -gt 1000000 ]; then
+                    log_info "Download OK (${FSIZE} bytes)"
+                    break
+                fi
+                rm -f "$PKG_PATH"
+            fi
+            [ "$attempt" -lt 5 ] && echo "Sleeping ${DELAY}s..." && sleep "$DELAY"
+            DELAY=$((DELAY * 2))
+        done
+
+        [ -f "$PKG_PATH" ] || die "All download attempts failed for ${FB_URL}"
+    fi
+fi
+
+# =============================================================================
+# Extract .pkg
+# =============================================================================
+
+log_info "Extracting .pkg..."
+
+PKG_EXPANDED="/tmp/firebird-expanded"
+EXTRACT_DIR="/tmp/firebird-payload"
+rm -rf "$PKG_EXPANDED" "$EXTRACT_DIR"
+mkdir -p "$EXTRACT_DIR"
+
+# pkgutil --expand-full extracts everything including payloads
+# (available on macOS 10.6+, handles both flat and distribution packages)
+if command -v pkgutil >/dev/null 2>&1; then
+    # Try --expand-full first (extracts Payload automatically)
+    if pkgutil --expand-full "$PKG_PATH" "$PKG_EXPANDED" 2>/dev/null; then
+        log_info "Expanded with pkgutil --expand-full"
+    else
+        # Fallback to --expand + manual Payload extraction
+        pkgutil --expand "$PKG_PATH" "$PKG_EXPANDED"
+        log_info "Expanded with pkgutil --expand, extracting payloads manually..."
+
+        find "$PKG_EXPANDED" -name "Payload" | while read -r payload; do
+            echo "Extracting payload: ${payload}"
+            cd "$EXTRACT_DIR"
+            if file "$payload" | grep -q "gzip"; then
+                gunzip -c "$payload" | cpio -idm 2>/dev/null || true
+            elif file "$payload" | grep -q "cpio"; then
+                cpio -idm < "$payload" 2>/dev/null || true
+            else
+                tar xf "$payload" 2>/dev/null || true
+            fi
+        done
+    fi
+else
+    die "pkgutil not found - this script must run on macOS"
+fi
+
+# Merge expanded content into extract dir
+# --expand-full puts payload contents directly in component dirs
+if [ -d "$PKG_EXPANDED" ]; then
+    # Find Payload directories from --expand-full
+    find "$PKG_EXPANDED" -name "Payload" -type d | while read -r payload_dir; do
+        log_info "Copying payload from: $payload_dir"
+        cp -a "$payload_dir"/* "$EXTRACT_DIR/" 2>/dev/null || true
+    done
+
+    # Also check for directly extracted framework (--expand-full puts files here)
+    find "$PKG_EXPANDED" -path "*/Firebird.framework" -type d | head -1 | while read -r fw; do
+        log_info "Found framework in expanded dir: $fw"
+        mkdir -p "$EXTRACT_DIR/Library/Frameworks"
+        cp -a "$fw" "$EXTRACT_DIR/Library/Frameworks/" 2>/dev/null || true
+    done
+fi
+
+echo "=== Extracted payload structure ==="
+find "$EXTRACT_DIR" -maxdepth 5 -type f | head -40
+
+# =============================================================================
+# Locate Firebird Framework
+# =============================================================================
+
+log_info "Locating Firebird framework..."
+
+FB_FRAMEWORK=$(find "$EXTRACT_DIR" -path "*/Firebird.framework" -type d 2>/dev/null | head -1)
+
+if [ -z "$FB_FRAMEWORK" ]; then
+    # Also search in the expanded pkg directory itself
+    FB_FRAMEWORK=$(find "$PKG_EXPANDED" -path "*/Firebird.framework" -type d 2>/dev/null | head -1)
+fi
+
+if [ -z "$FB_FRAMEWORK" ]; then
+    log_error "Firebird.framework not found in extracted payload"
+    echo "Full payload tree:"
+    find "$EXTRACT_DIR" -type f | head -60
+    find "$PKG_EXPANDED" -type f | head -60
+    die "Cannot proceed without Firebird.framework"
+fi
+
+log_info "Found Firebird framework: $FB_FRAMEWORK"
+
+# =============================================================================
+# Copy Headers and Libraries to Output
+# =============================================================================
+
+log_info "Installing to $OUTPUT_DIR..."
+
+mkdir -p "$OUTPUT_DIR/include/firebird/impl" "$OUTPUT_DIR/lib"
+
+# --- Headers ---
+# The framework Headers/ contains ibase.h, iberror.h, etc. but NOT the
+# nested firebird/impl/ subdirectory with types_pub.h
+HEADERS_DIR=""
+if [ -d "$FB_FRAMEWORK/Headers" ]; then
+    HEADERS_DIR="$FB_FRAMEWORK/Headers"
+elif [ -d "$FB_FRAMEWORK/Versions/A/Headers" ]; then
+    HEADERS_DIR="$FB_FRAMEWORK/Versions/A/Headers"
+fi
+
+if [ -n "$HEADERS_DIR" ] && [ -d "$HEADERS_DIR" ]; then
+    log_info "Copying headers from: $HEADERS_DIR"
+    cp -a "$HEADERS_DIR"/* "$OUTPUT_DIR/include/"
+
+    # CRITICAL FIX: Reconstruct the firebird/impl/ header tree
+    # ibase.h includes <firebird/impl/types_pub.h> but the .pkg doesn't
+    # ship the nested directory structure. We need to find types_pub.h
+    # and place it in the correct location.
+    if [ ! -f "$OUTPUT_DIR/include/firebird/impl/types_pub.h" ]; then
+        log_info "Reconstructing firebird/impl/ header tree..."
+
+        # Search for types_pub.h in the entire extracted tree
+        TYPES_PUB=$(find "$EXTRACT_DIR" "$PKG_EXPANDED" -name "types_pub.h" -type f 2>/dev/null | head -1)
+
+        if [ -n "$TYPES_PUB" ]; then
+            cp "$TYPES_PUB" "$OUTPUT_DIR/include/firebird/impl/types_pub.h"
+            log_info "Found types_pub.h at: $TYPES_PUB"
+        else
+            # types_pub.h may be embedded in the flat Headers/ dir
+            # or we need to extract it from the ibase.h include path
+            # As a last resort, check if it's in the Headers dir under a different path
+            TYPES_PUB=$(find "$FB_FRAMEWORK" -name "types_pub.h" -type f 2>/dev/null | head -1)
+            if [ -n "$TYPES_PUB" ]; then
+                cp "$TYPES_PUB" "$OUTPUT_DIR/include/firebird/impl/types_pub.h"
+                log_info "Found types_pub.h in framework: $TYPES_PUB"
+            fi
+        fi
+
+        # If types_pub.h is in the flat include dir, move it to the nested path
+        if [ -f "$OUTPUT_DIR/include/types_pub.h" ] && \
+           [ ! -f "$OUTPUT_DIR/include/firebird/impl/types_pub.h" ]; then
+            cp "$OUTPUT_DIR/include/types_pub.h" "$OUTPUT_DIR/include/firebird/impl/types_pub.h"
+            log_info "Copied flat types_pub.h to firebird/impl/"
+        fi
+
+        # Copy any other impl/ headers found
+        find "$EXTRACT_DIR" "$PKG_EXPANDED" -path "*/impl/*.h" -type f 2>/dev/null | while read -r hdr; do
+            BASENAME=$(basename "$hdr")
+            if [ ! -f "$OUTPUT_DIR/include/firebird/impl/$BASENAME" ]; then
+                cp "$hdr" "$OUTPUT_DIR/include/firebird/impl/$BASENAME"
+                log_info "Copied impl header: $BASENAME"
+            fi
+        done
+    fi
+
+    # Also ensure firebird/ directory symlink for includes that use <firebird/...>
+    # Some headers include via firebird/Interface.h or similar paths
+    find "$EXTRACT_DIR" "$PKG_EXPANDED" -name "Interface.h" -path "*/firebird/*" -type f 2>/dev/null | head -1 | while read -r iface; do
+        IFACE_DIR=$(dirname "$iface")
+        log_info "Found firebird interface headers at: $IFACE_DIR"
+        cp -a "$IFACE_DIR"/* "$OUTPUT_DIR/include/firebird/" 2>/dev/null || true
+    done
+else
+    log_info "No standard Headers/ dir found, searching for loose headers..."
+    find "$EXTRACT_DIR" "$PKG_EXPANDED" -name "ibase.h" -type f -exec cp {} "$OUTPUT_DIR/include/" \;
+    find "$EXTRACT_DIR" "$PKG_EXPANDED" -name "iberror.h" -type f -exec cp {} "$OUTPUT_DIR/include/" \;
+    find "$EXTRACT_DIR" "$PKG_EXPANDED" -name "types_pub.h" -type f | head -1 | while read -r f; do
+        cp "$f" "$OUTPUT_DIR/include/firebird/impl/"
+    done
+fi
+
+# --- Libraries ---
+log_info "Copying libraries..."
+
+# Find dylibs in the framework
+find "$FB_FRAMEWORK" -name "*.dylib" -type f -exec cp {} "$OUTPUT_DIR/lib/" \;
+
+# The framework binary itself is libfbclient
+FB_BINARY=""
+if [ -f "$FB_FRAMEWORK/Versions/A/Firebird" ]; then
+    FB_BINARY="$FB_FRAMEWORK/Versions/A/Firebird"
+elif [ -f "$FB_FRAMEWORK/Firebird" ]; then
+    FB_BINARY="$FB_FRAMEWORK/Firebird"
+fi
+
+if [ -n "$FB_BINARY" ] && [ -f "$FB_BINARY" ]; then
+    # Check if this is actually a Mach-O binary (not a symlink to directory)
+    if file "$FB_BINARY" | grep -q "Mach-O"; then
+        if [ ! -f "$OUTPUT_DIR/lib/libfbclient.dylib" ]; then
+            cp "$FB_BINARY" "$OUTPUT_DIR/lib/libfbclient.dylib"
+            log_info "Copied framework binary as libfbclient.dylib"
+        fi
+    fi
+fi
+
+# Also search for libfbclient directly in extracted payload
+find "$EXTRACT_DIR" -name "libfbclient*" -type f 2>/dev/null | while read -r lib; do
+    LIBNAME=$(basename "$lib")
+    if [ ! -f "$OUTPUT_DIR/lib/$LIBNAME" ]; then
+        cp "$lib" "$OUTPUT_DIR/lib/$LIBNAME"
+        log_info "Copied: $LIBNAME"
+    fi
+done
+
+# Create version symlinks
+cd "$OUTPUT_DIR/lib"
+for lib in libfbclient.dylib.*; do
+    if [ -f "$lib" ] && [ ! -L "$lib" ]; then
+        base="${lib%%.*}"
+        [ ! -e "${base}.dylib" ] && ln -sf "$lib" "${base}.dylib" 2>/dev/null || true
+    fi
+done 2>/dev/null || true
+
+# =============================================================================
+# Verification
+# =============================================================================
+
+log_info "Verifying installation..."
+
+echo "=== Headers ==="
+ls -la "$OUTPUT_DIR/include/" || true
+echo ""
+
+if [ -d "$OUTPUT_DIR/include/firebird" ]; then
+    echo "=== Nested headers (firebird/) ==="
+    find "$OUTPUT_DIR/include/firebird" -type f | head -10
+    echo ""
+fi
+
+echo "=== Libraries ==="
+ls -la "$OUTPUT_DIR/lib/" || true
+echo ""
+
+# Critical checks
+ERRORS=0
+
+if [ ! -f "$OUTPUT_DIR/include/ibase.h" ]; then
+    log_error "CRITICAL: ibase.h not found"
+    ERRORS=$((ERRORS + 1))
+fi
+
+if [ ! -f "$OUTPUT_DIR/include/firebird/impl/types_pub.h" ]; then
+    log_error "CRITICAL: firebird/impl/types_pub.h not found"
+    log_error "This will cause 'impl/types_pub.h file not found' build errors"
+    ERRORS=$((ERRORS + 1))
+fi
+
+if ! ls "$OUTPUT_DIR/lib/libfbclient"* >/dev/null 2>&1; then
+    log_error "CRITICAL: libfbclient not found"
+    ERRORS=$((ERRORS + 1))
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+    die "$ERRORS critical check(s) failed"
+fi
+
+# Show library architecture
+for dylib in "$OUTPUT_DIR"/lib/*.dylib; do
+    if [ -f "$dylib" ] && [ ! -L "$dylib" ]; then
+        echo "Architecture of $(basename "$dylib"):"
+        file "$dylib"
+        lipo -info "$dylib" 2>/dev/null || true
+    fi
+done
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+
+rm -rf "$PKG_EXPANDED" "$EXTRACT_DIR"
+
+log_info "Firebird SDK extracted successfully to $OUTPUT_DIR"
+log_info "  Headers: $OUTPUT_DIR/include/"
+log_info "  Libraries: $OUTPUT_DIR/lib/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,11 +744,52 @@ jobs:
           echo "=== Building extension ==="
           phpize
           ./configure --with-firebird="${FB_CLIENT_DIR}"
+
+          # WORKAROUND: macOS uses case-insensitive APFS by default.
+          # Our VERSION file conflicts with the C++ standard <version> header
+          # because phpize adds -I. to the include path. Temporarily hide it
+          # during compilation (configure already read it via config.m4).
+          if [ -f VERSION ]; then
+            mv VERSION VERSION.bak
+            echo "Temporarily renamed VERSION to avoid C++ header conflict"
+          fi
+
           make -j"$(sysctl -n hw.ncpu)"
+
+          # Restore VERSION file
+          if [ -f VERSION.bak ]; then
+            mv VERSION.bak VERSION
+          fi
 
           echo "Extension built successfully"
           ls -la modules/firebird.so
           file modules/firebird.so
+
+      - name: Patch extension RPATH
+        run: |
+          set -eu
+
+          FB_CLIENT_DIR="/tmp/firebird-client"
+          EXTENSION_PATH="$(pwd)/modules/firebird.so"
+
+          # Fix libfbclient reference: the Firebird .pkg installs with a
+          # hardcoded install_name pointing to /Library/Frameworks/...
+          # Rewrite to use @rpath so the extension finds the bundled dylib.
+          FB_DYLIB_REF=$(otool -L "$EXTENSION_PATH" | grep -o '[^ ]*libfbclient[^ ]*' | head -1 || true)
+          if [ -n "$FB_DYLIB_REF" ] && [[ "$FB_DYLIB_REF" != @rpath/* ]]; then
+            echo "Rewriting libfbclient reference: $FB_DYLIB_REF -> @rpath/libfbclient.dylib"
+            install_name_tool -change "$FB_DYLIB_REF" "@rpath/libfbclient.dylib" "$EXTENSION_PATH"
+            install_name_tool -add_rpath "${FB_CLIENT_DIR}/lib" "$EXTENSION_PATH" 2>/dev/null || true
+          fi
+
+          # Also fix the bundled dylib's install_name
+          FB_DYLIB="${FB_CLIENT_DIR}/lib/libfbclient.dylib"
+          if [ -f "$FB_DYLIB" ]; then
+            install_name_tool -id "@rpath/libfbclient.dylib" "$FB_DYLIB" 2>/dev/null || true
+          fi
+
+          echo "=== RPATH verification ==="
+          otool -L "$EXTENSION_PATH"
 
       - name: Verify extension loads
         run: |
@@ -756,7 +797,7 @@ jobs:
 
           EXTENSION_PATH="$(pwd)/modules/firebird.so"
 
-          # Set library path for Firebird client
+          # Set library path for Firebird client (belt and suspenders with RPATH)
           export DYLD_LIBRARY_PATH="/tmp/firebird-client/lib:${DYLD_LIBRARY_PATH:-}"
 
           echo "=== Verifying extension ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,82 +726,11 @@ jobs:
           FB_PKG_NAME: ${{ steps.fb-version.outputs.fb_pkg_name }}
         run: |
           set -eu
-
-          FB_CLIENT_DIR="/tmp/firebird-client"
-          mkdir -p "${FB_CLIENT_DIR}/include" "${FB_CLIENT_DIR}/lib"
-
-          # Expand the .pkg (flat package or distribution package)
-          PKG_EXPANDED="/tmp/firebird-expanded"
-          pkgutil --expand "/tmp/firebird-cache/${FB_PKG_NAME}" "${PKG_EXPANDED}"
-
-          echo "=== Package contents ==="
-          find "${PKG_EXPANDED}" -maxdepth 3 -type f | head -30
-
-          # Extract payload(s) - may be nested in component packages
-          EXTRACT_DIR="/tmp/firebird-payload"
-          mkdir -p "${EXTRACT_DIR}"
-
-          # Find all Payload files and extract them
-          find "${PKG_EXPANDED}" -name "Payload" | while read -r payload; do
-            echo "Extracting payload: ${payload}"
-            # macOS Payload files are gzipped cpio or xar archives
-            cd "${EXTRACT_DIR}"
-            # Try gzip+cpio first (common for .pkg)
-            if file "${payload}" | grep -q "gzip"; then
-              gunzip -c "${payload}" | cpio -idm 2>/dev/null || true
-            elif file "${payload}" | grep -q "cpio"; then
-              cpio -idm < "${payload}" 2>/dev/null || true
-            else
-              # Try as plain tar
-              tar xf "${payload}" 2>/dev/null || true
-            fi
-          done
-
-          echo "=== Extracted payload structure ==="
-          find "${EXTRACT_DIR}" -maxdepth 4 | head -40
-
-          # Locate Firebird framework headers and libraries
-          # Firebird installs to /Library/Frameworks/Firebird.framework/
-          FB_FRAMEWORK=$(find "${EXTRACT_DIR}" -path "*/Firebird.framework" -type d | head -1)
-
-          if [ -n "${FB_FRAMEWORK}" ]; then
-            echo "Found Firebird framework at: ${FB_FRAMEWORK}"
-
-            # Copy headers
-            if [ -d "${FB_FRAMEWORK}/Headers" ]; then
-              cp -a "${FB_FRAMEWORK}/Headers/"* "${FB_CLIENT_DIR}/include/"
-            elif [ -d "${FB_FRAMEWORK}/Versions/A/Headers" ]; then
-              cp -a "${FB_FRAMEWORK}/Versions/A/Headers/"* "${FB_CLIENT_DIR}/include/"
-            fi
-
-            # Copy libraries - look for dylibs in the framework
-            find "${FB_FRAMEWORK}" -name "*.dylib" -exec cp {} "${FB_CLIENT_DIR}/lib/" \;
-
-            # Also copy the framework binary itself as libfbclient if needed
-            if [ -f "${FB_FRAMEWORK}/Versions/A/Firebird" ]; then
-              cp "${FB_FRAMEWORK}/Versions/A/Firebird" "${FB_CLIENT_DIR}/lib/libfbclient.dylib" 2>/dev/null || true
-            fi
-          else
-            echo "WARNING: Firebird.framework not found, searching for loose files..."
-            # Fallback: search for ibase.h and libfbclient directly
-            find "${EXTRACT_DIR}" -name "ibase.h" -exec cp {} "${FB_CLIENT_DIR}/include/" \;
-            find "${EXTRACT_DIR}" -name "iberror.h" -exec cp {} "${FB_CLIENT_DIR}/include/" \;
-            find "${EXTRACT_DIR}" -name "libfbclient*" -exec cp {} "${FB_CLIENT_DIR}/lib/" \;
-          fi
-
-          echo "=== Firebird client directory ==="
-          ls -la "${FB_CLIENT_DIR}/include/" || echo "No headers"
-          ls -la "${FB_CLIENT_DIR}/lib/" || echo "No libraries"
-
-          # Verify we have ibase.h
-          if [ ! -f "${FB_CLIENT_DIR}/include/ibase.h" ]; then
-            echo "ERROR: ibase.h not found after extraction" >&2
-            echo "Full payload tree:"
-            find "${EXTRACT_DIR}" -type f | head -50
-            exit 1
-          fi
-
-          echo "Firebird client extracted successfully"
+          chmod +x .github/scripts/extract-firebird-macos.sh
+          .github/scripts/extract-firebird-macos.sh \
+            --arch ${{ matrix.fb-pkg-suffix == 'macos-arm64' && 'arm64' || 'x64' }} \
+            --pkg-path "/tmp/firebird-cache/${FB_PKG_NAME}" \
+            --output /tmp/firebird-client
 
       - name: Build PHP extension
         run: |

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -254,7 +254,21 @@ jobs:
           export LDFLAGS="${LDFLAGS:-} -L${FB_ROOT}/lib"
           phpize
           ./configure --with-firebird="${FB_ROOT}"
+
+          # WORKAROUND: macOS uses case-insensitive APFS by default.
+          # Our VERSION file conflicts with the C++ standard <version> header
+          # because phpize adds -I. to the include path. Temporarily hide it
+          # during compilation (configure already read it via config.m4).
+          if [ -f VERSION ]; then
+            mv VERSION VERSION.bak
+          fi
+
           make -j"$(sysctl -n hw.ncpu)"
+
+          # Restore VERSION file
+          if [ -f VERSION.bak ]; then
+            mv VERSION.bak VERSION
+          fi
 
           ls -la modules/firebird.so
           file modules/firebird.so

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,773 @@
+# =============================================================================
+# PHP Firebird Extension - macOS Precompiled Release Workflow
+# =============================================================================
+#
+# Builds and publishes precompiled PHP extensions with bundled Firebird client
+# libraries for macOS (arm64 and x86_64), including universal binaries.
+#
+# Triggers:
+#   - Tag push (v[0-9]*.*) - immutable releases
+#   - Release created/published - non-immutable releases
+#   - Manual dispatch (for testing)
+#
+# Build Matrix:
+#   - PHP 8.2, 8.3, 8.4, 8.5
+#   - NTS and ZTS variants
+#   - arm64 (macos-14, M1) and x86_64 (macos-13, Intel) architectures
+#
+# Universal binaries are created by combining arm64 and x86_64 slices via lipo.
+# macOS bundles use install_name_tool + @loader_path instead of patchelf + $ORIGIN.
+# =============================================================================
+
+name: Release (macOS)
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*.*'
+  release:
+    types: [created, published]
+  workflow_dispatch:
+    inputs:
+      php_versions:
+        description: 'PHP versions (comma-separated)'
+        required: false
+        default: '8.2,8.3,8.4,8.5'
+        type: string
+      upload_to_release:
+        description: 'Upload artifacts to release'
+        required: false
+        default: false
+        type: boolean
+      release_tag:
+        description: 'Release tag (if uploading to existing release)'
+        required: false
+        default: ''
+        type: string
+
+env:
+  FB_VERSION: '5.0.3'
+  FB_BUILD: '1683'
+
+permissions: read-all
+
+jobs:
+  # ===========================================================================
+  # Prepare Build Matrix
+  # ===========================================================================
+  prepare:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      version: ${{ steps.get-version.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Get Extension Version
+        id: get-version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            echo "${VERSION}" > VERSION
+            echo "Updated VERSION file from tag: ${VERSION}"
+          elif [ -f VERSION ]; then
+            VERSION=$(cat VERSION | tr -d '[:space:]')
+          else
+            VERSION=$(grep -E '#define PHP_FIREBIRD_VERSION_STRING' php_firebird.h | sed 's/.*"\([^"]*\)".*/\1/' | head -1)
+            if [ -z "$VERSION" ] || [[ "$VERSION" == *"unknown"* ]]; then
+              VERSION="7.0.0"
+            fi
+            echo "${VERSION}" > VERSION
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Extension version: ${VERSION}"
+
+      - name: Set Build Matrix
+        id: set-matrix
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.php_versions }}" ]; then
+            PHP_VERSIONS="${{ inputs.php_versions }}"
+          else
+            PHP_VERSIONS="8.2,8.3,8.4,8.5"
+          fi
+
+          MATRIX='{"include":['
+          FIRST=true
+
+          IFS=',' read -ra VERSIONS <<< "${PHP_VERSIONS}"
+          for version in "${VERSIONS[@]}"; do
+            version=$(echo "$version" | tr -d ' ')
+            for variant in nts zts; do
+              for arch in arm64 x86_64; do
+                if [ "$FIRST" = true ]; then
+                  FIRST=false
+                else
+                  MATRIX+=','
+                fi
+                # Map arch to runner and Firebird .pkg suffix
+                if [ "${arch}" = "arm64" ]; then
+                  RUNNER="macos-14"
+                  FB_PKG_SUFFIX="macos-arm64"
+                else
+                  RUNNER="macos-13"
+                  FB_PKG_SUFFIX="macos-x64"
+                fi
+                MATRIX+="{\"php\":\"${version}\",\"variant\":\"${variant}\",\"arch\":\"${arch}\",\"runner\":\"${RUNNER}\",\"fb_pkg_suffix\":\"${FB_PKG_SUFFIX}\"}"
+              done
+            done
+          done
+
+          MATRIX+=']}'
+          echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
+          echo "Build matrix: ${MATRIX}"
+
+  # ===========================================================================
+  # Build Precompiled Extensions (per-architecture)
+  # ===========================================================================
+  build:
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Cache Firebird macOS Package
+        id: cache-firebird
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: /tmp/firebird-cache
+          key: firebird-${{ env.FB_VERSION }}-${{ matrix.fb_pkg_suffix }}
+
+      - name: Extract Firebird SDK
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/extract-firebird-macos.sh
+          # Map arch for the extraction script
+          EXTRACT_ARCH="${{ matrix.arch }}"
+          if [ "${EXTRACT_ARCH}" = "x86_64" ]; then
+            EXTRACT_ARCH="x64"
+          fi
+          sudo mkdir -p /opt/firebird
+          sudo chown "$(whoami)" /opt/firebird
+          bash .github/scripts/extract-firebird-macos.sh \
+            --arch "${EXTRACT_ARCH}" \
+            --fb-version "${FB_VERSION}" \
+            --fb-build "${FB_BUILD}" \
+            --output /opt/firebird
+
+      - name: Determine PHP Full Version
+        id: php-version
+        run: |
+          MINOR="${{ matrix.php }}"
+          LATEST=$(curl -fsSL --retry 3 --retry-delay 5 \
+            "https://www.php.net/releases/index.php?json&version=${MINOR}" \
+            2>/dev/null | jq -r ".\"${MINOR}\".version // empty" 2>/dev/null || true)
+
+          if [ -n "${LATEST}" ] && [[ "${LATEST}" =~ ^${MINOR}\. ]]; then
+            echo "Resolved PHP ${MINOR} latest from php.net: ${LATEST}"
+            FULL_VERSION="${LATEST}"
+          else
+            echo "php.net API unavailable; using known-good fallback"
+            case "${MINOR}" in
+              8.2) FULL_VERSION="8.2.28" ;;
+              8.3) FULL_VERSION="8.3.16" ;;
+              8.4) FULL_VERSION="8.4.4" ;;
+              8.5) FULL_VERSION="8.5.0" ;;
+              *) FULL_VERSION="${MINOR}.0" ;;
+            esac
+          fi
+
+          echo "full_version=${FULL_VERSION}" >> $GITHUB_OUTPUT
+          echo "PHP full version: ${FULL_VERSION}"
+
+      - name: Install Build Dependencies
+        run: |
+          # Install build tools via Homebrew (some already present on runners)
+          brew install autoconf automake libtool re2c bison pkg-config 2>/dev/null || true
+          echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
+
+      - name: Build PHP ${{ matrix.php }} (${{ matrix.variant }})
+        run: |
+          FULL_VERSION="${{ steps.php-version.outputs.full_version }}"
+          VARIANT="${{ matrix.variant }}"
+          INSTALL_DIR="/opt/php/${{ matrix.php }}-${VARIANT}"
+
+          echo "Building PHP ${FULL_VERSION} (${VARIANT})..."
+
+          curl -fsSL "https://www.php.net/distributions/php-${FULL_VERSION}.tar.xz" \
+            -o /tmp/php.tar.xz
+
+          mkdir -p /tmp/php-src
+          tar -xJf /tmp/php.tar.xz -C /tmp/php-src --strip-components=1
+          cd /tmp/php-src
+
+          CONFIGURE_OPTS=(
+            "--prefix=${INSTALL_DIR}"
+            "--enable-cli"
+            "--disable-cgi"
+            "--disable-phpdbg"
+            "--without-pear"
+            "--enable-shared"
+            "--enable-mbstring"
+            "--enable-intl"
+            "--enable-opcache"
+            "--with-openssl"
+            "--with-zlib"
+            "--with-curl"
+          )
+
+          if [ "${VARIANT}" = "zts" ]; then
+            CONFIGURE_OPTS+=("--enable-zts")
+          fi
+
+          ./configure "${CONFIGURE_OPTS[@]}"
+          make -j"$(sysctl -n hw.ncpu)"
+          make install
+
+          "${INSTALL_DIR}/bin/php" -v
+          export PATH="${INSTALL_DIR}/bin:${PATH}"
+
+          cd /
+          rm -rf /tmp/php-src /tmp/php.tar.xz
+
+      - name: Build Extension
+        run: |
+          export PATH="/opt/php/${{ matrix.php }}-${{ matrix.variant }}/bin:${PATH}"
+          export FB_ROOT=/opt/firebird
+
+          echo "Building with:"
+          php -v | head -1
+          echo "Firebird: ${FB_ROOT}"
+
+          phpize --clean 2>/dev/null || true
+
+          # LTO for optimized release binaries
+          export CFLAGS="${CFLAGS:-} -O2"
+          export LDFLAGS="${LDFLAGS:-} -L${FB_ROOT}/lib"
+          phpize
+          ./configure --with-firebird="${FB_ROOT}"
+          make -j"$(sysctl -n hw.ncpu)"
+
+          ls -la modules/firebird.so
+          file modules/firebird.so
+
+      - name: Create Bundle
+        id: bundle
+        run: |
+          export PATH="/opt/php/${{ matrix.php }}-${{ matrix.variant }}/bin:${PATH}"
+          export FB_ROOT=/opt/firebird
+          VERSION="${{ needs.prepare.outputs.version }}"
+          PHP_VER="${{ matrix.php }}"
+          PHP_VER_SHORT="${PHP_VER//.}"
+          VARIANT="${{ matrix.variant }}"
+          ARCH="${{ matrix.arch }}"
+
+          BUNDLE_NAME="php-firebird-${VERSION}-php${PHP_VER_SHORT}-${VARIANT}-macos-${ARCH}"
+          DIST_DIR="dist/${BUNDLE_NAME}"
+
+          echo "Creating bundle: ${BUNDLE_NAME}"
+
+          rm -rf "${DIST_DIR}"
+          mkdir -p "${DIST_DIR}/lib"
+
+          # Copy extension
+          cp modules/firebird.so "${DIST_DIR}/firebird.so"
+
+          # Bundle libfbclient.dylib and its dependencies
+          echo "=== Bundling libraries ==="
+          for dylib in "${FB_ROOT}"/lib/libfbclient*.dylib; do
+            if [ -f "$dylib" ] && [ ! -L "$dylib" ]; then
+              cp "$dylib" "${DIST_DIR}/lib/"
+              echo "Bundled: $(basename "$dylib")"
+            fi
+          done
+
+          # Create symlinks for versioned dylibs
+          cd "${DIST_DIR}/lib"
+          for lib in libfbclient.dylib.*; do
+            if [ -f "$lib" ] && [ ! -L "$lib" ]; then
+              [ ! -e "libfbclient.dylib" ] && ln -sf "$lib" "libfbclient.dylib" 2>/dev/null || true
+            fi
+          done 2>/dev/null || true
+          # Ensure libfbclient.dylib exists (may be the only file)
+          cd "$GITHUB_WORKSPACE"
+
+          # Patch RPATH: use @loader_path/lib so the extension finds bundled dylibs
+          echo "=== Patching RPATH ==="
+          # Add @loader_path/lib rpath to the extension
+          install_name_tool -add_rpath @loader_path/lib "${DIST_DIR}/firebird.so" 2>/dev/null || true
+
+          # Rewrite the libfbclient dependency to use @rpath
+          FB_DYLIB_ID=$(otool -L "${DIST_DIR}/firebird.so" | grep -o '[^ ]*libfbclient[^ ]*' | head -1 || true)
+          if [ -n "${FB_DYLIB_ID}" ]; then
+            echo "Rewriting libfbclient reference: ${FB_DYLIB_ID} -> @rpath/libfbclient.dylib"
+            install_name_tool -change "${FB_DYLIB_ID}" "@rpath/libfbclient.dylib" "${DIST_DIR}/firebird.so"
+          fi
+
+          # Set the id of bundled libfbclient to @rpath/libfbclient.dylib
+          if [ -f "${DIST_DIR}/lib/libfbclient.dylib" ]; then
+            install_name_tool -id "@rpath/libfbclient.dylib" "${DIST_DIR}/lib/libfbclient.dylib" 2>/dev/null || true
+          fi
+
+          # Verify RPATH
+          echo "=== RPATH verification ==="
+          echo "firebird.so rpaths:"
+          otool -l "${DIST_DIR}/firebird.so" | grep -A2 LC_RPATH || echo "(none)"
+          echo "firebird.so dependencies:"
+          otool -L "${DIST_DIR}/firebird.so"
+
+          if [ -f "${DIST_DIR}/lib/libfbclient.dylib" ]; then
+            echo "libfbclient.dylib id:"
+            otool -D "${DIST_DIR}/lib/libfbclient.dylib"
+          fi
+
+          # Create documentation
+          printf '%s\n' \
+            "PHP Firebird Extension" \
+            "======================" \
+            "" \
+            "Copyright (c) 2024-2025 satware AG and contributors" \
+            "Licensed under the PHP License v3.01" \
+            "" \
+            "Bundled Libraries" \
+            "-----------------" \
+            "" \
+            "Firebird Client Library (libfbclient)" \
+            "  Copyright (c) 2000-2025 Firebird Foundation" \
+            "  Licensed under IDPL (Initial Developer's Public License)" \
+            "  https://firebirdsql.org/en/licensing/" \
+            > "${DIST_DIR}/LICENSE"
+
+          printf '%s\n' \
+            "# PHP Firebird Extension ${VERSION} - macOS ${ARCH}" \
+            "" \
+            "Pre-compiled PHP extension for Firebird database connectivity with bundled" \
+            "client libraries. No system-wide Firebird installation required." \
+            "" \
+            "## Package Information" \
+            "" \
+            "| Property | Value |" \
+            "|----------|-------|" \
+            "| **Extension Version** | ${VERSION} |" \
+            "| **PHP Version** | ${PHP_VER} (${VARIANT}) |" \
+            "| **Architecture** | ${ARCH} |" \
+            "| **Platform** | macOS |" \
+            "" \
+            "## Installation" \
+            "" \
+            "\`\`\`bash" \
+            "EXTDIR=\$(php -r 'echo ini_get(\"extension_dir\");')" \
+            "sudo tar -xzf ${BUNDLE_NAME}.tar.gz -C \"\$EXTDIR\" --strip-components=1" \
+            "echo \"extension=firebird.so\" | sudo tee /usr/local/etc/php/${PHP_VER}/conf.d/firebird.ini" \
+            "php -m | grep firebird" \
+            "\`\`\`" \
+            > "${DIST_DIR}/README.md"
+
+          # Create tarball
+          echo "=== Creating tarball ==="
+          tar -czvf "dist/${BUNDLE_NAME}.tar.gz" -C dist "${BUNDLE_NAME}"
+
+          # Checksums
+          cd dist
+          shasum -a 256 "${BUNDLE_NAME}.tar.gz" | awk '{print $1}' > "${BUNDLE_NAME}.tar.gz.sha256"
+          md5 -q "${BUNDLE_NAME}.tar.gz" > "${BUNDLE_NAME}.tar.gz.md5" 2>/dev/null || \
+            md5sum "${BUNDLE_NAME}.tar.gz" | awk '{print $1}' > "${BUNDLE_NAME}.tar.gz.md5"
+          cd "$GITHUB_WORKSPACE"
+
+          echo "bundle_name=${BUNDLE_NAME}" >> $GITHUB_OUTPUT
+          echo "bundle_file=dist/${BUNDLE_NAME}.tar.gz" >> $GITHUB_OUTPUT
+          echo "bundle_arch=${ARCH}" >> $GITHUB_OUTPUT
+
+          echo ""
+          echo "Bundle files:"
+          ls -la dist/
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          path: dist/${{ steps.bundle.outputs.bundle_name }}
+          format: cyclonedx-json
+          output-file: dist/${{ steps.bundle.outputs.bundle_name }}.sbom.cdx.json
+          artifact-name: ''
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ${{ steps.bundle.outputs.bundle_name }}
+          path: |
+            ${{ steps.bundle.outputs.bundle_file }}
+            ${{ steps.bundle.outputs.bundle_file }}.sha256
+            ${{ steps.bundle.outputs.bundle_file }}.md5
+            dist/${{ steps.bundle.outputs.bundle_name }}.sbom.cdx.json
+          retention-days: 30
+
+  # ===========================================================================
+  # Create Universal Binaries (arm64 + x86_64 via lipo)
+  # ===========================================================================
+  universal:
+    needs: [prepare, build]
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: "8.2"
+            variant: nts
+          - php: "8.2"
+            variant: zts
+          - php: "8.3"
+            variant: nts
+          - php: "8.3"
+            variant: zts
+          - php: "8.4"
+            variant: nts
+          - php: "8.4"
+            variant: zts
+          - php: "8.5"
+            variant: nts
+          - php: "8.5"
+            variant: zts
+
+    steps:
+      - name: Download arm64 Bundle
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: php-firebird-${{ needs.prepare.outputs.version }}-php${{ matrix.php == '8.2' && '82' || matrix.php == '8.3' && '83' || matrix.php == '8.4' && '84' || '85' }}-${{ matrix.variant }}-macos-arm64
+          path: arm64-bundle
+
+      - name: Download x86_64 Bundle
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: php-firebird-${{ needs.prepare.outputs.version }}-php${{ matrix.php == '8.2' && '82' || matrix.php == '8.3' && '83' || matrix.php == '8.4' && '84' || '85' }}-${{ matrix.variant }}-macos-x86_64
+          path: x86_64-bundle
+
+      - name: Create Universal Binary
+        id: universal
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          PHP_VER="${{ matrix.php }}"
+          PHP_VER_SHORT="${PHP_VER//.}"
+          VARIANT="${{ matrix.variant }}"
+
+          ARM64_NAME="php-firebird-${VERSION}-php${PHP_VER_SHORT}-${VARIANT}-macos-arm64"
+          X64_NAME="php-firebird-${VERSION}-php${PHP_VER_SHORT}-${VARIANT}-macos-x86_64"
+          UNIVERSAL_NAME="php-firebird-${VERSION}-php${PHP_VER_SHORT}-${VARIANT}-macos-universal"
+
+          echo "Creating universal binary: ${UNIVERSAL_NAME}"
+
+          # Extract per-arch bundles
+          mkdir -p arm64-extracted x86_64-extracted
+          tar -xzf "arm64-bundle/${ARM64_NAME}.tar.gz" -C arm64-extracted --strip-components=1
+          tar -xzf "x86_64-bundle/${X64_NAME}.tar.gz" -C x86_64-extracted --strip-components=1
+
+          # Create universal bundle directory
+          DIST_DIR="dist/${UNIVERSAL_NAME}"
+          mkdir -p "${DIST_DIR}/lib"
+
+          # Combine firebird.so via lipo
+          echo "=== Creating universal firebird.so ==="
+          lipo -create \
+            arm64-extracted/firebird.so \
+            x86_64-extracted/firebird.so \
+            -output "${DIST_DIR}/firebird.so"
+          lipo -info "${DIST_DIR}/firebird.so"
+
+          # Combine libfbclient.dylib via lipo (if both architectures have it)
+          echo "=== Creating universal libfbclient.dylib ==="
+          ARM64_FBCLIENT=$(find arm64-extracted/lib -name "libfbclient*.dylib" ! -type l | head -1)
+          X64_FBCLIENT=$(find x86_64-extracted/lib -name "libfbclient*.dylib" ! -type l | head -1)
+
+          if [ -n "${ARM64_FBCLIENT}" ] && [ -n "${X64_FBCLIENT}" ]; then
+            lipo -create "${ARM64_FBCLIENT}" "${X64_FBCLIENT}" \
+              -output "${DIST_DIR}/lib/libfbclient.dylib"
+            lipo -info "${DIST_DIR}/lib/libfbclient.dylib"
+
+            # Set install name
+            install_name_tool -id "@rpath/libfbclient.dylib" "${DIST_DIR}/lib/libfbclient.dylib"
+          else
+            echo "WARNING: Could not find libfbclient.dylib for both architectures"
+            # Fall back to arm64 version
+            cp arm64-extracted/lib/libfbclient*.dylib "${DIST_DIR}/lib/" 2>/dev/null || true
+          fi
+
+          # Copy any other bundled dylibs (combine via lipo if present in both)
+          for arm_lib in arm64-extracted/lib/*.dylib; do
+            LIB_NAME=$(basename "$arm_lib")
+            [ "$LIB_NAME" = "libfbclient.dylib" ] && continue
+            [ -L "$arm_lib" ] && continue
+
+            X64_LIB="x86_64-extracted/lib/${LIB_NAME}"
+            if [ -f "$X64_LIB" ] && [ ! -L "$X64_LIB" ]; then
+              lipo -create "$arm_lib" "$X64_LIB" -output "${DIST_DIR}/lib/${LIB_NAME}" 2>/dev/null || \
+                cp "$arm_lib" "${DIST_DIR}/lib/${LIB_NAME}"
+            else
+              cp "$arm_lib" "${DIST_DIR}/lib/${LIB_NAME}"
+            fi
+          done
+
+          # Copy symlinks from arm64 bundle
+          for link in arm64-extracted/lib/*.dylib; do
+            [ -L "$link" ] || continue
+            LIB_NAME=$(basename "$link")
+            TARGET=$(readlink "$link")
+            [ ! -e "${DIST_DIR}/lib/${LIB_NAME}" ] && ln -sf "$TARGET" "${DIST_DIR}/lib/${LIB_NAME}" 2>/dev/null || true
+          done
+
+          # Copy docs
+          cp arm64-extracted/LICENSE "${DIST_DIR}/" 2>/dev/null || true
+          cat > "${DIST_DIR}/README.md" << EOF
+          # PHP Firebird Extension ${VERSION} - macOS Universal
+
+          Universal binary containing both arm64 (Apple Silicon) and x86_64 (Intel) slices.
+          Works on all modern Macs without Rosetta 2.
+
+          | Property | Value |
+          |----------|-------|
+          | **Extension Version** | ${VERSION} |
+          | **PHP Version** | ${PHP_VER} (${VARIANT}) |
+          | **Architecture** | Universal (arm64 + x86_64) |
+          | **Platform** | macOS |
+          EOF
+
+          # Verify universal binary
+          echo "=== Universal binary verification ==="
+          file "${DIST_DIR}/firebird.so"
+          lipo -info "${DIST_DIR}/firebird.so"
+          otool -L "${DIST_DIR}/firebird.so"
+
+          # Create tarball
+          tar -czvf "dist/${UNIVERSAL_NAME}.tar.gz" -C dist "${UNIVERSAL_NAME}"
+
+          # Checksums
+          cd dist
+          shasum -a 256 "${UNIVERSAL_NAME}.tar.gz" | awk '{print $1}' > "${UNIVERSAL_NAME}.tar.gz.sha256"
+          md5 -q "${UNIVERSAL_NAME}.tar.gz" > "${UNIVERSAL_NAME}.tar.gz.md5" 2>/dev/null || true
+          cd ..
+
+          echo "bundle_name=${UNIVERSAL_NAME}" >> $GITHUB_OUTPUT
+          echo "bundle_file=dist/${UNIVERSAL_NAME}.tar.gz" >> $GITHUB_OUTPUT
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          path: dist/${{ steps.universal.outputs.bundle_name }}
+          format: cyclonedx-json
+          output-file: dist/${{ steps.universal.outputs.bundle_name }}.sbom.cdx.json
+          artifact-name: ''
+
+      - name: Upload Universal Artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ${{ steps.universal.outputs.bundle_name }}
+          path: |
+            ${{ steps.universal.outputs.bundle_file }}
+            ${{ steps.universal.outputs.bundle_file }}.sha256
+            ${{ steps.universal.outputs.bundle_file }}.md5
+            dist/${{ steps.universal.outputs.bundle_name }}.sbom.cdx.json
+          retention-days: 30
+
+  # ===========================================================================
+  # Aggregate and Upload to Release
+  # ===========================================================================
+  release:
+    needs: [prepare, build, universal]
+    runs-on: ubuntu-24.04
+    if: |
+      github.event_name == 'release' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
+
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          path: artifacts
+
+      - name: Prepare Release Assets
+        run: |
+          mkdir -p release-assets
+
+          echo "Downloaded artifacts:"
+          find artifacts -type f -name "*.tar.gz*" | head -40
+
+          find artifacts -name "*.tar.gz" -exec cp {} release-assets/ \;
+          find artifacts -name "*.sha256" -exec cp {} release-assets/ \;
+          find artifacts -name "*.md5" -exec cp {} release-assets/ \;
+          find artifacts -name "*.sbom.cdx.json" -exec cp {} release-assets/ \;
+
+          echo ""
+          echo "Release assets:"
+          ls -la release-assets/
+
+          cd release-assets
+          sha256sum *.tar.gz > CHECKSUMS-SHA256.txt
+          md5sum *.tar.gz > CHECKSUMS-MD5.txt
+
+          echo ""
+          echo "CHECKSUMS-SHA256.txt:"
+          cat CHECKSUMS-SHA256.txt
+
+      - name: Determine Release Tag
+        id: release-tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          elif [ -n "${{ inputs.release_tag }}" ]; then
+            TAG="${{ inputs.release_tag }}"
+          else
+            TAG="v${{ needs.prepare.outputs.version }}"
+          fi
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Release tag: ${TAG}"
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: ${{ steps.release-tag.outputs.tag }}
+          files: |
+            release-assets/*.tar.gz
+            release-assets/*.sha256
+            release-assets/*.sbom.cdx.json
+            release-assets/CHECKSUMS-SHA256.txt
+          fail_on_unmatched_files: false
+          draft: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SLSA Provenance Attestations
+        run: |
+          echo "Generating SLSA provenance attestations for macOS release artifacts..."
+          for artifact in release-assets/*.tar.gz; do
+            echo "Attesting: $(basename "$artifact")"
+            gh attestation generate "$artifact" \
+              --repo "${{ github.repository }}" \
+              --signer github 2>&1 || echo "WARNING: Attestation failed for $(basename "$artifact")"
+          done
+          echo "Attestation generation complete."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ===========================================================================
+  # Test Bundles on macOS Runners
+  # ===========================================================================
+  test-bundles:
+    needs: [prepare, build]
+    runs-on: ${{ matrix.runner }}
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            arch: arm64
+            php_brew: php
+          - runner: macos-13
+            arch: x86_64
+            php_brew: php
+
+    steps:
+      - name: Install PHP via Homebrew
+        run: |
+          brew install ${{ matrix.php_brew }} 2>/dev/null || true
+          echo "PHP version: $(php -v | head -1)"
+
+      - name: Download Bundle
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          pattern: "*macos-${{ matrix.arch }}*nts*"
+          path: bundle
+          merge-multiple: true
+
+      - name: Test Bundle
+        run: |
+          set -e
+
+          echo "=== Testing macOS ${{ matrix.arch }} bundle ==="
+
+          # Find a bundle tarball
+          TARBALL=$(find bundle -name "*.tar.gz" | head -1)
+          if [ -z "$TARBALL" ]; then
+            echo "ERROR: No bundle tarball found"
+            ls -laR bundle || true
+            exit 1
+          fi
+
+          echo "Testing: $TARBALL"
+
+          # Extract
+          mkdir -p /tmp/test-bundle
+          tar -xzf "$TARBALL" -C /tmp/test-bundle --strip-components=1
+          cd /tmp/test-bundle
+
+          echo ""
+          echo "=== Bundle structure ==="
+          ls -la
+          ls -la lib/ 2>/dev/null || echo "No lib/ directory"
+
+          echo ""
+          echo "=== Verify firebird.so ==="
+          file firebird.so
+          lipo -info firebird.so 2>/dev/null || true
+
+          echo ""
+          echo "=== RPATH verification ==="
+          otool -l firebird.so | grep -A2 LC_RPATH || echo "No LC_RPATH"
+          otool -L firebird.so
+
+          echo ""
+          echo "=== Check libfbclient ==="
+          if ls lib/libfbclient*.dylib 2>/dev/null; then
+            echo "[OK] libfbclient found"
+          else
+            echo "[WARN] libfbclient not found in lib/"
+          fi
+
+          echo ""
+          echo "=== PHP extension load test ==="
+          PHP_MAJOR=$(php -r 'echo PHP_MAJOR_VERSION;')
+          PHP_MINOR=$(php -r 'echo PHP_MINOR_VERSION;')
+          echo "System PHP: ${PHP_MAJOR}.${PHP_MINOR}"
+
+          # Extract bundle PHP version from tarball name
+          BUNDLE_PHP=$(basename "$TARBALL" | sed -n 's/.*php\([0-9][0-9]*\).*/\1/p')
+          if [ -n "$BUNDLE_PHP" ]; then
+            BUNDLE_MAJOR=$(printf '%s' "$BUNDLE_PHP" | cut -c1)
+            BUNDLE_MINOR=$(printf '%s' "$BUNDLE_PHP" | cut -c2-)
+            echo "Bundle PHP: ${BUNDLE_MAJOR}.${BUNDLE_MINOR}"
+
+            if [ "$PHP_MAJOR" != "$BUNDLE_MAJOR" ] || [ "$PHP_MINOR" != "$BUNDLE_MINOR" ]; then
+              echo ">>> SKIP load test: PHP version mismatch"
+              echo ">>> Structure checks passed - bundle is valid"
+              exit 0
+            fi
+          fi
+
+          # Try loading the extension
+          LOAD_RESULT=$(php -d "extension=$(pwd)/firebird.so" -m 2>&1 || true)
+          if echo "$LOAD_RESULT" | grep -qi "^firebird$"; then
+            echo "[OK] Extension loaded successfully!"
+            FUNC_CHECK=$(php -d "extension=$(pwd)/firebird.so" -r "echo function_exists('fbird_connect') ? 'YES' : 'NO';" 2>/dev/null || echo "NO")
+            echo "fbird_connect available: $FUNC_CHECK"
+          else
+            echo "[WARN] Extension load failed (may be PHP version mismatch)"
+            echo "$LOAD_RESULT" | tail -5
+          fi
+
+          echo ""
+          echo "=== Test complete ==="

--- a/scripts/build-precompiled.sh
+++ b/scripts/build-precompiled.sh
@@ -42,11 +42,18 @@ set -euo pipefail
 PHP_VERSION=""
 VARIANT=""
 ARCH=""
+PLATFORM=""
 DRY_RUN=false
 SKIP_BUILD=false
 GENERATE_CHECKSUMS=true
 VERBOSE=false
 RUN_VERIFY=false
+
+# Auto-detect platform
+case "$(uname -s)" in
+    Darwin) PLATFORM="macos" ;;
+    *)      PLATFORM="linux" ;;
+esac
 
 # Auto-detect extension version
 if [ -f "VERSION" ]; then
@@ -68,21 +75,33 @@ FB_VERSION="5.0"
 FB_ROOT="${FB_ROOT:-/opt/firebird}"
 PHP_PREFIX="${PHP_PREFIX:-/opt/php}"
 
-# System libraries that should NOT be bundled (glibc and core system libs)
-SYSTEM_LIBS_WHITELIST=(
-    "linux-vdso.so"
-    "ld-linux"
-    "libc.so"
-    "libpthread.so"
-    "libdl.so"
-    "libm.so"
-    "librt.so"
-    "libresolv.so"
-    "libnsl.so"
-    "libcrypt.so"
-    "libgcc_s.so"
-    "libstdc++.so"
-)
+# System libraries that should NOT be bundled
+if [ "$PLATFORM" = "macos" ]; then
+    SYSTEM_LIBS_WHITELIST=(
+        "libSystem"
+        "libc++.1.dylib"
+        "libc++abi.dylib"
+        "libobjc.A.dylib"
+        "libz.1.dylib"
+        "/usr/lib/lib"
+        "/System/Library/"
+    )
+else
+    SYSTEM_LIBS_WHITELIST=(
+        "linux-vdso.so"
+        "ld-linux"
+        "libc.so"
+        "libpthread.so"
+        "libdl.so"
+        "libm.so"
+        "librt.so"
+        "libresolv.so"
+        "libnsl.so"
+        "libcrypt.so"
+        "libgcc_s.so"
+        "libstdc++.so"
+    )
+fi
 
 # Library search paths
 LIB_SEARCH_PATHS=(
@@ -157,6 +176,8 @@ is_system_lib() {
 # Find library in search paths
 find_library() {
     local lib_name="$1"
+    local ext_pattern="so"
+    [ "$PLATFORM" = "macos" ] && ext_pattern="dylib"
     
     for search_path in "${LIB_SEARCH_PATHS[@]}"; do
         # Try exact name
@@ -166,8 +187,9 @@ find_library() {
         fi
         
         # Try with wildcard for version suffixes
-        local base_name="${lib_name%.so*}"
-        for found in "${search_path}/${base_name}.so"*; do
+        local base_name="${lib_name%.${ext_pattern}*}"
+        base_name="${base_name%.so*}"  # Also strip .so if searching cross-platform
+        for found in "${search_path}/${base_name}.${ext_pattern}"* "${search_path}/${base_name}.so"*; do
             if [ -f "$found" ]; then
                 echo "$found"
                 return 0
@@ -230,19 +252,27 @@ bundle_library() {
             ln -sf "$real_name" "${dest_dir}/${lib_name}"
         fi
         
-        # CRITICAL: Create SONAME symlink (e.g., libfbclient.so.2 -> libfbclient.so.5.0.3)
-        # The extension links against the SONAME, not the versioned filename
-        local soname
-        soname=$(objdump -p "$real_path" 2>/dev/null | grep -E '^\s+SONAME' | awk '{print $2}' || true)
-        if [ -n "$soname" ] && [ "$soname" != "$real_name" ] && [ ! -e "${dest_dir}/${soname}" ]; then
-            ln -sf "$real_name" "${dest_dir}/${soname}"
-            log_verbose "${indent}  Created SONAME symlink: ${soname} -> ${real_name}"
-        fi
-        
-        # Also create .so symlink if needed (without version suffix)
-        local base="${lib_name%%.*}"
-        if [ ! -e "${dest_dir}/${base}.so" ]; then
-            ln -sf "$real_name" "${dest_dir}/${base}.so" 2>/dev/null || true
+        if [ "$PLATFORM" = "macos" ]; then
+            # macOS: Create install_name symlinks for dylibs
+            local base="${lib_name%%.*}"
+            if [ ! -e "${dest_dir}/${base}.dylib" ]; then
+                ln -sf "$real_name" "${dest_dir}/${base}.dylib" 2>/dev/null || true
+            fi
+        else
+            # CRITICAL: Create SONAME symlink (e.g., libfbclient.so.2 -> libfbclient.so.5.0.3)
+            # The extension links against the SONAME, not the versioned filename
+            local soname
+            soname=$(objdump -p "$real_path" 2>/dev/null | grep -E '^\s+SONAME' | awk '{print $2}' || true)
+            if [ -n "$soname" ] && [ "$soname" != "$real_name" ] && [ ! -e "${dest_dir}/${soname}" ]; then
+                ln -sf "$real_name" "${dest_dir}/${soname}"
+                log_verbose "${indent}  Created SONAME symlink: ${soname} -> ${real_name}"
+            fi
+            
+            # Also create .so symlink if needed (without version suffix)
+            local base="${lib_name%%.*}"
+            if [ ! -e "${dest_dir}/${base}.so" ]; then
+                ln -sf "$real_name" "${dest_dir}/${base}.so" 2>/dev/null || true
+            fi
         fi
     fi
     
@@ -253,7 +283,12 @@ bundle_library() {
     # Trace transitive dependencies (max depth 5)
     if [ "$depth" -lt 5 ]; then
         local deps
-        deps=$(ldd "$real_path" 2>/dev/null | grep "=> /" | awk '{print $3}' || true)
+        if [ "$PLATFORM" = "macos" ]; then
+            # macOS: otool -L lists linked libraries
+            deps=$(otool -L "$real_path" 2>/dev/null | tail -n +2 | awk '{print $1}' | grep -v "^@" || true)
+        else
+            deps=$(ldd "$real_path" 2>/dev/null | grep "=> /" | awk '{print $3}' || true)
+        fi
         
         for dep in $deps; do
             local dep_name
@@ -381,7 +416,7 @@ ARCH="${ARCH:-x86_64}"
 # =============================================================================
 
 PHP_VER_SHORT="${PHP_VERSION//.}"
-DIST_NAME="php-firebird-${EXT_VERSION}-php${PHP_VER_SHORT}-${VARIANT}-linux-${ARCH}"
+DIST_NAME="php-firebird-${EXT_VERSION}-php${PHP_VER_SHORT}-${VARIANT}-${PLATFORM}-${ARCH}"
 DIST_DIR="dist/${DIST_NAME}"
 
 # =============================================================================
@@ -402,9 +437,14 @@ echo ""
 
 # Check required tools
 check_command make
-check_command patchelf
 check_command tar
-check_command objdump
+if [ "$PLATFORM" = "macos" ]; then
+    check_command install_name_tool
+    check_command otool
+else
+    check_command patchelf
+    check_command objdump
+fi
 
 if [ "$SKIP_BUILD" = false ]; then
     check_command phpize
@@ -500,17 +540,24 @@ log_info "Bundling libraries with transitive dependencies..."
 
 # Find and bundle libfbclient
 FB_CLIENT=""
+if [ "$PLATFORM" = "macos" ]; then
+    FB_LIB_PATTERNS=("libfbclient.dylib" "libfbclient.dylib*")
+else
+    FB_LIB_PATTERNS=("libfbclient.so*")
+fi
 for path in "${LIB_SEARCH_PATHS[@]}"; do
-    for lib in "${path}"/libfbclient.so*; do
-        if [ -f "$lib" ]; then
-            FB_CLIENT="$lib"
-            break 2
-        fi
+    for pattern in "${FB_LIB_PATTERNS[@]}"; do
+        for lib in "${path}"/${pattern}; do
+            if [ -f "$lib" ]; then
+                FB_CLIENT="$lib"
+                break 3
+            fi
+        done
     done
 done
 
 if [ -z "$FB_CLIENT" ]; then
-    log_error "libfbclient.so not found!"
+    log_error "libfbclient not found!"
     exit 1
 fi
 
@@ -574,20 +621,47 @@ done
 log_info "Patching RPATH for main extension..."
 
 if [ "$DRY_RUN" = true ]; then
-    log_dry_run "Would run: patchelf --force-rpath --set-rpath '\$ORIGIN/lib' ${DIST_DIR}/firebird.so"
+    if [ "$PLATFORM" = "macos" ]; then
+        log_dry_run "Would run: install_name_tool -add_rpath @loader_path/lib ${DIST_DIR}/firebird.so"
+    else
+        log_dry_run "Would run: patchelf --force-rpath --set-rpath '\$ORIGIN/lib' ${DIST_DIR}/firebird.so"
+    fi
 else
-    patchelf --force-rpath --set-rpath '$ORIGIN/lib' "${DIST_DIR}/firebird.so"
+    if [ "$PLATFORM" = "macos" ]; then
+        # macOS: add @loader_path/lib rpath and rewrite libfbclient reference
+        install_name_tool -add_rpath @loader_path/lib "${DIST_DIR}/firebird.so" 2>/dev/null || true
+        # Rewrite libfbclient dependency to use @rpath
+        FBCLIENT_DEP=$(otool -L "${DIST_DIR}/firebird.so" 2>/dev/null | grep libfbclient | awk '{print $1}' | head -1 || true)
+        if [ -n "$FBCLIENT_DEP" ]; then
+            install_name_tool -change "$FBCLIENT_DEP" "@rpath/libfbclient.dylib" "${DIST_DIR}/firebird.so"
+            log_verbose "  Rewrote libfbclient dep: $FBCLIENT_DEP -> @rpath/libfbclient.dylib"
+        fi
+    else
+        patchelf --force-rpath --set-rpath '$ORIGIN/lib' "${DIST_DIR}/firebird.so"
+    fi
 fi
 
 log_info "Patching RPATH for bundled libraries..."
 if [ "$DRY_RUN" = false ]; then
-    for so in "${DIST_DIR}"/lib/*.so*; do
-        if [[ -f "$so" && ! -L "$so" ]]; then
-            # Libraries in lib/ need $ORIGIN to find each other
-            patchelf --force-rpath --set-rpath '$ORIGIN' "$so" 2>/dev/null || true
-            log_verbose "  Patched: $(basename "$so")"
-        fi
-    done
+    if [ "$PLATFORM" = "macos" ]; then
+        for dylib in "${DIST_DIR}"/lib/*.dylib; do
+            if [[ -f "$dylib" && ! -L "$dylib" ]]; then
+                # Set install_name to @rpath-relative for relocatability
+                local_name=$(basename "$dylib")
+                install_name_tool -id "@rpath/${local_name}" "$dylib" 2>/dev/null || true
+                install_name_tool -add_rpath @loader_path "$dylib" 2>/dev/null || true
+                log_verbose "  Patched: ${local_name}"
+            fi
+        done
+    else
+        for so in "${DIST_DIR}"/lib/*.so*; do
+            if [[ -f "$so" && ! -L "$so" ]]; then
+                # Libraries in lib/ need $ORIGIN to find each other
+                patchelf --force-rpath --set-rpath '$ORIGIN' "$so" 2>/dev/null || true
+                log_verbose "  Patched: $(basename "$so")"
+            fi
+        done
+    fi
 fi
 
 # =============================================================================
@@ -830,18 +904,27 @@ log_info "Verifying bundle..."
 
 if [ "$DRY_RUN" = false ]; then
     echo ""
-    echo "RPATH of firebird.so:"
-    patchelf --print-rpath "${DIST_DIR}/firebird.so"
+    if [ "$PLATFORM" = "macos" ]; then
+        echo "RPATH of firebird.so:"
+        otool -l "${DIST_DIR}/firebird.so" 2>/dev/null | grep -A2 "LC_RPATH" || echo "  (no rpath)"
 
-    echo ""
-    echo "Dependencies:"
-    (cd "${DIST_DIR}" && ldd firebird.so) || true
+        echo ""
+        echo "Dependencies:"
+        otool -L "${DIST_DIR}/firebird.so" || true
+    else
+        echo "RPATH of firebird.so:"
+        patchelf --print-rpath "${DIST_DIR}/firebird.so"
 
-    # Check for missing dependencies
-    MISSING=$(cd "${DIST_DIR}" && ldd firebird.so 2>&1 | grep "not found" || true)
-    if [ -n "${MISSING}" ]; then
-        log_warn "Some dependencies not found (may be OK if they're glibc system libs):"
-        echo "${MISSING}"
+        echo ""
+        echo "Dependencies:"
+        (cd "${DIST_DIR}" && ldd firebird.so) || true
+
+        # Check for missing dependencies
+        MISSING=$(cd "${DIST_DIR}" && ldd firebird.so 2>&1 | grep "not found" || true)
+        if [ -n "${MISSING}" ]; then
+            log_warn "Some dependencies not found (may be OK if they're glibc system libs):"
+            echo "${MISSING}"
+        fi
     fi
 
     echo ""

--- a/scripts/verify-bundle.sh
+++ b/scripts/verify-bundle.sh
@@ -38,6 +38,7 @@ set -euo pipefail
 
 BUNDLE_PATH=""
 PHP_BINARY="php"
+PLATFORM=""
 RUN_CONNECTION_TEST=false
 FB_DSN=""
 FB_USER="SYSDBA"
@@ -175,6 +176,12 @@ if [ -z "$BUNDLE_PATH" ]; then
     exit 1
 fi
 
+# Auto-detect platform
+case "$(uname -s)" in
+    Darwin) PLATFORM="macos" ;;
+    *)      PLATFORM="linux" ;;
+esac
+
 # =============================================================================
 # Prepare Bundle Directory
 # =============================================================================
@@ -229,17 +236,22 @@ fi
 if [ -d "$BUNDLE_DIR/lib" ]; then
     log_pass "lib/ directory exists"
     
-    LIB_COUNT=$(find "$BUNDLE_DIR/lib" -name "*.so*" -type f | wc -l)
+    if [ "$PLATFORM" = "macos" ]; then
+        LIB_COUNT=$(find "$BUNDLE_DIR/lib" \( -name "*.dylib" -o -name "*.so" \) -type f | wc -l)
+    else
+        LIB_COUNT=$(find "$BUNDLE_DIR/lib" -name "*.so*" -type f | wc -l)
+    fi
     log_info "Found $LIB_COUNT library files in lib/"
 else
     log_fail "lib/ directory not found"
 fi
 
 # Check libfbclient
-if ls "$BUNDLE_DIR"/lib/libfbclient.so* &>/dev/null 2>&1; then
-    log_pass "libfbclient.so found"
+if ls "$BUNDLE_DIR"/lib/libfbclient.so* &>/dev/null 2>&1 || \
+   ls "$BUNDLE_DIR"/lib/libfbclient.dylib* &>/dev/null 2>&1; then
+    log_pass "libfbclient found"
 else
-    log_fail "libfbclient.so not found in lib/"
+    log_fail "libfbclient not found in lib/"
 fi
 
 # Check documentation
@@ -259,44 +271,66 @@ echo ""
 
 echo "--- Check 2: RPATH Configuration ---"
 
-if ! check_command patchelf; then
-    log_warn "patchelf not installed, skipping RPATH checks"
+if [ "$PLATFORM" = "macos" ]; then
+    # macOS: use otool to inspect load commands
+    RPATH_OUTPUT=$(otool -l "$BUNDLE_DIR/firebird.so" 2>/dev/null | grep -A2 "LC_RPATH" || true)
+    log_verbose "firebird.so LC_RPATH entries: $RPATH_OUTPUT"
+    
+    if echo "$RPATH_OUTPUT" | grep -q "@loader_path"; then
+        log_pass "firebird.so has @loader_path rpath"
+    else
+        log_warn "firebird.so missing @loader_path rpath"
+    fi
+    
+    # Check libfbclient dependency uses @rpath
+    FBCLIENT_DEP=$(otool -L "$BUNDLE_DIR/firebird.so" 2>/dev/null | grep libfbclient | awk '{print $1}' || true)
+    if [[ "$FBCLIENT_DEP" == @rpath/* ]]; then
+        log_pass "libfbclient linked via @rpath"
+    elif [ -n "$FBCLIENT_DEP" ]; then
+        log_warn "libfbclient linked as absolute path: $FBCLIENT_DEP"
+    fi
+    
+    # Check universal binary (if applicable)
+    if command -v lipo &>/dev/null; then
+        ARCHS=$(lipo -info "$BUNDLE_DIR/firebird.so" 2>/dev/null | sed 's/.*: //' || true)
+        log_info "Architecture(s): $ARCHS"
+    fi
 else
-    # Check firebird.so RPATH
-    EXT_RPATH=$(patchelf --print-rpath "$BUNDLE_DIR/firebird.so" 2>/dev/null || echo "")
-    log_verbose "firebird.so RPATH: $EXT_RPATH"
-    
-    if [[ "$EXT_RPATH" == *'$ORIGIN/lib'* ]] || [[ "$EXT_RPATH" == *'$ORIGIN'* ]]; then
-        log_pass "firebird.so RPATH contains \$ORIGIN"
+    if ! check_command patchelf; then
+        log_warn "patchelf not installed, skipping RPATH checks"
     else
-        log_fail "firebird.so RPATH should contain \$ORIGIN/lib (got: $EXT_RPATH)"
-    fi
-    
-    # Check if using DT_RPATH (--force-rpath) vs DT_RUNPATH
-    if readelf -d "$BUNDLE_DIR/firebird.so" 2>/dev/null | grep -q "RPATH"; then
-        log_pass "Using DT_RPATH (stronger precedence)"
-    elif readelf -d "$BUNDLE_DIR/firebird.so" 2>/dev/null | grep -q "RUNPATH"; then
-        log_warn "Using DT_RUNPATH (may be overridden by LD_LIBRARY_PATH)"
-    fi
-    
-    # Check library RPATHs
-    LIB_RPATH_ERRORS=0
-    for so in "$BUNDLE_DIR"/lib/*.so*; do
-        if [[ -f "$so" && ! -L "$so" ]]; then
-            LIB_RPATH=$(patchelf --print-rpath "$so" 2>/dev/null || echo "none")
-            log_verbose "$(basename "$so") RPATH: $LIB_RPATH"
-            
-            if [[ "$LIB_RPATH" != *'$ORIGIN'* ]] && [[ "$LIB_RPATH" != "none" ]] && [[ -n "$LIB_RPATH" ]]; then
-                log_verbose "Warning: $(basename "$so") has non-relative RPATH: $LIB_RPATH"
-                ((LIB_RPATH_ERRORS++))
-            fi
+        EXT_RPATH=$(patchelf --print-rpath "$BUNDLE_DIR/firebird.so" 2>/dev/null || echo "")
+        log_verbose "firebird.so RPATH: $EXT_RPATH"
+        
+        if [[ "$EXT_RPATH" == *'$ORIGIN/lib'* ]] || [[ "$EXT_RPATH" == *'$ORIGIN'* ]]; then
+            log_pass "firebird.so RPATH contains \$ORIGIN"
+        else
+            log_fail "firebird.so RPATH should contain \$ORIGIN/lib (got: $EXT_RPATH)"
         fi
-    done
-    
-    if [ "$LIB_RPATH_ERRORS" -eq 0 ]; then
-        log_pass "Bundled libraries have correct RPATH"
-    else
-        log_warn "$LIB_RPATH_ERRORS library(ies) have non-\$ORIGIN RPATH"
+        
+        if readelf -d "$BUNDLE_DIR/firebird.so" 2>/dev/null | grep -q "RPATH"; then
+            log_pass "Using DT_RPATH (stronger precedence)"
+        elif readelf -d "$BUNDLE_DIR/firebird.so" 2>/dev/null | grep -q "RUNPATH"; then
+            log_warn "Using DT_RUNPATH (may be overridden by LD_LIBRARY_PATH)"
+        fi
+        
+        LIB_RPATH_ERRORS=0
+        for so in "$BUNDLE_DIR"/lib/*.so*; do
+            if [[ -f "$so" && ! -L "$so" ]]; then
+                LIB_RPATH=$(patchelf --print-rpath "$so" 2>/dev/null || echo "none")
+                log_verbose "$(basename "$so") RPATH: $LIB_RPATH"
+                if [[ "$LIB_RPATH" != *'$ORIGIN'* ]] && [[ "$LIB_RPATH" != "none" ]] && [[ -n "$LIB_RPATH" ]]; then
+                    log_verbose "Warning: $(basename "$so") has non-relative RPATH: $LIB_RPATH"
+                    ((LIB_RPATH_ERRORS++))
+                fi
+            fi
+        done
+        
+        if [ "$LIB_RPATH_ERRORS" -eq 0 ]; then
+            log_pass "Bundled libraries have correct RPATH"
+        else
+            log_warn "$LIB_RPATH_ERRORS library(ies) have non-\$ORIGIN RPATH"
+        fi
     fi
 fi
 
@@ -308,43 +342,73 @@ echo ""
 
 echo "--- Check 3: Dependency Resolution ---"
 
-# Run ldd from within bundle directory to test $ORIGIN resolution
-MISSING_DEPS=""
-NOT_FOUND_COUNT=0
-
-if check_command ldd; then
-    # Change to bundle directory so $ORIGIN resolves correctly
-    pushd "$BUNDLE_DIR" > /dev/null
-    
-    LDD_OUTPUT=$(ldd firebird.so 2>&1 || true)
-    
-    popd > /dev/null
-    
-    log_verbose "ldd output:"
+if [ "$PLATFORM" = "macos" ]; then
+    # macOS: use otool -L
+    OTOOL_OUTPUT=$(otool -L "$BUNDLE_DIR/firebird.so" 2>&1 || true)
+    log_verbose "otool -L output:"
     if [ "$VERBOSE" = true ]; then
-        echo "$LDD_OUTPUT" | sed 's/^/  /'
+        echo "$OTOOL_OUTPUT" | sed 's/^/  /'
     fi
     
-    # Check for "not found" dependencies
-    MISSING_DEPS=$(echo "$LDD_OUTPUT" | grep "not found" || true)
-    
-    if [ -n "$MISSING_DEPS" ]; then
-        # Filter out expected system library mismatches (glibc version specific)
-        CRITICAL_MISSING=$(echo "$MISSING_DEPS" | grep -v "^$" || true)
-        NOT_FOUND_COUNT=$(echo "$CRITICAL_MISSING" | grep -c "not found" || echo 0)
-        
-        if [ "$NOT_FOUND_COUNT" -gt 0 ]; then
-            log_fail "Missing dependencies detected ($NOT_FOUND_COUNT):"
-            echo "$CRITICAL_MISSING" | sed 's/^/  /'
+    # Check all non-system, non-@rpath deps can be found
+    MISSING_COUNT=0
+    while IFS= read -r dep_line; do
+        dep_path=$(echo "$dep_line" | awk '{print $1}')
+        [ -z "$dep_path" ] && continue
+        # Skip @rpath/@loader_path (resolved at runtime) and system paths
+        [[ "$dep_path" == @* ]] && continue
+        [[ "$dep_path" == /usr/lib/* ]] && continue
+        [[ "$dep_path" == /System/* ]] && continue
+        if [ ! -f "$dep_path" ]; then
+            log_verbose "Dependency not at absolute path: $dep_path (expected via @rpath)"
+            ((MISSING_COUNT++)) || true
         fi
-    else
-        log_pass "All dependencies resolved"
-    fi
+    done <<< "$(echo "$OTOOL_OUTPUT" | tail -n +2)"
     
-    # List resolved dependencies
-    RESOLVED=$(echo "$LDD_OUTPUT" | grep "=> /" | wc -l)
-    BUNDLED=$(echo "$LDD_OUTPUT" | grep "\$ORIGIN" | wc -l || echo 0)
-    log_info "Resolved: $RESOLVED system, $BUNDLED bundled"
+    # For @rpath deps, verify the lib exists in bundle
+    RPATH_DEPS=$(echo "$OTOOL_OUTPUT" | tail -n +2 | awk '{print $1}' | grep "^@rpath/" || true)
+    RPATH_MISSING=0
+    for rdep in $RPATH_DEPS; do
+        local_name="${rdep#@rpath/}"
+        if [ ! -f "$BUNDLE_DIR/lib/$local_name" ]; then
+            log_fail "@rpath dependency not in bundle: $local_name"
+            ((RPATH_MISSING++))
+        fi
+    done
+    
+    if [ "$RPATH_MISSING" -eq 0 ]; then
+        log_pass "All @rpath dependencies found in bundle"
+    fi
+else
+    MISSING_DEPS=""
+    NOT_FOUND_COUNT=0
+    
+    if check_command ldd; then
+        pushd "$BUNDLE_DIR" > /dev/null
+        LDD_OUTPUT=$(ldd firebird.so 2>&1 || true)
+        popd > /dev/null
+        
+        log_verbose "ldd output:"
+        if [ "$VERBOSE" = true ]; then
+            echo "$LDD_OUTPUT" | sed 's/^/  /'
+        fi
+        
+        MISSING_DEPS=$(echo "$LDD_OUTPUT" | grep "not found" || true)
+        if [ -n "$MISSING_DEPS" ]; then
+            CRITICAL_MISSING=$(echo "$MISSING_DEPS" | grep -v "^$" || true)
+            NOT_FOUND_COUNT=$(echo "$CRITICAL_MISSING" | grep -c "not found" || echo 0)
+            if [ "$NOT_FOUND_COUNT" -gt 0 ]; then
+                log_fail "Missing dependencies detected ($NOT_FOUND_COUNT):"
+                echo "$CRITICAL_MISSING" | sed 's/^/  /'
+            fi
+        else
+            log_pass "All dependencies resolved"
+        fi
+        
+        RESOLVED=$(echo "$LDD_OUTPUT" | grep "=> /" | wc -l)
+        BUNDLED=$(echo "$LDD_OUTPUT" | grep "\$ORIGIN" | wc -l || echo 0)
+        log_info "Resolved: $RESOLVED system, $BUNDLED bundled"
+    fi
 fi
 
 echo ""
@@ -356,7 +420,11 @@ echo ""
 echo "--- Check 4: System Library Verification ---"
 
 # These should NOT be bundled (system libc)
-FORBIDDEN_LIBS=("libc.so" "libpthread.so" "libdl.so" "libm.so" "librt.so" "ld-linux")
+if [ "$PLATFORM" = "macos" ]; then
+    FORBIDDEN_LIBS=("libSystem.B.dylib" "libc++.1.dylib")
+else
+    FORBIDDEN_LIBS=("libc.so" "libpthread.so" "libdl.so" "libm.so" "librt.so" "ld-linux")
+fi
 
 for lib in "${FORBIDDEN_LIBS[@]}"; do
     if ls "$BUNDLE_DIR"/lib/"$lib"* &>/dev/null 2>&1; then
@@ -371,7 +439,8 @@ REQUIRED_LIBS=("libfbclient")
 OPTIONAL_LIBS=("libicuuc" "libicudata" "libtommath" "libtomcrypt")
 
 for lib in "${REQUIRED_LIBS[@]}"; do
-    if ls "$BUNDLE_DIR"/lib/"$lib".so* &>/dev/null 2>&1; then
+    if ls "$BUNDLE_DIR"/lib/"$lib".so* &>/dev/null 2>&1 || \
+       ls "$BUNDLE_DIR"/lib/"$lib".dylib* &>/dev/null 2>&1; then
         log_pass "Required library bundled: $lib"
     else
         log_fail "Required library missing: $lib"
@@ -379,7 +448,8 @@ for lib in "${REQUIRED_LIBS[@]}"; do
 done
 
 for lib in "${OPTIONAL_LIBS[@]}"; do
-    if ls "$BUNDLE_DIR"/lib/"$lib".so* &>/dev/null 2>&1; then
+    if ls "$BUNDLE_DIR"/lib/"$lib".so* &>/dev/null 2>&1 || \
+       ls "$BUNDLE_DIR"/lib/"$lib".dylib* &>/dev/null 2>&1; then
         log_pass "Optional library bundled: $lib"
     else
         log_warn "Optional library not bundled: $lib (may cause runtime issues)"


### PR DESCRIPTION
## Summary

Implements Phase 2 of the v10.6.0 Platform Expansion milestone - macOS universal binary builds.

Closes #174

## Changes

### New Files
- **.github/scripts/extract-firebird-macos.sh** - Firebird SDK extraction from macOS .pkg with types_pub.h header fix
- **.github/workflows/release-macos.yml** - Full macOS release workflow (PHP 8.2-8.5 x NTS/ZTS x arm64/x86_64, universal binaries via lipo)

### Modified Files
- **scripts/build-precompiled.sh** - macOS platform support (install_name_tool, otool, @loader_path, .dylib)
- **scripts/verify-bundle.sh** - macOS verification (otool -L, @rpath checks, lipo -info)
- **.github/workflows/ci.yml** - Simplified macOS CI job using shared extraction script