### PR TITLE
fix: add E_WARNING before silent RETURN_FALSE on 5 error paths (#231)

### DIFF
--- a/fbird_connection.c
+++ b/fbird_connection.c
@@ -617,12 +617,14 @@ PHP_FUNCTION(fbird_close)
 		is_default_link = true;
 
 		if (link_res == NULL) {
+			php_error_docref(NULL, E_WARNING, "No default connection to close");
 			RETURN_FALSE;
 		}
 	} else {
 		/* Explicit link path: accept resource or Connection object */
 		link_res = _php_fbird_res_from_zval(link_arg);
 		if (link_res == NULL) {
+			php_error_docref(NULL, E_WARNING, "Argument #1 must be a valid Firebird connection resource or Firebird\\Connection object");
 			RETURN_FALSE;
 		}
 		is_default_link = (IBG(default_link) == link_res);

--- a/fbird_service.c
+++ b/fbird_service.c
@@ -319,6 +319,7 @@ PHP_FUNCTION(fbird_service_detach)
 
 	svc_res = _php_fbird_service_res_from_zval(res);
 	if (!svc_res) {
+		php_error_docref(NULL, E_WARNING, "Argument #1 must be a valid Firebird service handle or Firebird\\Service object");
 		RETURN_FALSE;
 	}
 

--- a/fbird_transaction.c
+++ b/fbird_transaction.c
@@ -318,6 +318,7 @@ PHP_FUNCTION(fbird_trans_start)
 	}
 
 	if (!ib_link) {
+		php_error_docref(NULL, E_WARNING, "Invalid database link");
 		RETURN_FALSE;
 	}
 
@@ -633,6 +634,7 @@ PHP_FUNCTION(fbird_connection_info)
 	}
 
 	if (!ib_link) {
+		php_error_docref(NULL, E_WARNING, "Invalid database link");
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
## Summary

5 sites returned `false` with no error message, leaving callers unable to determine the cause. Each now emits `php_error_docref(NULL, E_WARNING, ...)` before `RETURN_FALSE`.

### Issue #231 sites (4)

| # | File | Function | Condition | Warning message |
|---|------|----------|-----------|----------------|
| 1 | `fbird_connection.c` | `fbird_close()` | `default_link == NULL` | `"No default connection to close"` |
| 2 | `fbird_connection.c` | `fbird_close()` | `_php_fbird_res_from_zval` returns NULL | `"Argument #1 must be a valid Firebird connection resource or Firebird\\Connection object"` |
| 3 | `fbird_transaction.c` | `fbird_trans_start()` | `!ib_link` | `"Invalid database link"` |
| 4 | `fbird_service.c` | `fbird_service_detach()` | `svc_res == NULL` | `"Argument #1 must be a valid Firebird service handle or Firebird\\Service object"` |

### Sibling site (1, discovered during review)

| # | File | Function | Condition | Warning message |
|---|------|----------|-----------|----------------|
| 5 | `fbird_transaction.c` | `fbird_connection_info()` | `!ib_link` | `"Invalid database link"` |

Same silent `RETURN_FALSE` pattern as site 3, same file, not listed in the issue. Included for completeness.

### Pattern

All use `php_error_docref(NULL, E_WARNING, ...)` matching the established pattern in:
- `CHECK_LINK` macro (`php_fbird_includes.h:41`)
- `fbird_connection.c:538`
- `fbird_transaction.c:404, 515`

## Testing

- Build: ✅
- Full suite: **203 pass / 76 skip / 0 fail**

Closes #231