### PR TITLE
fix: qa.sh matrix PHP 8.2 + implement PDO_FBIRD_ATTR_PAGE_BUFFERS (#238, #240)

### DIFF
--- a/firebird_utils.cpp
+++ b/firebird_utils.cpp
@@ -513,7 +513,9 @@ extern "C" void* fbc_connect(
         if (charset && charset_len > 0) params.charset = std::string_view(charset, charset_len);
         if (role && role_len > 0) params.role = std::string_view(role, role_len);
         params.dialect = static_cast<unsigned short>(dialect);
-        // Note: num_buffers and force_write could be added to DPB in future
+        if (num_buffers > 0) {
+            params.num_buffers = static_cast<unsigned short>(num_buffers);
+        }
 
         // Create connection using factory method
         auto conn = fb::Connection::create(master, params);

--- a/pdo_fbird/pdo_fbird_driver.c
+++ b/pdo_fbird/pdo_fbird_driver.c
@@ -643,6 +643,19 @@ static bool pdo_fbird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval 
 		case PDO_FBIRD_ATTR_DIALECT:
 			H->dialect = (int)zval_get_long(val);
 			return true;
+		case PDO_FBIRD_ATTR_PAGE_BUFFERS:
+			if (H->fbc_conn) {
+				pdo_raise_impl_error(dbh, NULL, "IM001",
+					"FBIRD_ATTR_PAGE_BUFFERS is read-only after connection; set via DSN page_buffers=N");
+				return false;
+			}
+			if (zval_get_long(val) < 0) {
+				pdo_raise_impl_error(dbh, NULL, "HY000",
+					"FBIRD_ATTR_PAGE_BUFFERS must be a non-negative integer");
+				return false;
+			}
+			H->num_buffers = (int)zval_get_long(val);
+			return true;
 		case PDO_FBIRD_ATTR_CHARSET:
 			if (H->charset) efree(H->charset);
 			H->charset = estrdup(Z_STRVAL_P(val));
@@ -908,6 +921,9 @@ static int pdo_fbird_handle_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 			return 1;
 		case PDO_FBIRD_ATTR_DIALECT:
 			ZVAL_LONG(val, H->dialect);
+			return 1;
+		case PDO_FBIRD_ATTR_PAGE_BUFFERS:
+			ZVAL_LONG(val, H->num_buffers);
 			return 1;
 		case PDO_FBIRD_ATTR_CHARSET:
 			ZVAL_STRING(val, H->charset ? H->charset : "");
@@ -1200,6 +1216,7 @@ static int pdo_fbird_handle_factory(pdo_dbh_t *dbh, zval *driver_options)
 			else if (!strcasecmp(key, "charset")) snprintf(charset, sizeof(charset), "%s", v);
 			else if (!strcasecmp(key, "role"))    snprintf(role,    sizeof(role),    "%s", v);
 			else if (!strcasecmp(key, "dialect")) dialect = atoi(v);
+			else if (!strcasecmp(key, "page_buffers")) H->num_buffers = atoi(v);
 		}
 		tok = strtok_r(NULL, ";", &saveptr);
 	}
@@ -1221,7 +1238,7 @@ static int pdo_fbird_handle_factory(pdo_dbh_t *dbh, zval *driver_options)
 		dbh->password  ? dbh->password  : "", dbh->password  ? strlen(dbh->password)  : 0,
 		charset[0] ? charset : NULL,           charset[0] ? strlen(charset) : 0,
 		role[0]    ? role    : NULL,           role[0]    ? strlen(role)    : 0,
-		0,       /* num_buffers */
+		H->num_buffers,  /* page buffers (0 = server default) */
 		dialect,
 		-1,      /* force_write: not set */
 		H->status

