### PR TITLE
fix: CI security hardening + SPB bounds check (#223, #224, #225, #230)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,7 +569,12 @@ jobs:
         run: |
           # Download composer binary only if not already present
           if ! command -v composer >/dev/null 2>&1; then
-            curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+            EXPECTED_SIGNATURE="$(curl -sS https://composer.github.io/installer.sig)"
+            curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
+            ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', '/tmp/composer-setup.php');")"
+            [ "$EXPECTED_SIGNATURE" = "$ACTUAL_SIGNATURE" ] || { echo "ERROR: Invalid Composer installer signature"; exit 1; }
+            php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
+            rm -f /tmp/composer-setup.php
           fi
           composer install --prefer-dist --no-progress --no-interaction
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,10 +64,13 @@ jobs:
           set -eu
 
           # Download and install Firebird 5.0 for client libraries
-          FB_SCRIPT_URL="https://raw.githubusercontent.com/IBSurgeon/firebirdlinuxinstall/refs/heads/main/fb_vanilla-50.sh"
+          # Pinned to specific commit SHA for supply-chain safety (issue #223).
+          # Update by changing the SHA after reviewing the script at:
+          # https://github.com/IBSurgeon/firebirdlinuxinstall/commit/<NEW_SHA>
+          FB_SCRIPT_URL="https://raw.githubusercontent.com/IBSurgeon/firebirdlinuxinstall/4a0b76a957c9ba75da1307c8ee5f9ccfc6f823c9/fb_vanilla-50.sh"
           curl -fsSL "${FB_SCRIPT_URL}" -o /tmp/fb_install.sh
           chmod +x /tmp/fb_install.sh
-          printf '\n' | /tmp/fb_install.sh || true
+          printf '\n' | /tmp/fb_install.sh
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -396,7 +396,12 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+          EXPECTED_SIGNATURE="$(curl -sS https://composer.github.io/installer.sig)"
+          curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
+          ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', '/tmp/composer-setup.php');")"
+          [ "$EXPECTED_SIGNATURE" = "$ACTUAL_SIGNATURE" ] || { echo "ERROR: Invalid Composer installer signature"; exit 1; }
+          php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
+          rm -f /tmp/composer-setup.php
           composer install --prefer-dist --no-progress
 
       - name: Run PHPT tests

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -34,10 +34,7 @@ on:
         description: 'Release tag to build for (optional)'
         required: false
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+permissions: read-all
 
 env:
   FIREBIRD_SDK_CACHE_KEY: firebird-sdk-v2
@@ -142,6 +139,10 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     if: |
       github.event_name == 'release' ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -692,7 +692,12 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+          EXPECTED_SIGNATURE="$(curl -sS https://composer.github.io/installer.sig)"
+          curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
+          ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', '/tmp/composer-setup.php');")"
+          [ "$EXPECTED_SIGNATURE" = "$ACTUAL_SIGNATURE" ] || { echo "ERROR: Invalid Composer installer signature"; exit 1; }
+          php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
+          rm -f /tmp/composer-setup.php
           composer install --prefer-dist --no-progress
 
       - name: Run tests with LeakSanitizer

--- a/fbird_service.c
+++ b/fbird_service.c
@@ -512,6 +512,10 @@ static void _php_fbird_backup_restore(INTERNAL_FUNCTION_PARAMETERS, char operati
 		(char)opts,(char)(opts >> 8), (char)(opts >> 16), (char)(opts >> 24));
 
 	if (verbose) {
+		if (spb_len >= sizeof(buf)) {
+			_php_fbird_module_error("Internal error: SPB buffer overflow for verbose flag");
+			RETURN_FALSE;
+		}
 		buf[spb_len++] = isc_spb_verbose;
 	}
 

--- a/tests/fbird_service_backup_verbose.phpt
+++ b/tests/fbird_service_backup_verbose.phpt
@@ -1,0 +1,51 @@
+--TEST--
+fbird_backup with verbose=true: exercises SPB verbose flag path (#230)
+--EXTENSIONS--
+firebird
+--SKIPIF--
+<?php
+if (!extension_loaded('firebird')) die('skip firebird extension not available');
+$host     = getenv('FIREBIRD_HOST') ?: 'localhost';
+$user     = getenv('ISC_USER')      ?: 'SYSDBA';
+$password = getenv('ISC_PASSWORD')  ?: 'masterkey';
+$svc = @fbird_service_attach($host, $user, $password);
+if (!$svc) die('skip: cannot attach to Firebird service manager');
+fbird_service_detach($svc);
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/firebird.inc';
+
+$host     = getenv('FIREBIRD_HOST') ?: 'localhost';
+$user     = getenv('ISC_USER')      ?: 'SYSDBA';
+$password = getenv('ISC_PASSWORD')  ?: 'masterkey';
+
+// Strip host prefix - service manager expects server-side path
+$db_path = $test_base;
+if (!empty($host) && strpos($test_base, $host . ':') === 0) {
+    $db_path = substr($test_base, strlen($host) + 1);
+}
+
+$bakfile = '/tmp/fbird_verbose_bkp_' . getmypid() . '.fbk';
+
+// Attach to service manager
+$s = @fbird_service_attach($host, $user, $password);
+if (!$s) die("ERROR: cannot attach to service manager\n");
+
+// Backup with verbose=true - this exercises the isc_spb_verbose SPB path (#230).
+// Verbose mode returns service output lines as a string instead of true.
+$r = fbird_backup($s, $db_path, $bakfile, 0, true);
+
+fbird_service_detach($s);
+
+// Verbose backup returns either true or a string of service output lines.
+// The key assertion is that it does NOT crash (Termsig=11) and does NOT return false.
+var_dump($r !== false);
+var_dump($r === true || is_string($r));
+
+echo "ok\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+ok


### PR DESCRIPTION
## Summary

4 fixes in one PR — 3 CI security hardening + 1 C code bounds check.

### #223 — Pin IBSurgeon install script (codeql.yml)
Replaced mutable `refs/heads/main` URL with pinned commit SHA `4a0b76a9`. Removed `|| true` so install failures fail the workflow instead of being silently swallowed.

### #224 — Replace curl-pipe Composer (3 workflows)
Replaced `curl -sS https://getcomposer.org/installer | php` with signature-verified installation in `ci.yml`, `coverage.yml`, `sanitizers.yml`. Downloads installer to file, verifies SHA384 signature against `composer.github.io/installer.sig`, then executes. `ci.yml` keeps its existing `command -v composer` guard.

### #225 — Scope permissions to release job (release-windows.yml)
Changed top-level `permissions` from `contents: write, id-token: write, attestations: write` to `read-all`. Moved the 3 write permissions to the `release` job only — the `build` job no longer has write access it doesn't need.

### #230 — Bounds-check before verbose write (fbird_service.c)
Added `spb_len >= sizeof(buf)` check before writing `isc_spb_verbose` to the SPB buffer. Previously the verbose flag was written before the bounds check ran.

## Testing
- Build: ✅
- Full suite: **202 pass / 76 skip / 0 fail**

Also closes #220 (already fixed in commit c3193f9, issue was left open).

Closes #223, Closes #224, Closes #225, Closes #230