### PR TITLE
fix: correct FBIRD_VER in stubs, add FBIRD_EXCEPTION_MODE_COMPAT, remove continue-on-error

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -174,10 +174,10 @@ jobs:
             --inline-suppr \
             *.c *.cpp
 
-      - name: Run clang-tidy (informational)
-        continue-on-error: true
+      - name: Run clang-tidy (informational, non-blocking per-file due to PHP header noise)
         run: |
-          # Run clang-tidy on C files (informational, not blocking)
+          # clang-tidy output is informational; PHP headers generate unavoidable
+          # warnings. Per-file `|| true` prevents blocking on those. Review logs manually.
           for file in *.c *.cpp; do
             if [ -f "$file" ]; then
               echo "Analyzing $file..."

--- a/phpstan/fbird-bootstrap.php
+++ b/phpstan/fbird-bootstrap.php
@@ -27,8 +27,21 @@ if (!defined('FBIRD_DEFAULT')) {
     /** Force new connection (bypass connection reuse) */
     define('FBIRD_CONNECT_FORCE_NEW', 2);
 
-    /** Extension version */
-    define('FBIRD_VER', 10);
+    /** Extension version (100 for 10.x+ series) */
+    define('FBIRD_VER', 100);
+
+    // ========================================================================
+    // EXCEPTION MODE CONSTANTS
+    // ========================================================================
+
+    /** Exception mode: suppress errors (default) */
+    define('FBIRD_EXCEPTION_MODE_SILENT', 0);
+
+    /** Exception mode: throw exceptions on errors */
+    define('FBIRD_EXCEPTION_MODE_THROW', 1);
+
+    /** Exception mode: backward-compatible alias for SILENT (default) */
+    define('FBIRD_EXCEPTION_MODE_COMPAT', 0);
 
     // ========================================================================
     // FETCH FLAGS

--- a/phpstan/fbird.stub.php
+++ b/phpstan/fbird.stub.php
@@ -25,8 +25,8 @@ const FBIRD_CREATE = 0;
 /** Force new connection (bypass connection reuse) */
 const FBIRD_CONNECT_FORCE_NEW = 2;
 
-/** Extension version */
-const FBIRD_VER = 10;
+/** Extension version (100 for 10.x+ series) */
+const FBIRD_VER = 100;
 
 // ============================================================================
 // EXCEPTION MODE CONSTANTS
@@ -37,6 +37,9 @@ const FBIRD_EXCEPTION_MODE_SILENT = 0;
 
 /** Exception mode: throw exceptions on errors */
 const FBIRD_EXCEPTION_MODE_THROW = 1;
+
+/** Exception mode: backward-compatible alias for SILENT (default) */
+const FBIRD_EXCEPTION_MODE_COMPAT = 0;
 
 // ============================================================================
 // FETCH FLAGS

--- a/stubs/firebird-stubs.php
+++ b/stubs/firebird-stubs.php
@@ -39,8 +39,8 @@ const FBIRD_CREATE = 0;
 /** @var int Force new connection (bypass connection reuse) */
 const FBIRD_CONNECT_FORCE_NEW = 2;
 
-/** @var int Extension version (e.g. 90 for 9.0.x) */
-const FBIRD_VER = 90;
+/** @var int Extension version (100 for 10.x+ series) */
+const FBIRD_VER = 100;
 
 // ============================================================================
 // EXCEPTION MODE CONSTANTS
@@ -51,6 +51,9 @@ const FBIRD_EXCEPTION_MODE_SILENT = 0;
 
 /** @var int Exception mode: throw exceptions on errors */
 const FBIRD_EXCEPTION_MODE_THROW = 1;
+
+/** @var int Exception mode: backward-compatible alias for SILENT (default) */
+const FBIRD_EXCEPTION_MODE_COMPAT = 0;
 
 // ============================================================================
 // FETCH FLAGS


### PR DESCRIPTION
Closes #228, Closes #229, Closes #236.

**#228**: FBIRD_VER was 90 in stubs, 10 in phpstan files, runtime is 100. Fixed all 3 stub locations.

**#229**: FBIRD_EXCEPTION_MODE_COMPAT registered at runtime (= 0, same as SILENT) but missing from all 3 stub files. Added.

**#236**: Removed `continue-on-error: true` from clang-tidy step. Step was already non-blocking via `|| true` per-command. Added comment explaining why.