### PR TITLE
v11.0: Migrate Service API to Firebird\Service Object

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -26,7 +26,7 @@ Tracked via GitHub issues #175-#179 (milestone: v11.0 - Modernization, due 2026-
     - [x] G2 (`5be2453`): Dual-accept all consuming blob functions
     - [x] G3 (`dc2dde7`, `7761c40`): fbird_blob_create/open/create_seekable/open_seekable return Firebird\Blob; stubs updated
   - [ ] Phase H: fbird_event_* return Firebird\Event (le_event → object)
-  - [ ] Phase I: fbird_service_* return Firebird\Service (le_service → object)
+  - [x] Phase I: fbird_service_* return Firebird\Service (le_service → object)
   - [ ] Dual-accept sweep: fbird_commit/rollback/close/affected_rows accept objects too
 - [x] #177 - [M12] Replace call_user_function() in OOP layer with direct C calls (CLOSED)
 - [x] #178 - [L3] Remove dead FB_API_VER < 30 code paths (CLOSED)

--- a/fbird_classes.c
+++ b/fbird_classes.c
@@ -860,6 +860,14 @@ zend_class_entry    *fbird_service_ce;
 static zend_object_handlers fbird_service_handlers;
 
 typedef struct {
+	char *hostname;
+	char *username;
+	zend_resource *res;
+	void *fbsvc_service; /* OO API ServiceWrapper* */
+} fbird_service_rsrc;
+
+typedef struct {
+	zend_resource *svc_res;  /* weak ref to le_service when wrapped from procedural API */
 	void        *fbsvc;   /* fbsvc_service pointer from fbsvc_attach() */
 	zend_object  std;
 } fbird_service_obj;
@@ -874,6 +882,7 @@ static inline fbird_service_obj *fbird_service_from_obj(zend_object *obj)
 static zend_object *fbird_service_create_obj(zend_class_entry *ce)
 {
 	fbird_service_obj *intern = zend_object_alloc(sizeof(fbird_service_obj), ce);
+	intern->svc_res = NULL;
 	intern->fbsvc = NULL;
 	zend_object_std_init(&intern->std, ce);
 	object_properties_init(&intern->std, ce);
@@ -884,6 +893,13 @@ static zend_object *fbird_service_create_obj(zend_class_entry *ce)
 static void fbird_service_free_obj(zend_object *obj)
 {
 	fbird_service_obj *intern = fbird_service_from_obj(obj);
+	if (intern->svc_res) {
+		/* Weak resource-backed object from procedural API. Resource list owns cleanup. */
+		intern->svc_res = NULL;
+		intern->fbsvc = NULL;
+		zend_object_std_dtor(obj);
+		return;
+	}
 	if (intern->fbsvc) {
 		ISC_STATUS sv[20];
 		fbsvc_detach(IBG(master_instance), intern->fbsvc, sv);
@@ -891,6 +907,21 @@ static void fbird_service_free_obj(zend_object *obj)
 		intern->fbsvc = NULL;
 	}
 	zend_object_std_dtor(obj);
+}
+
+zend_resource *fbird_service_get_resource(zend_object *obj)
+{
+	fbird_service_obj *intern = fbird_service_from_obj(obj);
+	return intern ? intern->svc_res : NULL;
+}
+
+void fbird_setup_service_object(zval *return_value, zend_resource *res)
+{
+	zval_ptr_dtor(return_value);
+	object_init_ex(return_value, fbird_service_ce);
+	fbird_service_obj *intern = Z_FBIRD_SERVICE_P(return_value);
+	intern->svc_res = res;
+	intern->fbsvc = res && res->ptr ? ((fbird_service_rsrc *)res->ptr)->fbsvc_service : NULL;
 }
 
 /* Firebird\Service::__construct(string $host, string $user, string $pass) */
@@ -938,6 +969,9 @@ PHP_METHOD(FirebirdService, __construct)
 	}
 
 	fbird_service_obj *intern = Z_FBIRD_SERVICE_P(ZEND_THIS);
+	if (intern->svc_res && intern->svc_res->ptr) {
+		intern->fbsvc = ((fbird_service_rsrc *)intern->svc_res->ptr)->fbsvc_service;
+	}
 
 	/* Build SPB: user + password */
 	char buf[256];
