### PR TITLE
fix: error on missing blob total_length instead of silent empty string (#271)

### DIFF
--- a/fbird_result.c
+++ b/fbird_result.c
@@ -565,6 +565,8 @@ static int _php_fbird_fetch_blob_field(
 		goto blob_cleanup;
 	}
 
+	bool found_length = false;
+
 	for (unsigned j = 0; j < sizeof(bl_info); ) {
 		unsigned short item_len;
 		unsigned char item = bl_info[j++];
@@ -591,9 +593,15 @@ static int _php_fbird_fetch_blob_field(
 
 		if (item == isc_info_blob_total_length) {
 			max_len = (zend_ulong)isc_vax_integer((char *)&bl_info[j + 2], item_len);
+			found_length = true;
 			break;
 		}
 		j += item_len + 2;
+	}
+
+	if (!found_length) {
+		_php_fbird_module_error("Could not determine BLOB total length");
+		goto blob_cleanup;
 	}
 
 	if (max_len == 0) {


### PR DESCRIPTION
## Summary

In `_php_fbird_fetch_blob_field()` (`fbird_result.c`), if the Firebird info response omits `isc_info_blob_total_length`, `max_len` stayed at 0 and the code silently returned `""` for a non-empty blob - data loss without any error indication.

Firebird protocol guarantees that even a zero-length blob reports `isc_info_blob_total_length` with value 0. So `max_len == 0` from a legitimate empty blob is explicitly set by `isc_vax_integer()`. The bug only manifests when the item is **never found** in the response.

## Fix

Add a `bool found_length` flag to distinguish the two scenarios:

| Scenario | `found_length` | `max_len` | Behavior |
|----------|------------------|------------|----------|
| Legitimate zero-length blob | true | 0 (set by isc_vax_integer) | `ZVAL_STRING(result, "")` (correct) |
| Missing total_length item | false | 0 (initializer) | Error + `goto blob_cleanup` (new) |

The `bool` type is already used at `fbird_result.c:762`, so this is consistent with the codebase.

## Testing

- Full suite: **202 pass / 76 skip / 0 fail**

Closes #271