### PR TITLE
fix(ci): add php-pdo to test-bundles deps (Alpine + Fedora)

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -715,16 +715,18 @@ jobs:
             # Install PHP and dependencies (plus bash for the rest of the script)
             if command -v apk >/dev/null 2>&1; then
               # Alpine Linux (musl)
-              apk add --no-cache bash php83 php83-cli patchelf binutils file grep
+              # php83-pdo required: firebird.so integrates pdo_fbird when built against PDO-enabled PHP
+              apk add --no-cache bash php83 php83-cli php83-pdo patchelf binutils file grep
               ln -sf /usr/bin/php83 /usr/bin/php 2>/dev/null || true
             elif command -v apt-get >/dev/null 2>&1; then
               export DEBIAN_FRONTEND=noninteractive
               apt-get update
-              apt-get install -y php-cli patchelf binutils file || apt-get install -y php-cli binutils file
+              apt-get install -y php-cli php-pdo patchelf binutils file || apt-get install -y php-cli binutils file
             elif command -v dnf &>/dev/null; then
               # Enable EPEL for patchelf on RHEL/AlmaLinux
               dnf install -y epel-release || true
-              dnf install -y php-cli patchelf binutils file || dnf install -y php-cli binutils file
+              # php-pdo required: firebird.so integrates pdo_fbird when built against PDO-enabled PHP
+              dnf install -y php-cli php-pdo patchelf binutils file || dnf install -y php-cli php-pdo binutils file
             elif command -v yum &>/dev/null; then
               yum install -y epel-release || true
               yum install -y php-cli patchelf binutils file || yum install -y php-cli binutils file || true


### PR DESCRIPTION
## Problem

The `test-bundles` job failed for `php83-nts` on **alpine:3.21** and **fedora:41** in runs `23893182158` and `23893182187` (triggered by the v10.6.1 release event):

```
Error relocating /tmp/test-bundle/firebird.so: php_pdo_unregister_driver: symbol not found
```

## Root Cause

`config.m4` lines 100-107: when `PHP_CHECK_PDO_INCLUDES` is defined (i.e. PHP is built with PDO, which is the default), the `pdo_fbird` sources are compiled **into** `firebird.so` and `PHP_ADD_EXTENSION_DEP(firebird, pdo)` is set.

The test-bundles step installed `php83` + `php83-cli` on Alpine **without `php83-pdo`**, and `php-cli` on Fedora **without `php-pdo`**. The PDO symbols were therefore absent at extension load time.

## Fix

Add the missing packages to both distro install commands:
- Alpine: `php83-pdo`
- Fedora (dnf): `php-pdo`
- apt (Ubuntu/Debian): `php-pdo` (belt-and-suspenders; most apt meta-packages already pull it)

## Impact

- v10.6.1 **release assets are not affected** - bundles were uploaded by the tag-push run (`23893182085`) before the test failures occurred, and the extension works correctly on systems where PDO is installed (the standard case).
- This PR fixes the CI signal for future releases.