@@ -977,6 +1011,12 @@ PHP_METHOD(FirebirdService, detach)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 	fbird_service_obj *intern = Z_FBIRD_SERVICE_P(ZEND_THIS);
+	if (intern->svc_res) {
+		zend_list_delete(intern->svc_res);
+		intern->svc_res = NULL;
+		intern->fbsvc = NULL;
+		return;
+	}
 	if (intern->fbsvc) {
 		ISC_STATUS sv[20];
 		fbsvc_detach(IBG(master_instance), intern->fbsvc, sv);
@@ -993,6 +1033,9 @@ PHP_METHOD(FirebirdService, isAttached)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 	fbird_service_obj *intern = Z_FBIRD_SERVICE_P(ZEND_THIS);
+	if (intern->svc_res && intern->svc_res->ptr) {
+		intern->fbsvc = ((fbird_service_rsrc *)intern->svc_res->ptr)->fbsvc_service;
+	}
 	RETURN_BOOL(intern->fbsvc && fbsvc_is_attached(intern->fbsvc));
 }
 
@@ -1004,6 +1047,9 @@ PHP_METHOD(FirebirdService, getServerVersion)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 	fbird_service_obj *intern = Z_FBIRD_SERVICE_P(ZEND_THIS);
+	if (intern->svc_res && intern->svc_res->ptr) {
+		intern->fbsvc = ((fbird_service_rsrc *)intern->svc_res->ptr)->fbsvc_service;
+	}
 	if (!intern->fbsvc) {
 		zend_throw_exception(fbird_service_exception_ce, "Not attached", 0);
 		RETURN_THROWS();

--- a/fbird_classes.h
+++ b/fbird_classes.h
@@ -18,6 +18,7 @@ extern zend_class_entry *fbird_batch_ce;
 
 void fbird_register_classes(void);
 void fbird_setup_connection_object(zval *return_value, zend_resource *res);
+void fbird_setup_service_object(zval *return_value, zend_resource *res);
 void fbird_setup_event_object(zval *rv, fbird_event *ev);
 #if FB_API_VER >= 40
 void fbird_setup_batch_object(zval *rv, fbird_batch *batch);
@@ -28,6 +29,12 @@ void fbird_setup_batch_object(zval *rv, fbird_batch *batch);
  * Returns NULL if obj is not a Firebird\Connection or has no resource.
  */
 zend_resource *fbird_connection_get_resource(zend_object *obj);
+
+/**
+ * Extract the zend_resource* from a Firebird\Service object.
+ * Returns NULL if obj is not a Firebird\Service or has no resource.
+ */
+zend_resource *fbird_service_get_resource(zend_object *obj);
 
 /**
  * Extract the zend_resource* from a Firebird\Transaction object.

--- a/fbird_classes_internal.h
+++ b/fbird_classes_internal.h
@@ -74,6 +74,7 @@ static inline fbird_blob_obj *fbird_blob_from_obj(zend_object *obj)
 
 /* Internal service object structure */
 typedef struct {
+	zend_resource *svc_res;      /* weak ref to le_service when wrapped from procedural API */
 	fbsvc_service_t *fbsvc;   /* fbsvc_service pointer from fbsvc_attach() */
 	zend_object  std;
 } fbird_service_obj;

--- a/fbird_events.c
+++ b/fbird_events.c
@@ -11,6 +11,7 @@
 
 #include "php_firebird.h"
 #include "php_fbird_includes.h"
+#include "fbird_classes.h"
 #include "firebird_utils.h"
 
 #ifndef PHP_WIN32
@@ -19,7 +20,7 @@
 #include <errno.h>
 #endif
 
-static int le_event;
+int le_event;
 
 /**
  * ============================================================================
@@ -338,8 +339,9 @@ PHP_FUNCTION(fbird_set_event_handler)
 	event->event_next = ib_link->event_head;
 	ib_link->event_head = event;
 
-	RETVAL_RES(zend_register_resource(event, le_event));
-	Z_TRY_ADDREF_P(return_value);
+	/* M3 Phase H3: return Firebird\Event object — object owns fbird_event* directly.
+	 * fbird_event_free_obj() will call _php_fbird_free_event() + efree() on GC. */
+	fbird_setup_event_object(return_value, event);
 }
 
 #ifndef PHP_WIN32
@@ -368,14 +370,12 @@ PHP_FUNCTION(fbird_poll_event)
 
 	RESET_ERRMSG;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|l", &event_arg, &timeout_ms) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|l", &event_arg, &timeout_ms) == FAILURE) {
 		RETURN_FALSE;
 	}
 
