### PR TITLE
fix(release): exclude musl+aarch64 from Linux matrix

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -112,6 +112,12 @@ jobs:
             for variant in nts zts; do
               for arch in x86_64 aarch64; do
                 for libc in glibc musl; do
+                  # Skip musl+aarch64: GitHub Actions JS actions (checkout, upload-artifact)
+                  # do not run inside Alpine containers on ARM64 runners.
+                  # See: "JavaScript Actions in Alpine containers are only supported on x64 Linux runners"
+                  if [ "${libc}" = "musl" ] && [ "${arch}" = "aarch64" ]; then
+                    continue
+                  fi
                   if [ "$FIRST" = true ]; then
                     FIRST=false
                   else


### PR DESCRIPTION
GitHub Actions JS actions cannot run inside Alpine containers on ARM64 runners. Excludes musl+aarch64 (reduces Linux from 32 to 24 builds). Can be added later with Docker-based approach.