### PR TITLE
refactor: fix sign-compare warnings and missing field initializer (#273)

### DIFF
--- a/fbird_connection.c
+++ b/fbird_connection.c
@@ -327,7 +327,7 @@ zend_resource *_php_fbird_connect_link(
 	zend_long flags, int persistent)
 {
 	char *c, hash[16], *args[] = { db, user, pass, charset, role };
-	int i;
+	size_t i;
 	size_t len[] = { db_len, user_len, pass_len, charset_len, role_len };
 	zend_long largs[] = { buffers, dialect, 0 };
 	PHP_MD5_CTX hash_context;

--- a/fbird_service.c
+++ b/fbird_service.c
@@ -157,7 +157,7 @@ static void _php_fbird_user(INTERNAL_FUNCTION_PARAMETERS, char operation)
 	    isc_spb_sec_firstname, isc_spb_sec_middlename, isc_spb_sec_lastname };
 	char buf[128], *args[] = { NULL, NULL, NULL, NULL, NULL };
 	size_t args_len[] = { 0, 0, 0, 0, 0 };
-	int i;
+	size_t i;
 	unsigned short spb_len = 1;
 	zval *res;
 	fbird_service *svm;
@@ -183,7 +183,7 @@ static void _php_fbird_user(INTERNAL_FUNCTION_PARAMETERS, char operation)
 			int chunk = slprintf(&buf[spb_len], sizeof(buf) - spb_len, "%c%c%c%s",
 				user_flags[i], (char)args_len[i], (char)(args_len[i] >> 8), args[i]);
 
-			if ((spb_len + chunk) > sizeof(buf) || chunk <= 0) {
+			if (chunk <= 0 || (size_t)spb_len + (size_t)chunk > sizeof(buf)) {
 				_php_fbird_module_error("Internal error: insufficient buffer space for SPB (%d)", spb_len);
 				RETURN_FALSE;
 			}
@@ -619,7 +619,7 @@ options_argument:
 		}
 	}
 
-	if (spb_len > sizeof(buf) || spb_len == -1) {
+	if (spb_len < 0 || (size_t)spb_len > sizeof(buf)) {
 		_php_fbird_module_error("Internal error: insufficient buffer space for SPB (%d)", spb_len);
 		RETURN_FALSE;
 	}

--- a/pdo_fbird/pdo_fbird_driver.c
+++ b/pdo_fbird/pdo_fbird_driver.c
@@ -1144,7 +1144,7 @@ const struct pdo_dbh_methods pdo_fbird_dbh_methods = {
 	pdo_fbird_fetch_error_func,
 	pdo_fbird_handle_get_attribute,
 	pdo_fbird_check_liveness,
-	NULL, NULL, NULL, NULL,
+	NULL, NULL, NULL, NULL, NULL,
 };
 /* }}} */
 


### PR DESCRIPTION
## Problem

Issue #273 batch 2: 6 sign-compare and missing-initializer warnings.

## Changes (3 files)

| File | Line | Warning | Fix |
|---|---|---|---|
| `fbird_connection.c` | 330 | int vs sizeof | `int i` → `size_t i` |
| `fbird_service.c` | 160 | int vs sizeof | `int i` → `size_t i` |
| `fbird_service.c` | 186 | unsigned short + int vs size_t | Reorder: `chunk <= 0` first, then cast to `size_t` |
| `fbird_service.c` | 622 | int vs sizeof + redundant `-1` check | `spb_len < 0 || (size_t)spb_len > sizeof(buf)` (subsumes `== -1`) |
| `pdo_fbird_driver.c` | 1147 | missing `scanner` field initializer | Add 5th `NULL` |

### Safety

- `slprintf` returns `int` (can be -1), so `spb_len` stays `int` — only the comparison is cast
- The `chunk <= 0` / `spb_len < 0` checks short-circuit before any cast, so negative values are handled correctly
- Loop index type changes (`int` → `size_t`) are safe — `i` is only used as an index, never compared with negative values

## Verification

- **Warnings**: 12 → 8 (excluding Zend headers)
- **Tests**: 202 pass / 76 skip / 0 fail (identical to baseline)

## Remaining (batch 3)

- 2x implicit-fallthrough (`fbird_service.c:593,599`)
- 2x Waddress (`fbird_metadata.c:403,406`)
- 1x Wtype-limits (`fbird_query_bind.c:94`)
- 3x unused code (const, function, arginfo)