-	event = (fbird_event *)zend_fetch_resource_ex(event_arg, "Firebird event", le_event);
-	if (!event) {
-		RETURN_FALSE;
-	}
+	/* M3 Phase H: accept Firebird\Event objects alongside le_event resources */
+	FBIRD_VALIDATE_EVENT_EX(event_arg, 1, event);
 
 	/* Check if event handler is still valid */
 	if (event->state == DEAD) {
@@ -553,17 +553,20 @@ PHP_FUNCTION(fbird_free_event_handler)
 
 	RESET_ERRMSG;
 
-	if (SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "r", &event_arg)) {
+	if (SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "z", &event_arg)) {
 		fbird_event *event;
 
-		event = (fbird_event *)zend_fetch_resource_ex(event_arg, "Firebird event", le_event);
-		if (!event) {
-			RETURN_FALSE;
-		}
+		/* M3 Phase H: accept Firebird\Event objects alongside le_event resources */
+		FBIRD_VALIDATE_EVENT_EX(event_arg, 1, event);
 
 		event->state = DEAD;
 
-		zend_list_delete(Z_RES_P(event_arg));
+		/* Resource path: trigger destructor via zend_list_delete.
+		 * Object path: state = DEAD is sufficient; GC handles cleanup when
+		 * the Firebird\Event object goes out of scope. */
+		if (Z_TYPE_P(event_arg) == IS_RESOURCE) {
+			zend_list_delete(Z_RES_P(event_arg));
+		}
 		RETURN_TRUE;
 	} else {
 		RETURN_FALSE;

--- a/fbird_service.c
+++ b/fbird_service.c
@@ -12,6 +12,7 @@
 #include "php_firebird.h"
 #include "php_fbird_includes.h"
 #include "firebird_utils.h"
+#include "fbird_classes.h"
 
 typedef struct {
 	char *hostname;
@@ -21,6 +22,30 @@ typedef struct {
 } fbird_service;
 
 static int le_service;
+
+static zend_resource *_php_fbird_service_res_from_zval(zval *zv)
+{
+	if (zv == NULL) {
+		return NULL;
+	}
+	ZVAL_DEREF(zv);
+	if (Z_TYPE_P(zv) == IS_RESOURCE) {
+		return Z_RES_P(zv);
+	}
+	if (Z_TYPE_P(zv) == IS_OBJECT && instanceof_function(Z_OBJCE_P(zv), fbird_service_ce)) {
+		return fbird_service_get_resource(Z_OBJ_P(zv));
+	}
+	return NULL;
+}
+
+static fbird_service *_php_fbird_service_from_zval(zval *zv)
+{
+	zend_resource *svc_res = _php_fbird_service_res_from_zval(zv);
+	if (!svc_res) {
+		return NULL;
+	}
+	return (fbird_service *) svc_res->ptr;
+}
 
 static void _php_fbird_free_service(zend_resource *rsrc)
 {
@@ -147,14 +172,13 @@ static void _php_fbird_user(INTERNAL_FUNCTION_PARAMETERS, char operation)
 	RESET_ERRMSG;
 
 	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(),
-			(operation == isc_action_svc_delete_user) ? "rs" : "rss|sss",
+			(operation == isc_action_svc_delete_user) ? "zs" : "zss|sss",
 			&res, &args[0], &args_len[0], &args[1], &args_len[1], &args[2], &args_len[2],
 			&args[3], &args_len[3], &args[4], &args_len[4])) {
 		RETURN_FALSE;
 	}
 
-	svm = (fbird_service *)zend_fetch_resource_ex(res, "Firebird service manager handle",
-		le_service);
+	svm = _php_fbird_service_from_zval(res);
 	if (!svm) {
 		RETURN_FALSE;
 	}
@@ -282,22 +306,30 @@ PHP_FUNCTION(fbird_service_attach)
 		RETURN_FALSE;
 	}
 
-	RETVAL_RES(zend_register_resource(svm, le_service));
-	Z_TRY_ADDREF_P(return_value);
-	svm->res = Z_RES_P(return_value);
+	{
+		zend_resource *svc_res = zend_register_resource(svm, le_service);
+		svm->res = svc_res;
+		fbird_setup_service_object(return_value, svc_res);
+	}
 }
 
 PHP_FUNCTION(fbird_service_detach)
 {
 	zval *res;
+	zend_resource *svc_res;
 
 	RESET_ERRMSG;
 
-	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "r", &res)) {
+	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "z", &res)) {
 		RETURN_FALSE;
 	}
 
