### PR TITLE
fix: bounds-check blob info buffer parsing to prevent OOB read (#270)

### DIFF
--- a/fbird_result.c
+++ b/fbird_result.c
@@ -570,12 +570,24 @@ static int _php_fbird_fetch_blob_field(
 		unsigned char item = bl_info[j++];
 
 		if (item == isc_info_end || item == isc_info_truncated ||
-			item == isc_info_error || j >= sizeof(bl_info)) {
+			item == isc_info_error) {
 			_php_fbird_module_error("Could not determine BLOB size (internal error)");
 			goto blob_cleanup;
 		}
 
+		/* Bounds-check: need 2 bytes for the length field */
+		if (j + 2 > sizeof(bl_info)) {
+			_php_fbird_module_error("BLOB info buffer truncated (internal error)");
+			goto blob_cleanup;
+		}
+
 		item_len = (unsigned short)isc_vax_integer((char *)&bl_info[j], 2);
+
+		/* Bounds-check: need item_len bytes for the value field */
+		if (j + 2 + item_len > sizeof(bl_info)) {
+			_php_fbird_module_error("BLOB info buffer truncated (internal error)");
+			goto blob_cleanup;
+		}
 
 		if (item == isc_info_blob_total_length) {
 			max_len = (zend_ulong)isc_vax_integer((char *)&bl_info[j + 2], item_len);


### PR DESCRIPTION
## Summary

The blob info parsing loop in `_php_fbird_fetch_blob_field()` (`fbird_result.c:568`) had two OOB read risks in the 32-byte stack buffer `bl_info[32]`:

### Risk 1: Off-by-one in the length-field read
The existing guard checked `j >= sizeof(bl_info)` but `isc_vax_integer(&bl_info[j], 2)` reads **2 bytes**, so `j=31` would read `bl_info[32]` (OOB). Fixed by checking `j + 2 > sizeof(bl_info)`.

### Risk 2: Unchecked value-field read
`isc_vax_integer(&bl_info[j+2], item_len)` had **no bounds check at all**. A malformed response with large `item_len` could read past the buffer. Fixed by checking `j + 2 + item_len > sizeof(bl_info)`.

### Pattern alignment
The imprecise `j >= sizeof(bl_info)` guard was removed from the terminator check (subsumed by the new `j + 2` check). This matches the correct pattern already used in `fbt_get_limbo_transactions()` (`firebird_utils.cpp:3023`).

## Testing

- Full suite: **202 pass / 76 skip / 0 fail**
- No compiler warnings from changed file

## Scope

Issue #270 only. The similar unbounded parsing in `pdo_fbird_driver.c` (service manager) tracked separately in #278.

Closes #270