### PR TITLE
fix(release): resolve SIGPIPE, SBOM, and iconv failures

### DIFF
--- a/.github/scripts/build-firebird-musl.sh
+++ b/.github/scripts/build-firebird-musl.sh
@@ -144,10 +144,11 @@ echo ">>> Installing to ${FB_ROOT}..."
 mkdir -p "${FB_ROOT}/lib" "${FB_ROOT}/include/firebird"
 
 # Find and copy the built libfbclient
-LIBFB=$(find /tmp/fb-src -name "libfbclient.so*" -type f | head -1)
+# Use -quit to avoid SIGPIPE from find|head under set -euo pipefail
+LIBFB=$(find /tmp/fb-src -name "libfbclient.so*" -type f -print -quit)
 if [ -z "${LIBFB}" ]; then
   # Try gen/ directory (common Firebird build output location)
-  LIBFB=$(find /tmp/fb-src/gen -name "libfbclient.so*" -type f 2>/dev/null | head -1)
+  LIBFB=$(find /tmp/fb-src/gen -name "libfbclient.so*" -type f -print -quit 2>/dev/null)
 fi
 
 if [ -z "${LIBFB}" ]; then
@@ -169,7 +170,7 @@ done
 # Ensure symlinks exist
 cd "${FB_ROOT}/lib"
 if [ ! -e libfbclient.so ]; then
-  REAL=$(ls libfbclient.so.* 2>/dev/null | head -1)
+  REAL=$(ls libfbclient.so.* 2>/dev/null | head -1 || true)
   [ -n "${REAL}" ] && ln -sf "${REAL}" libfbclient.so
 fi
 
@@ -180,13 +181,13 @@ find /tmp/fb-src -path "*/include/ibase.h" -exec cp {} "${FB_ROOT}/include/" \; 
 find /tmp/fb-src -path "*/include/iberror.h" -exec cp {} "${FB_ROOT}/include/" \; 2>/dev/null
 
 # Copy firebird subdirectory headers (Interface.h etc.)
-FB_INCLUDE_DIR=$(find /tmp/fb-src -path "*/include/firebird" -type d | head -1)
+FB_INCLUDE_DIR=$(find /tmp/fb-src -path "*/include/firebird" -type d -print -quit)
 if [ -n "${FB_INCLUDE_DIR}" ]; then
   cp -r "${FB_INCLUDE_DIR}"/* "${FB_ROOT}/include/firebird/" 2>/dev/null || true
 fi
 
 # Also check gen/Release/firebird/include for generated headers
-GEN_INCLUDE=$(find /tmp/fb-src/gen -path "*/include" -type d 2>/dev/null | head -1)
+GEN_INCLUDE=$(find /tmp/fb-src/gen -path "*/include" -type d -print -quit 2>/dev/null || true)
 if [ -n "${GEN_INCLUDE}" ]; then
   cp -n "${GEN_INCLUDE}"/*.h "${FB_ROOT}/include/" 2>/dev/null || true
   [ -d "${GEN_INCLUDE}/firebird" ] && cp -rn "${GEN_INCLUDE}/firebird/"* "${FB_ROOT}/include/firebird/" 2>/dev/null || true

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -514,6 +514,7 @@ jobs:
           ls -la dist/
       
       - name: Generate SBOM (CycloneDX)
+        continue-on-error: true  # sbom-action may fail in manylinux/musl containers
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: dist/${{ steps.bundle.outputs.bundle_name }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -209,6 +209,9 @@ jobs:
           tar -xJf /tmp/php.tar.xz -C /tmp/php-src --strip-components=1
           cd /tmp/php-src
 
+          # Homebrew iconv is keg-only; PHP configure cannot find it without explicit path
+          ICONV_PREFIX="$(brew --prefix libiconv 2>/dev/null || echo "")"
+          
           CONFIGURE_OPTS=(
             "--prefix=${INSTALL_DIR}"
             "--enable-cli"
@@ -223,7 +226,11 @@ jobs:
             "--with-zlib"
             "--with-curl"
           )
-
+          
+          if [ -n "${ICONV_PREFIX}" ] && [ -d "${ICONV_PREFIX}" ]; then
+            CONFIGURE_OPTS+=("--with-iconv=${ICONV_PREFIX}")
+          fi
+          
           if [ "${VARIANT}" = "zts" ]; then
             CONFIGURE_OPTS+=("--enable-zts")
           fi


### PR DESCRIPTION
Fixes 3 release workflow failures for v10.6.0 tag push:
- **SIGPIPE (exit 141)**: `find|head` replaced with `find -print -quit` in musl build script
- **SBOM failure**: `continue-on-error: true` for anchore/sbom-action in manylinux/musl containers
- **iconv not found**: Added `--with-iconv=$(brew --prefix libiconv)` for macOS arm64 PHP builds