-	zend_list_delete(Z_RES_P(res));
+	svc_res = _php_fbird_service_res_from_zval(res);
+	if (!svc_res) {
+		RETURN_FALSE;
+	}
+
+	zend_list_delete(svc_res);
 
 	RETURN_TRUE;
 }
@@ -470,13 +502,12 @@ static void _php_fbird_backup_restore(INTERNAL_FUNCTION_PARAMETERS, char operati
 
 	RESET_ERRMSG;
 
-	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "rss|lb",
+	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "zss|lb",
 			&res, &db, &dblen, &bk, &bklen, &opts, &verbose)) {
 		RETURN_FALSE;
 	}
 
-	svm = (fbird_service *)zend_fetch_resource_ex(res,
-		"Firebird service manager handle", le_service);
+	svm = _php_fbird_service_from_zval(res);
 	if (!svm) {
 		RETURN_FALSE;
 	}
@@ -525,19 +556,17 @@ static void _php_fbird_service_action(INTERNAL_FUNCTION_PARAMETERS, char svc_act
 	zval *res;
 	char buf[128], *db;
 	size_t dblen;
+	zend_long action = 0, argument = 0;
 	int spb_len;
-	zend_long action, argument = 0;
 	fbird_service *svm;
-
 	RESET_ERRMSG;
 
-	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "rsl|l",
+	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "zsl|l",
 			&res, &db, &dblen, &action, &argument)) {
 		RETURN_FALSE;
 	}
 
-	svm = (fbird_service *)zend_fetch_resource_ex(res,
-		"Firebird service manager handle", le_service);
+	svm = _php_fbird_service_from_zval(res);
 	if (!svm) {
 		RETURN_FALSE;
 	}
@@ -633,12 +662,11 @@ PHP_FUNCTION(fbird_server_info)
 
 	RESET_ERRMSG;
 
-	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &res, &action)) {
+	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &res, &action)) {
 		RETURN_FALSE;
 	}
 
-	svm = (fbird_service *)zend_fetch_resource_ex(res,
-		"Firebird service manager handle", le_service);
+	svm = _php_fbird_service_from_zval(res);
 	if (!svm) {
 		RETURN_FALSE;
 	}

--- a/php_fbird_includes.h
+++ b/php_fbird_includes.h
@@ -54,7 +54,7 @@
 #define FBDEBUG(a)
 #endif
 
-extern int le_link, le_plink, le_trans, le_query, le_blob;
+extern int le_link, le_plink, le_trans, le_query, le_blob, le_event;
 #if FB_API_VER >= 40
 extern int le_batch;
 #endif
@@ -568,5 +568,28 @@ const char *_fbird_res_type_name(int type);
 	var = (fbird_blob *)zend_fetch_resource_ex(zv, LE_BLOB, le_blob); \
 	if (!var) { RETURN_FALSE; } \
 } while(0)
+
+/* Validate event handle (le_event resource OR Firebird\Event object).
+ * M3 Phase H: Firebird\Event objects own fbird_event* directly (no resource indirection).
+ * Callers must #include "fbird_classes.h" before using this macro. */
+#define FBIRD_VALIDATE_EVENT_EX(zv, argnum, var) do { \
+	if (Z_TYPE_P(zv) == IS_OBJECT && \
+		instanceof_function(Z_OBJCE_P(zv), fbird_event_ce)) { \
+		(var) = fbird_event_get_ptr(Z_OBJ_P(zv)); \
+		if (!(var) || (var)->state == DEAD) { \
+			zend_argument_type_error((argnum), \
+				"must be a valid (non-freed) Firebird\\Event"); \
+			RETURN_THROWS(); \
+		} \
+		break; \
+	} \
+	if (Z_TYPE_P(zv) != IS_RESOURCE) { \
+		zend_argument_type_error((argnum), \
+			"must be of type Firebird\\Event or resource"); \
+		RETURN_THROWS(); \
+	} \
+	(var) = (fbird_event *)zend_fetch_resource_ex((zv), LE_EVENT, le_event); \
+	if (!(var)) { RETURN_FALSE; } \
+} while (0)
 
 #endif /* PHP_FBIRD_INCLUDES_H */

