### PR TITLE
refactor: fix fallthrough, Waddress, Wtype-limits, remove dead code (#273)

### DIFF
--- a/fbird_connection.c
+++ b/fbird_connection.c
@@ -277,10 +277,6 @@ void _php_fbird_close_plink(zend_resource *rsrc)
 
 enum connect_args { DB = 0, USER = 1, PASS = 2, CSET = 3, ROLE = 4, BUF = 0, DLECT = 1, SYNC = 2 };
 
-static char const dpb_args[] = {
-	0, isc_dpb_user_name, isc_dpb_password, isc_dpb_lc_ctype, isc_dpb_sql_role_name, 0
-};
-
 int _php_fbird_attach_db(char **args, size_t *len, zend_long *largs, void **out_connection)
 {
     void* connection = NULL;

--- a/fbird_metadata.c
+++ b/fbird_metadata.c
@@ -30,7 +30,6 @@
 /* Forward declarations */
 static bool _php_fbird_infer_returning_prefix(const char *sql, size_t index, char *out, size_t out_len);
 static bool _php_fbird_infer_returning_full_alias(const char *sql, size_t index, char *out, size_t out_len);
-static bool _php_fbird_returning_token_alias(const char *sql, size_t index, char *out, size_t out_len);
 static bool _php_fbird_sql_has_returning(const char *sql);
 
 void _php_fbird_insert_alias(HashTable *ht, const char *alias)
@@ -400,10 +399,10 @@ int _php_fbird_alloc_ht_aliases(fbird_query *ib_query)
 		} else if (ib_query->out_sqlda) {
 			/* Fallback to XSQLDA (limited to 31 chars) */
 			XSQLVAR *var = &ib_query->out_sqlda->sqlvar[i];
-			if (var->aliasname && var->aliasname[0]) {
+			if (var->aliasname[0]) {
 				base_alias = var->aliasname;
 			}
-			if (var->sqlname && var->sqlname[0]) {
+			if (var->sqlname[0]) {
 				base_field = var->sqlname;
 			}
 		}
@@ -572,64 +571,6 @@ static bool _php_fbird_infer_returning_full_alias(const char *sql, size_t index,
                     }
                 }
                 return 0;
-            }
-            i++;
-            if (*s == '\0' || *s == ';') break;
-            s++;
-            while (*s && (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r')) s++;
-            tok_start = s;
-        } else {
-            s++;
-        }
-    }
-    return 0;
-}
-
-/* Extract the raw token for the k-th RETURNING expression. If the token
- * contains a qualifier (e.g., OLD.I or NEW.C), write it as-is (uppercased
- * qualifier plus original column part) into out and return 1. If token has
- * no qualifier, return 0 so caller can fallback to base alias. */
-static bool _php_fbird_returning_token_alias(const char *sql, size_t index, char *out, size_t out_len)
-{
-    if (!sql || !out || out_len < 6) return 0;
-
-    const char *p = sql;
-    const char *ret = NULL;
-    while (*p) {
-        if (strncasecmp(p, "returning", 9) == 0) { ret = p + 9; break; }
-        p++;
-    }
-    if (!ret) return 0;
-
-    size_t i = 0;
-    const char *s = ret;
-    while (*s && (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\r')) s++;
-
-    const char *tok_start = s;
-    for (;;) {
-        if (*s == ',' || *s == '\0' || *s == ';') {
-            if (i == index) {
-                const char *tok_end = s;
-                while (tok_end > tok_start && (tok_end[-1] == ' ' || tok_end[-1] == '\t' || tok_end[-1] == '\n' || tok_end[-1] == '\r')) tok_end--;
-                while (tok_start < tok_end && (*tok_start == ' ' || *tok_start == '\t' || *tok_start == '\n' || *tok_start == '\r')) tok_start++;
-
-                const char *dot = memchr(tok_start, '.', tok_end - tok_start);
-                if (!dot) return 0;
-
-                /* Copy qualifier uppercased + '.' + rest as-is */
-                size_t qual_len = (size_t)(dot - tok_start);
-                size_t rest_len = (size_t)(tok_end - (dot + 1));
-                if (qual_len < 3 || (qual_len + 1 + rest_len + 1) > out_len) return 0;
-
-                /* Qualifier */
-                for (size_t k = 0; k < qual_len; k++) {
-                    out[k] = (char) toupper((unsigned char) tok_start[k]);
-                }
-                out[qual_len] = '.';
-                /* Column part */
-                memcpy(out + qual_len + 1, dot + 1, rest_len);
-                out[qual_len + 1 + rest_len] = '\0';
-                return 1;
             }
             i++;
             if (*s == '\0' || *s == ';') break;

--- a/fbird_query_bind.c
+++ b/fbird_query_bind.c
@@ -91,7 +91,9 @@ int _php_fbird_safe_copy_sqlvar_data(XSQLVAR *dest_var, const XSQLVAR *src_var, 
 					field_index, dest_var->sqllen, src_var->sqllen, query_context ? query_context : "unknown");
 				return FAILURE;
 			}
-			if (dest_var->sqllen < 0 || dest_var->sqllen > 65535) {
+			/* ISC_SHORT is signed 16-bit (max 32767), so > 65535 is unreachable.
+			 * Only the < 0 check is meaningful (catches negative lengths). */
+			if (dest_var->sqllen < 0) {
 				_php_fbird_module_error("EXECUTE PROCEDURE: Invalid VARCHAR length %d for field %d in query: %s",
 					dest_var->sqllen, field_index, query_context ? query_context : "unknown");
 				return FAILURE;

--- a/fbird_service.c
+++ b/fbird_service.c
@@ -591,12 +591,14 @@ unknown_option:
 			case isc_spb_rpr_validate_db:
 			case isc_spb_rpr_sweep_db:
 				svc_action = isc_action_svc_repair;
+			/* fall through */
 
 			case isc_spb_prp_activate:
 			case isc_spb_prp_db_online:
 options_argument:
 				argument |= action;
 				action = isc_spb_options;
+			/* fall through */
 
 			case isc_spb_prp_page_buffers:
 			case isc_spb_prp_sweep_interval:

--- a/firebird.c
+++ b/firebird.c
@@ -63,10 +63,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_get_exception_mode, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-/* Firebird\Exception method arginfo */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_firebird_exception_getSqlState, 0, 0, IS_STRING, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_fbird_connect, 0, 0, MAY_BE_RESOURCE|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, database)
 	ZEND_ARG_INFO(0, username)


### PR DESCRIPTION
## Problem

Issue #273 batch 3 (final): remaining 8 compiler warnings.

## Changes (5 files, +5/-70 lines)

| File | Warning | Fix |
|---|---|---|
| `fbird_service.c:593,599` | implicit-fallthrough | Add `/* fall through */` comments (intentional fallthrough) |
| `fbird_metadata.c:403,406` | Waddress (always-true NULL check) | Remove redundant `ptr &&` — array members address is never NULL |
| `fbird_query_bind.c:94` | Wtype-limits (always-false) | Remove `> 65535` check — `ISC_SHORT` (signed short) max is 32767 |
| `fbird_connection.c:280` | unused const `dpb_args` | Delete legacy DPB array (6 bytes, superseded by `fbc_connect`) |
| `firebird.c:67` | unused arginfo | Delete duplicate definition (canonical in `fbird_error.c:168`) |
| `fbird_metadata.c:592` | unused function | Delete dead `_php_fbird_returning_token_alias` (~52 lines) + forward decl |

## Verification

- **Warnings**: 8 → **0** (excluding Zend internals)
- **Tests**: 202 pass / 76 skip / 0 fail (identical to baseline)

## Completes Issue #273

All 22 compiler warnings (excluding Zend headers) are now resolved across 3 batches:

| Batch | PR | Warnings |
|---|---|---|
| 1: unused variables | #274 (merged) | 8 |
| 2: sign-compare + initializer | #275 (merged) | 6 |
| 3: fallthrough + dead code | This PR | 8 |
| **Total** | | **22 → 0** |

Closes #273