### PR TITLE
fix(result): free ht_ret on error path in _php_fbird_fetch_hash (#265)

### DIFF
--- a/fbird_result.c
+++ b/fbird_result.c
@@ -863,8 +863,9 @@ void _php_fbird_fetch_hash_query(
 					ZVAL_NEW_STR(result, _php_fbird_quad_to_string(ar_qd));
 				}
 				break;
-			_php_fbird_fetch_error:
-				RETURN_FALSE;
+		_php_fbird_fetch_error:
+			zend_array_release(ht_ret);
+			RETURN_FALSE;
 		} /* switch */
 
 		zend_hash_move_forward_ex(ht_ret, &pos);


### PR DESCRIPTION
## Problem

`_php_fbird_fetch_hash_query()` in `fbird_result.c` allocates `ht_ret` via `zend_array_dup()` (lines 582/585) but leaks it on error paths. 13 `goto _php_fbird_fetch_error` sites jump to the error label (line 866) which did a bare `RETURN_FALSE`.

On the success path, ownership transfers to `return_value` via `RETVAL_ARR(ht_ret)` (line 873). The error path had no corresponding free.

## Fix

One line added at the error label:

```c
_php_fbird_fetch_error:
    zend_array_release(ht_ret);   // ← NEW
    RETURN_FALSE;
```

### Why `zend_array_release`

| API | Behavior | Choice |
|---|---|---|
| `zend_array_release` | Checks `IS_ARRAY_IMMUTABLE`, decrements refcount, destroys at 0 | ✅ Defensive, idiomatic |
| `zend_array_destroy` | Directly destroys data + frees struct | Equivalent for refcount=1, but skips safety checks |

## Safety

| Check | Result |
|---|---|
| Is `ht_ret` always initialized before any goto? | ✅ All 13 goto sites (lines 651-857) are after initialization (line 586) |
| Could early returns reach the label? | ✅ No — `RETURN_FALSE` at line 579 is direct, does not goto the label |
| Does it clean up partially-populated zvals? | ✅ `zend_array_destroy` iterates and destroys all contained zvals |

## Verification

```
Full suite: 202 pass / 76 skip / 0 fail (identical to baseline)
Error-path spot-checks: array_error_paths, blob_seek_segments, result_fetch_modes → all PASS
```

## Out of scope (noted)

- Blob handle leak (`fbb_open` without `fbb_close` on error) — Firebird resource, cleaned up at attachment close
- Filed as pre-existing; not part of this issue

## Closes

Closes #265