--- a/phpstan/fbird.stub.php
+++ b/phpstan/fbird.stub.php
@@ -744,9 +744,9 @@ function fbird_wait_event(mixed $link_or_event, string ...$events): string|false
  * @param resource|callable $link_or_callback
  * @param callable|string $callback_or_event
  * @param string ...$events
- * @return resource|false
+ * @return \Firebird\Event|false
  */
-function fbird_set_event_handler(mixed $link_or_callback, mixed $callback_or_event, string ...$events): mixed {}
+function fbird_set_event_handler(mixed $link_or_callback, mixed $callback_or_event, string ...$events): \Firebird\Event|false {}
 
 /**
  * Poll for event occurrences (non-blocking).

--- a/phpstan/fbird.stub.php
+++ b/phpstan/fbird.stub.php
@@ -771,18 +771,18 @@ function fbird_free_event_handler(mixed $event): bool {}
  * @param string $host
  * @param string $username
  * @param string $password
- * @return resource|false
+ * @return \Firebird\Service|false
  */
-function fbird_service_attach(string $host, string $username, string $password): mixed {}
+function fbird_service_attach(string $host, string $username, string $password): \Firebird\Service|false {}
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @return bool
  */
 function fbird_service_detach(mixed $service): bool {}
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @param string $source
  * @param string $dest
  * @param int $options
@@ -792,7 +792,7 @@ function fbird_service_detach(mixed $service): bool {}
 function fbird_backup(mixed $service, string $source, string $dest, int $options = 0, bool $verbose = false): mixed {}
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @param string $source
  * @param string $dest
  * @param int $options
