### PR TITLE
fix(ci): enable PDO extension in all Docker test images (#263)

### DIFF
--- a/docker/php/Dockerfile-8.2-fb3
+++ b/docker/php/Dockerfile-8.2-fb3
@@ -25,7 +25,7 @@ RUN ln -sf /opt/firebird/lib/libfbclient.so /usr/lib/libfbclient.so \
     && ln -sf /opt/firebird/lib/libfbclient.so.2 /usr/lib/libfbclient.so.2 \
     && ln -sf /opt/firebird/include /usr/include/firebird \
     && echo "/opt/firebird/lib" > /etc/ld.so.conf.d/firebird.conf \
-    && ldconfig && docker-php-ext-install pcntl
+    && ldconfig && docker-php-ext-install pdo pcntl
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/php/Dockerfile-8.2-fb5
+++ b/docker/php/Dockerfile-8.2-fb5
@@ -21,7 +21,7 @@ RUN ln -sf /opt/firebird/lib/libfbclient.so /usr/lib/libfbclient.so \
     && ln -sf /opt/firebird/lib/libfbclient.so.2 /usr/lib/libfbclient.so.2 \
     && ln -sf /opt/firebird/include /usr/include/firebird \
     && echo "/opt/firebird/lib" > /etc/ld.so.conf.d/firebird.conf \
-    && ldconfig && docker-php-ext-install pcntl
+    && ldconfig && docker-php-ext-install pdo pcntl
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/php/Dockerfile-8.3-fb3
+++ b/docker/php/Dockerfile-8.3-fb3
@@ -25,7 +25,7 @@ RUN ln -sf /opt/firebird/lib/libfbclient.so /usr/lib/libfbclient.so \
     && ln -sf /opt/firebird/lib/libfbclient.so.2 /usr/lib/libfbclient.so.2 \
     && ln -sf /opt/firebird/include /usr/include/firebird \
     && echo "/opt/firebird/lib" > /etc/ld.so.conf.d/firebird.conf \
-    && ldconfig && docker-php-ext-install pcntl
+    && ldconfig && docker-php-ext-install pdo pcntl
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/php/Dockerfile-8.3-fb5
+++ b/docker/php/Dockerfile-8.3-fb5
@@ -21,7 +21,7 @@ RUN ln -sf /opt/firebird/lib/libfbclient.so /usr/lib/libfbclient.so \
     && ln -sf /opt/firebird/lib/libfbclient.so.2 /usr/lib/libfbclient.so.2 \
     && ln -sf /opt/firebird/include /usr/include/firebird \
     && echo "/opt/firebird/lib" > /etc/ld.so.conf.d/firebird.conf \
-    && ldconfig && docker-php-ext-install pcntl
+    && ldconfig && docker-php-ext-install pdo pcntl
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/php/Dockerfile-8.4-fb3
+++ b/docker/php/Dockerfile-8.4-fb3
@@ -25,7 +25,7 @@ RUN ln -sf /opt/firebird/lib/libfbclient.so /usr/lib/libfbclient.so \
     && ln -sf /opt/firebird/lib/libfbclient.so.2 /usr/lib/libfbclient.so.2 \
     && ln -sf /opt/firebird/include /usr/include/firebird \
     && echo "/opt/firebird/lib" > /etc/ld.so.conf.d/firebird.conf \
-    && ldconfig && docker-php-ext-install pcntl
+    && ldconfig && docker-php-ext-install pdo pcntl
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/php/Dockerfile-8.4-fb5
+++ b/docker/php/Dockerfile-8.4-fb5
@@ -21,7 +21,7 @@ RUN ln -sf /opt/firebird/lib/libfbclient.so /usr/lib/libfbclient.so \
     && ln -sf /opt/firebird/lib/libfbclient.so.2 /usr/lib/libfbclient.so.2 \
     && ln -sf /opt/firebird/include /usr/include/firebird \
     && echo "/opt/firebird/lib" > /etc/ld.so.conf.d/firebird.conf \
-    && ldconfig && docker-php-ext-install pcntl
+    && ldconfig && docker-php-ext-install pdo pcntl
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/php/Dockerfile-8.5-fb3
+++ b/docker/php/Dockerfile-8.5-fb3
@@ -25,7 +25,7 @@ RUN ln -sf /opt/firebird/lib/libfbclient.so /usr/lib/libfbclient.so \
     && ln -sf /opt/firebird/lib/libfbclient.so.2 /usr/lib/libfbclient.so.2 \
     && ln -sf /opt/firebird/include /usr/include/firebird \
     && echo "/opt/firebird/lib" > /etc/ld.so.conf.d/firebird.conf \
-    && ldconfig && docker-php-ext-install pcntl
+    && ldconfig && docker-php-ext-install pdo pcntl
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/php/Dockerfile-8.5-fb5
+++ b/docker/php/Dockerfile-8.5-fb5
@@ -21,7 +21,7 @@ RUN ln -sf /opt/firebird/lib/libfbclient.so /usr/lib/libfbclient.so \
     && ln -sf /opt/firebird/lib/libfbclient.so.2 /usr/lib/libfbclient.so.2 \
     && ln -sf /opt/firebird/include /usr/include/firebird \
     && echo "/opt/firebird/lib" > /etc/ld.so.conf.d/firebird.conf \
-    && ldconfig && docker-php-ext-install pcntl
+    && ldconfig && docker-php-ext-install pdo pcntl
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/php/Dockerfile-asan
+++ b/docker/php/Dockerfile-asan
@@ -52,6 +52,7 @@ RUN mkdir -p /usr/src/php && \
         --enable-mbstring \
         --with-readline \
         --enable-pcntl \
+        --enable-pdo \
     && make -j$(nproc) \
     && make install \
     && mkdir -p /usr/local/etc/php \

--- a/docker/php/Dockerfile-tsan
+++ b/docker/php/Dockerfile-tsan
@@ -82,6 +82,7 @@ RUN set -eu \
         --enable-pcntl \
         --enable-posix \
         --enable-session \
+        --enable-pdo \
         --with-zlib \
         CC=clang \
         CXX=clang++ \


### PR DESCRIPTION
## Problem

The FB3/FB5 Docker test containers did not have PDO enabled, so `PHP_CHECK_PDO_INCLUDES` in `config.m4:101` failed at build time. This caused `pdo_fbird` (the PDO Firebird driver) to be **omitted from compilation**, resulting in 39+ PDO tests skipping with `"could not find driver"`.

## Root Cause

Two categories of Docker images had the gap:

| Category | Dockerfiles | Issue |
|---|---|---|
| Official `php:*-cli` base | 8 files (`8.{2,3,4,5}-fb{3,5}`) | `docker-php-ext-install pcntl` without `pdo` |
| From-source (sanitizers) | `Dockerfile-asan`, `Dockerfile-tsan` | `./configure` without `--enable-pdo` |

## Fix

- **B1** (commit 2): Add `pdo` to `docker-php-ext-install` in all 8 FB3/FB5 images
- **B2** (commit 3): Add `--enable-pdo` to `./configure` in asan + tsan images

## Verification

Built and tested `php85-fb3-dev` locally:

```
$ grep HAVE_PDO_FBIRD config.h
#define HAVE_PDO_FBIRD 1

$ php -r "echo implode(\", \", PDO::getAvailableDrivers());"
sqlite, fbird

# End-to-end PDO query against Firebird 3.0:
Result: {"ID":1,"VAL":"hello_from_pdo"}
Drivers: sqlite, fbird
STATUS: PASS
```

The `pdo_fbird_driver` and `pdo_fbird_dbh_methods` symbols are present in `firebird.so`.

## Acceptance Criteria

- [x] All 8 FB3/FB5 Dockerfiles enable PDO
- [x] asan + tsan Dockerfiles enable PDO
- [x] `HAVE_PDO_FBIRD` defined in config.h after configure
- [x] `phpinfo()` shows `pdo_fbird` under PDO drivers
- [x] PDO query executes successfully against FB 3.0 server
- [ ] Full PDO test suite passes in CI (needs CI run after merge)

## Closes

Closes #263