### PR TITLE
fix: MSHUTDOWN pconnect SIGSEGV (#264) + build regression from #274

### DIFF
--- a/fbird_query_bind.c
+++ b/fbird_query_bind.c
@@ -1008,13 +1008,11 @@ int _php_fbird_bind(fbird_query *ib_query, zval *b_vars)
 					if (!ib_query->link || !ib_query->link->fbc_connection) {
 						_php_fbird_module_error("Parameter %d: OO API connection required for array binding", i + 1);
 						rv = FAILURE;
-						++array_cnt;
 						continue;
 					}
 					if (!ib_query->trans || !ib_query->trans->fbt_transaction) {
 						_php_fbird_module_error("Parameter %d: OO API transaction required for array binding", i + 1);
 						rv = FAILURE;
-						++array_cnt;
 						continue;
 					}
 
@@ -1114,7 +1112,6 @@ int _php_fbird_bind(fbird_query *ib_query, zval *b_vars)
 				if (arr_relname[0] == '\0' || arr_sqlname[0] == '\0') {
 					_php_fbird_module_error("Parameter %d: cannot determine table/column name for array binding. Use explicit INSERT INTO table (columns...) VALUES (...).", i + 1);
 					rv = FAILURE;
-					++array_cnt;
 					continue;
 				}
 
@@ -1135,7 +1132,6 @@ int _php_fbird_bind(fbird_query *ib_query, zval *b_vars)
 					) != 0) {
 					_php_fbird_error();
 					rv = FAILURE;
-					++array_cnt;
 					continue;
 				}
 
@@ -1191,7 +1187,6 @@ int _php_fbird_bind(fbird_query *ib_query, zval *b_vars)
 						default:
 							_php_fbird_module_error("Parameter %d: unsupported array element dtype %d", i + 1, ar_desc.array_desc_dtype);
 							rv = FAILURE;
-							++array_cnt;
 							continue;
 					}
 
@@ -1206,7 +1201,6 @@ int _php_fbird_bind(fbird_query *ib_query, zval *b_vars)
 						_php_fbird_module_error("Parameter %d: failed to bind array argument", i + 1);
 						efree(array_data);
 						rv = FAILURE;
-						++array_cnt;
 						continue;
 					}
 
@@ -1224,14 +1218,12 @@ int _php_fbird_bind(fbird_query *ib_query, zval *b_vars)
 						_php_fbird_error();
 						efree(array_data);
 						rv = FAILURE;
-						++array_cnt;
 						continue;
 					}
 
 					buf[i].val.qval = array_id;
 					efree(array_data);
 				}
-				++array_cnt;
 				continue;
 		} /* switch */
 

--- a/src/cpp/fb_connection.hpp
+++ b/src/cpp/fb_connection.hpp
@@ -556,31 +556,34 @@ inline bool Connection::detachNoThrow() noexcept {
         // Use getMaster() to get the current global master instead of the cached master_
         // pointer, which may be dangling if MSHUTDOWN already released the Firebird
         // client library (persistent connections destroyed after module shutdown).
-        // getMaster() returns nullptr during MSHUTDOWN, so we skip detach entirely.
+        // getMaster() returns nullptr during MSHUTDOWN - in that case, skip the
+        // Firebird API entirely. Calling pingAttachment()/detach() on a dead
+        // attachment (dropped by cleanup_db() in RSHUTDOWN) SIGSEGVs with
+        // opcache protect_memory=1 (issue #264). The Firebird client library's
+        // atexit handler cleans up server-side state on process exit.
+        // This matches the pattern already used in BlobWrapper::~BlobWrapper().
         Firebird::IMaster* master = getMaster();
         if (!master) {
-            master = master_;
+            attachment_.reset();
+            return true;
         }
-        if (master) {
-            // Liveness check: if the DB was dropped by another connection
-            // (e.g., test harness cleanup_db()), the server-side attachment
-            // is dead. Calling detach() on it SIGSEGVs on FB 3.0 (issue #260).
-            // The dropped_ flag only covers same-connection dropDatabase().
-            if (!pingAttachment(master)) {
-                attachment_.reset();
-                return true;
-            }
 
-            // Attachment is alive — safe to detach
-            CheckStatusScope status(master);
-            attachment_->detach(status.get());
-            if (status.hasError()) {
-                attachment_.reset();
-                return false;
-            }
+        // Liveness check: if the DB was dropped by another connection
+        // (e.g., test harness cleanup_db()), the server-side attachment
+        // is dead. Calling detach() on it SIGSEGVs on FB 3.0 (issue #260).
+        // The dropped_ flag only covers same-connection dropDatabase().
+        if (!pingAttachment(master)) {
+            attachment_.reset();
+            return true;
         }
-        // If no master available at all (MSHUTDOWN), just release the pointer.
-        // The Firebird client library will clean up on process exit.
+
+        // Attachment is alive - safe to detach
+        CheckStatusScope status(master);
+        attachment_->detach(status.get());
+        if (status.hasError()) {
+            attachment_.reset();
+            return false;
+        }
         attachment_.reset();
         return true;
     } catch (...) {


### PR DESCRIPTION
## Summary

Two commits:

### Commit 1: Fix build regression from PR #274
PR #274 removed the `array_cnt` declaration at `fbird_query_bind.c:527` (unused accumulator - incremented but never read) but missed 8 remaining `++array_cnt` references. This caused a build failure:
```
error: 'array_cnt' undeclared (first use in this function)
```
All 8 references were dead increments (the variable was never read), so removing them is safe.

### Commit 2: Fix MSHUTDOWN SIGSEGV (#264)

**Root cause:** During MSHUTDOWN, `getMaster()` returns `nullptr` (`in_mshutdown` flag is set). The previous code in `detachNoThrow()` fell back to the cached `master_` pointer and called `pingAttachment()` → `attachment_->getInfo()`. If the DB was dropped by `cleanup_db()` in RSHUTDOWN (test harness), the attachment is dead and `getInfo()` SIGSEGVs with `opcache protect_memory=1`.

The fallback contradicted its own comment ("we skip detach entirely") and reintroduced the exact crash PR #262 meant to prevent.

**Fix:** When `getMaster()` returns nullptr, just reset the attachment pointer and return. The Firebird client library's `atexit` handler cleans up server-side state on process exit. This matches the pattern already used in `BlobWrapper::~BlobWrapper()` (`fb_blob.hpp:63`).

**Why safe:** `getMaster() == nullptr` ⟺ `in_mshutdown == 1` ⟺ process is exiting. Skipping detach during MSHUTDOWN is the established pattern.

## Testing

- 3 consecutive full-suite runs (host, no `-n` flag, with opcache): **202 pass / 76 skip / 0 fail** each
- 0 compiler warnings from changed files
- Build succeeds cleanly

Closes #264