### PR TITLE
fix(ci): musl bash shell + macOS libiconv for release workflows

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -334,6 +334,7 @@ jobs:
           echo "PHP full version: ${FULL_VERSION}"
       
       - name: Install PHP ${{ matrix.php }} (${{ matrix.variant }})
+        shell: bash
         run: |
           FULL_VERSION="${{ steps.php-version.outputs.full_version }}"
           VARIANT="${{ matrix.variant }}"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install Build Dependencies
         run: |
           # Install build tools via Homebrew (some already present on runners)
-          brew install autoconf automake libtool re2c bison pkg-config 2>/dev/null || true
+          brew install autoconf automake libtool re2c bison pkg-config libiconv 2>/dev/null || true
           echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
 
       - name: Build PHP ${{ matrix.php }} (${{ matrix.variant }})


### PR DESCRIPTION
Round 4 workflow fixes for v10.6.0 release:

- **Linux musl**: Add `shell: bash` to 'Install PHP' step. Musl containers default to ash which doesn't support bash arrays (`CONFIGURE_OPTS=(...)`), causing `syntax error: unexpected (` on all 8 musl builds.
- **macOS**: Add `libiconv` to `brew install`. Homebrew's libiconv is keg-only and not pre-installed on GitHub runners, causing `configure: error: Please specify the install prefix of iconv` on all 16 macOS builds.

Fixes 24 of the 25 failed jobs from the previous v10.6.0 tag push.