--- a/pdo_fbird/php_pdo_fbird_int.h
+++ b/pdo_fbird/php_pdo_fbird_int.h
@@ -22,6 +22,7 @@ typedef struct {
 	int          isolation_level; /* PDO_FBIRD_TXN_READ_COMMITTED etc */
 	int          writable;      /* 1 = read/write txn (default), 0 = read-only */
 	int          fetch_table_names; /* 1 = prepend table name to column names */
+	int          num_buffers;       /* page buffer count (0 = server default) */
 	char        *host;             /* server hostname for service API   */
 	char        *date_format;       /* strftime format for DATE columns */
 	char        *time_format;       /* strftime format for TIME columns */

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -19,17 +19,17 @@
 #   full     - Standard + Valgrind memory analysis + UBSan
 #   security - Full + Gitleaks secret scanning
 #   fuzz     - Run fuzzing (without ASan due to PHP compatibility issues)
-#   matrix   - Test across PHP 8.1/FB3 (oldest) and PHP 8.5/FB5 (newest)
+#   matrix   - Test across PHP 8.2/FB3 (oldest) and PHP 8.5/FB5 (newest)
 #
 # Matrix Testing:
 #   The 'matrix' mode runs the full test suite across:
-#     - php81-fb3-dev (PHP 8.1 + Firebird 3.0) - oldest supported
+#     - php82-fb3-dev (PHP 8.2 + Firebird 3.0) - oldest supported
 #     - php85-fb5-dev (PHP 8.5 + Firebird 5.0) - newest supported
 #
 # Examples:
 #   ./scripts/qa.sh --mode fast                    # Quick static analysis
 #   ./scripts/qa.sh --mode matrix                  # Test oldest + newest combinations
-#   ./scripts/qa.sh --valgrind --container php81-fb3-dev  # Valgrind on PHP 8.1/FB3
+#   ./scripts/qa.sh --valgrind --container php82-fb3-dev  # Valgrind on PHP 8.2/FB3
 #   ./scripts/qa.sh --valgrind --container php85-fb5-dev  # Valgrind on PHP 8.5/FB5
 #   ./scripts/qa.sh --asan                         # ASan with php83-asan container
 
@@ -123,7 +123,7 @@ if [ "$MODE" == "matrix" ]; then
     
     # Matrix configurations: container:firebird_server:description
     MATRIX_CONFIGS=(
-        "php81-fb3-dev:firebird30:PHP 8.1 + Firebird 3.0 (oldest)"
+        "php82-fb3-dev:firebird30:PHP 8.2 + Firebird 3.0 (oldest)"
         "php84-fb3-dev:firebird30:PHP 8.4 + Firebird 3.0 (amicron-platform)"
         "php85-fb5-dev:firebird50:PHP 8.5 + Firebird 5.0 (newest)"
     )

--- a/tests/pdo_fbird_page_buffers.phpt
+++ b/tests/pdo_fbird_page_buffers.phpt
@@ -1,0 +1,62 @@
+--TEST--
+PDO_FBIRD: page_buffers DSN option and getAttribute round-trip (#240)
+--SKIPIF--
+<?php
+if (!extension_loaded('PDO')) die('skip PDO not loaded');
+if (!in_array('fbird', PDO::getAvailableDrivers())) die('skip pdo_fbird not loaded');
+require_once __DIR__ . '/config.inc';
+$dbEnv = getenv('FIREBIRD_DB_PATH') ?: getenv('FIREBIRD_DATABASE');
+$db = ($dbEnv ?: '/firebird/data/test.fdb');
+$dsn = "fbird:host={$host};dbname={$db}";
+try { new PDO($dsn, $user, $password); } catch (Throwable $e) { die('skip cannot connect: ' . $e->getMessage()); }
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/config.inc';
+$dbEnv = getenv('FIREBIRD_DB_PATH') ?: getenv('FIREBIRD_DATABASE');
+$db = ($dbEnv ?: '/firebird/data/test.fdb');
+$dsn_base = "fbird:host={$host};dbname={$db}";
+
+// Connect WITH page_buffers=2048 in DSN
+$pdo = new PDO($dsn_base . ';page_buffers=2048', $user, $password,
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+// getAttribute should return the value parsed from DSN
+$buffers = $pdo->getAttribute(PDO::FBIRD_ATTR_PAGE_BUFFERS);
+echo "page_buffers from getAttribute: ";
+var_dump($buffers);
+
+// Verify the value matches
+if ($buffers === 2048) {
+    echo "PASS: value matches\n";
+} else {
+    echo "FAIL: expected 2048, got $buffers\n";
+}
+
+// setAttribute after connect should fail with IM001
+try {
+    $pdo->setAttribute(PDO::FBIRD_ATTR_PAGE_BUFFERS, 4096);
+    echo "FAIL: setAttribute should have thrown\n";
+} catch (PDOException $e) {
+    if (strpos($e->getCode(), 'IM001') !== false) {
+        echo "PASS: setAttribute correctly rejected with IM001\n";
+    } else {
+        echo "FAIL: expected IM001, got " . $e->getCode() . "\n";
+    }
+}
+
+// Connect WITHOUT page_buffers — should default to 0
+$pdo2 = new PDO($dsn_base, $user, $password,
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+$buffers2 = $pdo2->getAttribute(PDO::FBIRD_ATTR_PAGE_BUFFERS);
+echo "default page_buffers: ";
+var_dump($buffers2);
+
+echo "Done\n";
+?>
+--EXPECT--
+page_buffers from getAttribute: int(2048)
+PASS: value matches
+PASS: setAttribute correctly rejected with IM001
+default page_buffers: int(0)
+Done


### PR DESCRIPTION
## Summary

### #238 — qa.sh matrix references non-existent php81-fb3-dev

4 text replacements in `scripts/qa.sh`: `php81-fb3-dev` -> `php82-fb3-dev`, `PHP 8.1` -> `PHP 8.2` in matrix config and comments. PHP 8.1 was dropped in v7.2.0.

### #240 — PDO_FBIRD_ATTR_PAGE_BUFFERS registered but never handled

Constant 1004 was defined in `php_pdo_fbird.h` and registered via `zend_declare_class_constant_long()` but the setAttribute/getAttribute switch had no case for it. The attribute silently did nothing.

**Implemented across 3 files:**

| File | Change |
|------|--------|
| `pdo_fbird/php_pdo_fbird_int.h` | Add `int num_buffers` to `pdo_fbird_db_handle` |
| `pdo_fbird/pdo_fbird_driver.c` (handle_factory) | Parse `page_buffers=N` from DSN, use at connect time (was hardcoded 0) |
| `pdo_fbird/pdo_fbird_driver.c` (setAttribute) | Error if already connected (IM001) |
| `pdo_fbird/pdo_fbird_driver.c` (getAttribute) | Return active value |

Page buffers is a connection-time DPB setting. It can only be set via DSN, not changed after connect.

Usage:
```php
$pdo = new PDO('fbird:dbname=/path/db.fdb;page_buffers=2048', 'user', 'pass');
echo $pdo->getAttribute(PDO::FBIRD_ATTR_PAGE_BUFFERS); // 2048
```

## Testing

- Build: ✅
- Full suite: **203 pass / 76 skip / 0 fail**

Closes #238, Closes #240