### PR TITLE
fix: standardize VERSION.txt across workflows, fail-fast instead of stale 7.0.0 (#226, #227)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,16 +146,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Ensure VERSION file
+      - name: Ensure VERSION.txt file
         shell: bash
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             echo "${GITHUB_REF#refs/tags/v}" > VERSION.txt
-            echo "Updated VERSION file from tag: $(cat VERSION.txt)"
+            echo "Updated VERSION.txt from tag: $(cat VERSION.txt)"
           elif [ ! -f VERSION.txt ]; then
             VERSION=$(grep -E '#define PHP_FIREBIRD_VERSION_STRING' php_firebird.h | sed 's/.*"\([^"]*\)".*/\1/' | head -1)
-            echo "${VERSION:-7.0.0}" > VERSION.txt
-            echo "Created VERSION file from header/default: $(cat VERSION.txt)"
+            if [ -z "$VERSION" ] || [[ "$VERSION" == *"unknown"* ]]; then
+              echo "ERROR: Cannot determine version" >&2
+              exit 1
+            fi
+            echo "${VERSION}" > VERSION.txt
+            echo "Created VERSION.txt from header: $(cat VERSION.txt)"
           fi
 
       - name: Install system dependencies
@@ -641,12 +645,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Ensure VERSION file
+      - name: Ensure VERSION.txt file
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             echo "${GITHUB_REF#refs/tags/v}" > VERSION.txt
           elif [ ! -f VERSION.txt ]; then
-            echo "0.0.0-unknown" > VERSION.txt
+            echo "ERROR: Cannot determine version" >&2
+            exit 1
           fi
 
       - name: Install PHP via Homebrew
@@ -751,21 +756,7 @@ jobs:
           phpize
           ./configure --with-firebird="${FB_CLIENT_DIR}"
 
-          # WORKAROUND: macOS uses case-insensitive APFS by default.
-          # Our VERSION file conflicts with the C++ standard <version> header
-          # because phpize adds -I. to the include path. Temporarily hide it
-          # during compilation (configure already read it via config.m4).
-          if [ -f VERSION.txt ]; then
-            mv VERSION.txt VERSION.txt.bak
-            echo "Temporarily renamed VERSION.txt to avoid C++ header conflict"
-          fi
-
           make -j"$(sysctl -n hw.ncpu)"
-
-          # Restore VERSION.txt file
-          if [ -f VERSION.txt.bak ]; then
-            mv VERSION.txt.bak VERSION.txt
-          fi
 
           echo "Extension built successfully"
           ls -la modules/firebird.so

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -189,7 +189,7 @@ jobs:
           done
 
   # ==========================================================================
-  # Version Stamp Check (stubs @version must match VERSION file)
+  # Version Stamp Check (stubs @version must match VERSION.txt)
   # ==========================================================================
   version-stamps:
     name: Version Stamps Check
@@ -199,7 +199,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Check stubs @version tags match VERSION file
+      - name: Check stubs @version tags match VERSION.txt
         run: |
           chmod +x scripts/check-version-stamps.sh
           bash scripts/check-version-stamps.sh

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -73,20 +73,19 @@ jobs:
           # Priority 1: Git tag (for immutable release builds)
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
-            # Update VERSION file if it exists or create it
-            echo "${VERSION}" > VERSION
-            echo "Updated VERSION file from tag: ${VERSION}"
-          # Priority 2: VERSION file (source of truth for development)
-          elif [ -f VERSION ]; then
-            VERSION=$(cat VERSION | tr -d '[:space:]')
-          # Fallback: php_firebird.h or static default
+            echo "${VERSION}" > VERSION.txt
+            echo "Updated VERSION.txt from tag: ${VERSION}"
+          # Priority 2: VERSION.txt (source of truth; .txt avoids C++ <version> header conflict)
+          elif [ -f VERSION.txt ]; then
+            VERSION=$(cat VERSION.txt | tr -d '[:space:]')
+          # Fallback: php_firebird.h or fail
           else
             VERSION=$(grep -E '#define PHP_FIREBIRD_VERSION_STRING' php_firebird.h | sed 's/.*"\([^"]*\)".*/\1/' | head -1)
             if [ -z "$VERSION" ] || [[ "$VERSION" == *"unknown"* ]]; then
-              VERSION="7.0.0"
+              echo "ERROR: Cannot determine version (no tag, no VERSION.txt, no php_firebird.h define)" >&2
+              exit 1
             fi
-            # Ensure VERSION file exists for subsequent steps
-            echo "${VERSION}" > VERSION
+            echo "${VERSION}" > VERSION.txt
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extension version: ${VERSION}"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -70,16 +70,17 @@ jobs:
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
-            echo "${VERSION}" > VERSION
-            echo "Updated VERSION file from tag: ${VERSION}"
-          elif [ -f VERSION ]; then
-            VERSION=$(cat VERSION | tr -d '[:space:]')
+            echo "${VERSION}" > VERSION.txt
+            echo "Updated VERSION.txt from tag: ${VERSION}"
+          elif [ -f VERSION.txt ]; then
+            VERSION=$(cat VERSION.txt | tr -d '[:space:]')
           else
             VERSION=$(grep -E '#define PHP_FIREBIRD_VERSION_STRING' php_firebird.h | sed 's/.*"\([^"]*\)".*/\1/' | head -1)
             if [ -z "$VERSION" ] || [[ "$VERSION" == *"unknown"* ]]; then
-              VERSION="7.0.0"
+              echo "ERROR: Cannot determine version" >&2
+              exit 1
             fi
-            echo "${VERSION}" > VERSION
+            echo "${VERSION}" > VERSION.txt
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extension version: ${VERSION}"
@@ -266,20 +267,7 @@ jobs:
           phpize
           ./configure --with-firebird="${FB_ROOT}"
 
-          # WORKAROUND: macOS uses case-insensitive APFS by default.
-          # Our VERSION file conflicts with the C++ standard <version> header
-          # because phpize adds -I. to the include path. Temporarily hide it
-          # during compilation (configure already read it via config.m4).
-          if [ -f VERSION ]; then
-            mv VERSION VERSION.bak
-          fi
-
           make -j"$(sysctl -n hw.ncpu)"
-
-          # Restore VERSION file
-          if [ -f VERSION.bak ]; then
-            mv VERSION.bak VERSION
-          fi
 
           ls -la modules/firebird.so
           file modules/firebird.so

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -23,7 +23,7 @@ on:
       - '*.c'
       - '*.h'
       - 'config.w32'
-      - 'VERSION'
+      - 'VERSION.txt'
       - '.github/workflows/release-windows.yml'
   pull_request:
   release:
@@ -76,26 +76,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Ensure VERSION file
+      - name: Ensure VERSION.txt file
         shell: pwsh
         run: |
           if ("${{ github.ref }}" -like "refs/tags/v*") {
             $version = "${{ github.ref }}".Substring(11)
-            Set-Content -Path "VERSION" -Value $version
-            Write-Host "Updated VERSION file from tag: $version"
-          } elseif (-not (Test-Path "VERSION")) {
+            Set-Content -Path "VERSION.txt" -Value $version
+            Write-Host "Updated VERSION.txt from tag: $version"
+          } elseif (-not (Test-Path "VERSION.txt")) {
             # Extract from php_firebird.h as fallback
             $header = Get-Content "php_firebird.h"
             $match = $header | Select-String -Pattern '#define PHP_FIREBIRD_VERSION_STRING "([^"]+)"'
             if ($match) {
               $version = $match.Matches[0].Groups[1].Value
             } else {
-              $version = "7.0.0"
+              Write-Error "Cannot determine version (no tag, no VERSION.txt, no php_firebird.h define)"
+              exit 1
             }
-            Set-Content -Path "VERSION" -Value $version
-            Write-Host "Created VERSION file from header/default: $version"
+            Set-Content -Path "VERSION.txt" -Value $version
+            Write-Host "Created VERSION.txt from header: $version"
           } else {
-            Write-Host "Using existing VERSION file: $(Get-Content VERSION)"
+            Write-Host "Using existing VERSION.txt: $(Get-Content VERSION.txt)"
           }
 
       - name: Cache Firebird SDK


### PR DESCRIPTION
Closes #226, Closes #227.

**#226**: Release workflows (linux/macos/windows) used bare `VERSION` while ci.yml used `VERSION.txt`. Standardized all on `VERSION.txt`. Removed dead APFS workaround code.

**#227**: Stale `7.0.0` fallback replaced with fail-fast (`exit 1`) in all 4 workflows.

5 files, -60/+39 lines.