### PR TITLE
docs: close v10.x security, build-hardening, and supply-chain specs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to the modernized PHP Firebird exten
 ```bash
 # Use our Docker development environment
 cd docker/
-docker-compose up -d php81  # or php82, php83, php84, php85
+docker-compose up -d php82  # or php83, php84, php85
 
 # Build extension in container
 docker exec -it php-firebird-dev /ext/scripts/container/build.sh
@@ -30,7 +30,7 @@ docker exec -it php-firebird-dev /ext/scripts/container/build.sh
 
 ### Native Development Requirements
 - **Compilers**: GCC 7+ or Clang 5+ (C++17 support)
-- **PHP**: 8.1+ with php-dev/php-devel packages
+- **PHP**: 8.2+ with php-dev/php-devel packages
 - **Firebird**: Client libraries and headers (fbclient, ibase.h)
 - **Build Tools**: autotools, make, pkg-config
 


### PR DESCRIPTION
## Summary

Audits all three open v10.x implementation specs against current codebase and marks them DONE:

- **spec-v10.3.7-security.md**: C1 (SQL injection), C2 (SPB overflow), M10 (dynamic alloc), M7 (PHP 8.2 gate) - all verified implemented. H5 (stale CONTRIBUTING.md refs) fixed in this PR.
- **spec-v10.4-build-hardening.md**: H4 (compiler flags), M1 (gnu17), M8 (out_connection), L1 (LTO) - all verified implemented.
- **spec-v10.4-supply-chain.md**: H1 (SLSA attestations), H2 (CycloneDX SBOM, Linux), H3 (Dependabot), M4 (version stamps) - all verified. Note: Windows SBOM is TBD as follow-up.

### Changes
- Fix CONTRIBUTING.md: `php81` -> `php82`, `8.1+` -> `8.2+`
- Update NEXT_STEPS.md: move specs to Completed section
- Mark all three spec files as DONE with completion date