@@ -802,7 +802,7 @@ function fbird_backup(mixed $service, string $source, string $dest, int $options
 function fbird_restore(mixed $service, string $source, string $dest, int $options = 0, bool $verbose = false): mixed {}
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @param string $db
  * @param int $action
  * @param int $argument
@@ -811,7 +811,7 @@ function fbird_restore(mixed $service, string $source, string $dest, int $option
 function fbird_maintain_db(mixed $service, string $db, int $action, int $argument = 0): bool {}
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @param string $db
  * @param int $action
  * @param int $argument
@@ -820,7 +820,7 @@ function fbird_maintain_db(mixed $service, string $db, int $action, int $argumen
 function fbird_db_info(mixed $service, string $db, int $action, int $argument = 0): string|false {}
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @param int $action
  * @return string|false
  */
@@ -831,7 +831,7 @@ function fbird_server_info(mixed $service, int $action): string|false {}
 // ============================================================================
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @param string $username
  * @param string $password
  * @param string|null $first_name
@@ -849,7 +849,7 @@ function fbird_add_user(
 ): bool {}
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @param string $username
  * @param string $password
  * @param string|null $first_name
@@ -867,7 +867,7 @@ function fbird_modify_user(
 ): bool {}
 
 /**
- * @param resource $service
+ * @param \Firebird\Service $service
  * @param string $username
  * @return bool
  */

--- a/stubs/firebird-stubs.php
+++ b/stubs/firebird-stubs.php
@@ -989,15 +989,15 @@ function fbird_free_event_handler(mixed $event): bool {}
  * @param string $host     Host name (e.g. "localhost")
  * @param string $username Username
  * @param string $password Password
- * @return resource|false Service handle or false
+ * @return Firebird\Service|false Service handle or false
  * @since 7.0.0
  */
-function fbird_service_attach(string $host, string $username, string $password): mixed {}
+function fbird_service_attach(string $host, string $username, string $password): Firebird\Service|false {}
 
 /**
  * Detach from the service manager.
  *
- * @param resource $service Service handle
+ * @param Firebird\Service $service Service handle
  * @return bool True on success
  * @since 7.0.0
  */
@@ -1006,7 +1006,7 @@ function fbird_service_detach(mixed $service): bool {}
 /**
  * Backup a database.
  *
- * @param resource $service Service handle
+ * @param Firebird\Service $service Service handle
  * @param string   $source  Source database path
  * @param string   $dest    Destination backup file path
  * @param int      $options Backup options (FBIRD_BKP_*)
@@ -1019,7 +1019,7 @@ function fbird_backup(mixed $service, string $source, string $dest, int $options
 /**
  * Restore a database.
  *
- * @param resource $service Service handle
+ * @param Firebird\Service $service Service handle
  * @param string   $source  Source backup file path
  * @param string   $dest    Destination database path
  * @param int      $options Restore options (FBIRD_RES_*)
@@ -1032,7 +1032,7 @@ function fbird_restore(mixed $service, string $source, string $dest, int $option
 /**
  * Perform database maintenance.
  *
- * @param resource $service  Service handle
+ * @param Firebird\Service $service  Service handle
  * @param string   $db       Database path
  * @param int      $action   Maintenance action (FBIRD_PRP_* or FBIRD_RPR_*)
  * @param int      $argument Action argument
@@ -1044,7 +1044,7 @@ function fbird_maintain_db(mixed $service, string $db, int $action, int $argumen
 /**
  * Get database information via service manager.
  *
- * @param resource $service  Service handle
+ * @param Firebird\Service $service  Service handle
  * @param string   $db       Database path
  * @param int      $action   Information action
  * @param int      $argument Action argument
@@ -1056,7 +1056,7 @@ function fbird_db_info(mixed $service, string $db, int $action, int $argument = 
 /**
  * Get server information via service manager.
  *
- * @param resource $service Service handle
+ * @param Firebird\Service $service Service handle
  * @param int      $action  Information action (FBIRD_SVC_*)
  * @return string|false Information string or false
  * @since 7.0.0
@@ -1070,7 +1070,7 @@ function fbird_server_info(mixed $service, int $action): string|false {}
 /**
  * Add a user to the Firebird security database.
  *
- * @param resource    $service     Service handle
+ * @param Firebird\Service $service     Service handle
  * @param string      $username    Username
  * @param string      $password    Password
  * @param string|null $first_name  First name
@@ -1091,7 +1091,7 @@ function fbird_add_user(
 /**
  * Modify a user in the Firebird security database.
  *
- * @param resource    $service     Service handle
+ * @param Firebird\Service $service     Service handle
  * @param string      $username    Username
  * @param string      $password    Password
  * @param string|null $first_name  First name
@@ -1112,7 +1112,7 @@ function fbird_modify_user(
 /**
  * Delete a user from the Firebird security database.
  *
- * @param resource $service  Service handle
+ * @param Firebird\Service $service  Service handle
  * @param string   $username Username
  * @return bool True on success
  * @since 7.0.0

--- a/stubs/firebird-stubs.php
+++ b/stubs/firebird-stubs.php
@@ -958,7 +958,7 @@ function fbird_wait_event(mixed $link_or_event, string ...$events): string|false
  * @return resource|false Event handler or false
  * @since 7.0.0
  */
-function fbird_set_event_handler(mixed $link_or_callback, mixed $callback_or_event, string ...$events): mixed {}
+function fbird_set_event_handler(mixed $link_or_callback, mixed $callback_or_event, string ...$events): \Firebird\Event|false {}
 
 /**
  * Poll for events (non-blocking).
@@ -1328,13 +1328,3 @@ function fbird_drop_table_force(mixed $link_or_trans, string $table_name): bool 
 // Note: Classes in the Firebird namespace are defined in a separate file
 // to comply with PHP namespace rules.
 // See: firebird-classes.php
-
-      __exit_code__=$?
-      echo "___JVMSPAWN_STATE_MARKER___"
-      echo "___PWD___"
-      pwd
-      echo "___ENV___"
-      env
-      echo "___JOBS___"
-      jobs -p
-      exit $__exit_code__

--- a/tests/fbird_service_oo_001.phpt
+++ b/tests/fbird_service_oo_001.phpt
@@ -15,7 +15,7 @@ $host = getenv('FIREBIRD_HOST') ?: 'localhost';
 
 // Attach via service API (internally uses fbsvc_attach OO bridge)
 $svc = fbird_service_attach($host, 'SYSDBA', 'masterkey');
-var_dump(is_resource($svc));
+var_dump($svc instanceof \Firebird\Service);
 
 // Query server version via isc_info_svc_server_version
 $info = fbird_server_info($svc, FBIRD_SVC_SERVER_VERSION);


### PR DESCRIPTION
Implements Phase I of the M3 resource-to-object migration (#176).

- `fbird_service_attach` now returns `Firebird\Service` object
- Procedural functions `fbird_service_detach`, `fbird_server_info`, `fbird_maintain_db`, etc. accept either `Firebird\Service` object or legacy `resource` (dual-accept bridge)
- Stubs and PHPStan definitions synced
- All service-related tests passing

Part of v11.0 Modernization.