### PR TITLE
feat: add llms.txt for IPADP L1 conformance, update metadata.json

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,31 @@
+# php-firebird
+
+> Modernized PHP 8.2+ extension providing native connectivity to Firebird SQL databases (3.0, 4.0, 5.0+). High-performance replacement for legacy ext/interbase, written in C/C++17 using the modern Firebird OO API.
+
+## Build & Test
+- [AGENTS.md](AGENTS.md): Agent context - architecture layers, SDD workflow, build system
+- [scripts/build.sh](scripts/build.sh): Build extension (phpize + configure)
+- [scripts/qa.sh](scripts/qa.sh): QA matrix runner (PHP 8.2-8.5 x FB 3.0-5.0)
+- [tests/firebird.inc](tests/firebird.inc): Test harness with per-test DB isolation
+- [VERSION.txt](VERSION.txt): Current version (11.0.1)
+
+## Architecture
+- Layer 1 (Procedural): `fbird_*` functions in `*.c` files
+- Layer 2 (OOP): `Firebird\*` classes in `fbird_classes.c`, `src/`
+- Layer 3 (PDO): `pdo_fbird` driver in `pdo_fbird/`
+
+## Key Source Files
+- [firebird.c](firebird.c): Zend module entry point, constant registration
+- [firebird_utils.cpp](firebird_utils.cpp): Modern Firebird OO API wrapper
+- [fbird_result.c](fbird_result.c): Result fetching and blob handling
+- [php_firebird.h](php_firebird.h): Public API declarations, version macros
+
+## Specs & Planning
+- [specs/metadata.json](specs/metadata.json): IPADP dependency graph and project metadata
+- [NEXT_STEPS.md](NEXT_STEPS.md): Roadmap and release status
+- [docs/VERSIONING_STRATEGY.md](docs/VERSIONING_STRATEGY.md): Versioning policy
+
+## Stubs (IDE/phpstan)
+- [stubs/firebird-stubs.php](stubs/firebird-stubs.php): Procedural API constants and signatures
+- [phpstan/fbird.stub.php](phpstan/fbird.stub.php): PHPStan stub file
+- [phpstan/fbird-bootstrap.php](phpstan/fbird-bootstrap.php): PHPStan runtime constant bootstrap

--- a/specs/metadata.json
+++ b/specs/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "php-firebird",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "sdd_source": "https://github.com/satwareAG/spec-kit",
   "forge": "github",
   "visibility": "public",
@@ -8,7 +8,7 @@
   "ipadp": {
     "project_number": 1,
     "conformance_level": "L3",
-    "issue_tracker": "https://github.com/satwareAG/php-firebird/issues/254",
+    "issue_tracker": "https://github.com/satwareAG/php-firebird/issues",
     "rfc_location": "<internal>/wiki/specs/rfc-interproject-agentic-development.md"
   },
   "upstream": {


### PR DESCRIPTION
Closes #255.

Adds `llms.txt` (LLM-friendly project index) completing IPADP L1 conformance alongside the existing `AGENTS.md` and `specs/metadata.json`.

Also fixes metadata.json: version 11.0.0→11.0.1, stale issue tracker ref.