### PR TITLE
fix: bounds-check isc_vax_integer parsing in 5 sibling sites (#278, #280)

### DIFF
--- a/fbird_classes.c
+++ b/fbird_classes.c
@@ -1070,8 +1070,17 @@ PHP_METHOD(FirebirdService, getServerVersion)
 	}
 
 	char *result = res_buf;
-	if (*result == isc_info_svc_server_version) {
+	const char *end = res_buf + sizeof(res_buf);
+	if (result < end && *result == isc_info_svc_server_version) {
+		/* Bounds-check: need 2 bytes for the length field (result+1, result+2) */
+		if (result + 3 > end) {
+			RETURN_STRING("");
+		}
 		int len = isc_vax_integer(result + 1, 2);
+		/* Bounds-check: need len bytes for the value, and len must be non-negative */
+		if (len < 0 || result + 3 + len > end) {
+			RETURN_STRING("");
+		}
 		RETURN_STRINGL(result + 3, len);
 	}
 	RETURN_STRING("");

--- a/fbird_transaction.c
+++ b/fbird_transaction.c
@@ -540,10 +540,21 @@ PHP_FUNCTION(fbird_trans_info)
 
 	array_init(return_value);
 
-	while (*p != isc_info_end && p < res_buf + sizeof(res_buf)) {
+	const char *end = res_buf + sizeof(res_buf);
+	while (p < end && *p != isc_info_end) {
 		unsigned char item = *p++;
+
+		/* Bounds-check: need 2 bytes for the length field */
+		if (p + 2 > end) {
+			break;
+		}
 		unsigned short len = (unsigned short)isc_vax_integer(p, 2);
 		p += 2;
+
+		/* Bounds-check: need len bytes for the value field */
+		if (p + len > end) {
+			break;
+		}
 
 		switch (item) {
 			case isc_info_tra_id:
@@ -647,10 +658,21 @@ PHP_FUNCTION(fbird_connection_info)
 	array_init(return_value);
 	p = res_buf;
 
-	while (*p != isc_info_end && p < res_buf + sizeof(res_buf)) {
+	const char *end = res_buf + sizeof(res_buf);
+	while (p < end && *p != isc_info_end) {
 		unsigned char item = *p++;
+
+		/* Bounds-check: need 2 bytes for the length field */
+		if (p + 2 > end) {
+			break;
+		}
 		unsigned short len = (unsigned short)isc_vax_integer(p, 2);
 		p += 2;
+
+		/* Bounds-check: need len bytes for the value field */
+		if (p + len > end) {
+			break;
+		}
 
 		switch (item) {
 			case isc_info_reads:

--- a/pdo_fbird/pdo_fbird_driver.c
+++ b/pdo_fbird/pdo_fbird_driver.c
@@ -470,7 +470,8 @@ static char *_pdo_fbird_service_query_line(pdo_dbh_t *dbh, char info_action)
 	}
 
 	char *result = res_buf;
-	while (*result != isc_info_end) {
+	const char *end = res_buf + sizeof(res_buf);
+	while (result < end && *result != isc_info_end) {
 		switch (*result++) {
 			case isc_info_svc_server_version:
 			case isc_info_svc_implementation:
@@ -478,7 +479,15 @@ static char *_pdo_fbird_service_query_line(pdo_dbh_t *dbh, char info_action)
 			case isc_info_svc_get_env_lock:
 			case isc_info_svc_get_env_msg:
 			case isc_info_svc_user_dbpath: {
+				/* Bounds-check: need 2 bytes for the length field */
+				if (result + 2 > end) {
+					return NULL;
+				}
 				int len = isc_vax_integer(result, 2);
+				/* Bounds-check: need len bytes for the value, and len must be non-negative */
+				if (len < 0 || result + 2 + len > end) {
+					return NULL;
+				}
 				char *str = emalloc(len + 1);
 				memcpy(str, result + 2, len);
 				str[len] = '\0';
@@ -510,12 +519,23 @@ static char *_pdo_fbird_service_query_lines(pdo_dbh_t *dbh)
 		}
 
 		char *result = res_buf;
+		const char *end = res_buf + sizeof(res_buf);
 		int done = 0;
-		while (*result != isc_info_end && !done) {
+		while (result < end && *result != isc_info_end && !done) {
 			switch (*result++) {
 				case isc_info_svc_line: {
+					/* Bounds-check: need 2 bytes for the length field */
+					if (result + 2 > end) {
+						done = 1;
+						break;
+					}
 					int len = isc_vax_integer(result, 2);
 					if (len == 0) { done = 1; break; }
+					/* Bounds-check: need len bytes for the value, and len must be non-negative */
+					if (len < 0 || result + 2 + len > end) {
+						done = 1;
+						break;
+					}
 					result += 2;
 					smart_str_appendl(&output, result, len);
 					smart_str_appendc(&output, '\n');


### PR DESCRIPTION
## Summary

Apply the two-check bounds pattern from #270 to the remaining 5 info buffer parsing sites that had unbounded `isc_vax_integer` reads.

### #278 — PDO service manager (`pdo_fbird/pdo_fbird_driver.c`)

| Site | Function | Buffer | Bugs |
|------|----------|--------|------|
| 1 | `_pdo_fbird_service_query_line()` | 512B | Unchecked 2-byte length read, unchecked `memcpy`, signed `int len` could go negative |
| 2 | `_pdo_fbird_service_query_lines()` | 4096B | Same pattern |

### #280 — Transaction info + service version

| Site | Function | File | Buffer | Bugs |
|------|----------|------|--------|------|
| 3 | `fbird_transaction_info()` | `fbird_transaction.c` | 128B | Off-by-one in loop guard, unchecked value reads |
| 4 | `fbird_connection_info()` | `fbird_transaction.c` | 512B | Same pattern |
| 5 | `getServerVersion()` | `fbird_classes.c` | 256B | Single-item check, no bounds on length or value |

### Fix per site

1. `ptr + 2 > end` check before the 2-byte length read
2. `ptr + 2 + len > end` check before the value read
3. `len < 0` check where `int len` is signed (sites 1, 2, 5)
4. `const char *end` pointer to avoid repeating buffer bound expression
5. Error handling matches each site's existing convention (`return NULL`, `break`, or `RETURN_STRING("")`)

## Testing

- Full suite: **202 pass / 76 skip / 0 fail**

Closes #278, Closes #280