### PR TITLE
refactor: clean up compiler warnings (#273)

### DIFF
--- a/fbird_blobs.c
+++ b/fbird_blobs.c
@@ -691,7 +691,6 @@ PHP_FUNCTION(fbird_blob_cancel)
 PHP_FUNCTION(fbird_blob_info)
 {
 	char *blob_id = NULL;
-	size_t blob_id_len;
 	zval *link = NULL, *arg1 = NULL;
 	fbird_db_link *ib_link;
 	fbird_transaction *trans = NULL;
@@ -735,7 +734,6 @@ PHP_FUNCTION(fbird_blob_info)
 		}
 	} else if (arg1 && Z_TYPE_P(arg1) == IS_STRING) {
 		blob_id = Z_STRVAL_P(arg1);
-		blob_id_len = Z_STRLEN_P(arg1);
 	} else {
 		// Invalid argument type
 		php_error_docref(NULL, E_WARNING, "Expected blob ID string or blob stream resource");
@@ -902,7 +900,6 @@ PHP_FUNCTION(fbird_blob_echo)
 PHP_FUNCTION(fbird_blob_import)
 {
 	zval *link = NULL, *file;
-	int size;
 	unsigned b;
 	fbird_blob ib_blob = { 0, {0, 0}, NULL };
 	fbird_db_link *ib_link;
@@ -947,7 +944,7 @@ PHP_FUNCTION(fbird_blob_import)
 			break;
 		}
 
-		for (size = 0; (b = (unsigned)php_stream_read(stream, bl_data, sizeof(bl_data))) > 0; size += b) {
+		for (; (b = (unsigned)php_stream_read(stream, bl_data, sizeof(bl_data))) > 0; ) {
 			/* fbb_put_segment returns 1 on success, 0 on error */
 			if (fbb_put_segment(IBG(master_instance), ib_blob.fbb_blob, b, bl_data, IB_STATUS) == 0) {
 				fbb_cancel(IBG(master_instance), ib_blob.fbb_blob, IB_STATUS);

--- a/fbird_inspection.c
+++ b/fbird_inspection.c
@@ -131,7 +131,6 @@ static int _fbird_drop_table(fbird_db_link *link, fbird_transaction *trans, cons
 	void *stmt = NULL;
 	void *attachment = NULL;
 	void *transaction = NULL;
-	int result = FAILURE;
 
 	/* OO API Only: Require fbc_connection */
 	if (!link->fbc_connection) {

--- a/fbird_query_bind.c
+++ b/fbird_query_bind.c
@@ -524,7 +524,7 @@ int _php_fbird_bind(fbird_query *ib_query, zval *b_vars)
 	BIND_BUF *buf = ib_query->bind_buf;
 	XSQLDA *sqlda = ib_query->in_sqlda;
 
-	int i, array_cnt = 0, rv = SUCCESS;
+	int i, rv = SUCCESS;
 
 	for (i = 0; i < sqlda->sqld; ++i) { /* bound vars */
 
@@ -571,7 +571,6 @@ int _php_fbird_bind(fbird_query *ib_query, zval *b_vars)
 			case IS_NULL:
 					buf[i].nullind = -1;
 
-				if ((var->sqltype & ~1) == SQL_ARRAY) ++array_cnt;
 
 				continue;
 		}

--- a/fbird_result.c
+++ b/fbird_result.c
@@ -629,7 +629,7 @@ void _php_fbird_fetch_hash_query(
 	zval *return_value)
 {
 	zval *result;
-	zend_long i, array_cnt = 0;
+	zend_long i;
 
 	/* Pure OO API: Check message buffer instead of XSQLDA */
 	if (ib_query->out_metadata == NULL || ib_query->out_msg_buffer == NULL ||

--- a/fbird_transaction.c
+++ b/fbird_transaction.c
@@ -287,8 +287,6 @@ PHP_FUNCTION(fbird_trans_start)
 	zval *link_arg = NULL, *options_arg = NULL;
 	fbird_db_link *ib_link;
 	fbird_transaction *ib_trans;
-	void *tr_handle = 0;
-	ISC_STATUS result;
 	char last_tpb[TPB_MAX_SIZE];
 	unsigned short tpb_len = 0;
 	zend_long trans_timeout = 0;
@@ -604,7 +602,6 @@ PHP_FUNCTION(fbird_connection_info)
 	};
 	char res_buf[512];
 	char *p;
-	ISC_STATUS status[ISC_STATUS_LENGTH];
 
 	RESET_ERRMSG;
 
@@ -712,8 +709,6 @@ PHP_FUNCTION(fbird_trans)
 	char last_tpb[TPB_MAX_SIZE];
 	fbird_db_link **ib_link = NULL;
 	fbird_transaction *ib_trans;
-	void *tr_handle = 0;
-	ISC_STATUS result = 0;
 
 	RESET_ERRMSG;
 
@@ -843,8 +838,6 @@ PHP_FUNCTION(fbird_trans)
 					RETURN_FALSE;
 				}
 
-				tr_handle = fbt_get_handle(oo_trans);
-
 				/* Allocate and register transaction with OO API wrapper */
 				ib_trans = (fbird_transaction *) safe_emalloc(link_cnt-1, sizeof(fbird_db_link *), sizeof(fbird_transaction));
 				ib_trans->link_cnt = link_cnt;
@@ -897,7 +890,6 @@ PHP_FUNCTION(fbird_trans)
 			efree(ib_link);
 			RETURN_FALSE;
 		}
-		tr_handle = fbt_get_handle(oo_trans);
 
 		/* Allocate and register transaction with OO API wrapper */
 		ib_trans = (fbird_transaction *) safe_emalloc(link_cnt-1, sizeof(fbird_db_link *), sizeof(fbird_transaction));


### PR DESCRIPTION
## Problem

Issue #273: Building with `-Wall -Wextra` produces 25+ warnings. This PR addresses the trivial unused-variable warnings (batch 1).

## Changes

Removed 8 unused/set-but-not-used variables across 5 source files:

| File | Variable | Warning |
|---|---|---|
| `fbird_result.c:632` | `array_cnt` | unused |
| `fbird_transaction.c:290-291` | `tr_handle`, `result` | unused |
| `fbird_transaction.c:607` | `status` | unused |
| `fbird_transaction.c:715-716` | `tr_handle` (set, never read), `result` (unused) | unused-but-set |
| `fbird_inspection.c:134` | `result` | unused |
| `fbird_blobs.c:694` | `blob_id_len` | set but not used |
| `fbird_blobs.c:903` | `size` | loop accumulator, never read |
| `fbird_query_bind.c:527` | `array_cnt` | incremented, never read |

Also removed dead assignments (`tr_handle = fbt_get_handle()` at 2 sites, `++array_cnt` at 1 site).

## Verification

- **Warnings**: 25 → 12 (excluding Zend headers)
- **Tests**: 202 pass / 76 skip / 0 fail (identical to baseline)

## Remaining (follow-up commits)

- Sign-compare warnings (cast to `size_t`)
- Missing field initializer
- Implicit-fallthrough investigation
- Maybe-uninitialized investigation
- Unused code (const, function, arginfo)