### PR TITLE
Fix release pipeline warnings and add SLSA verification

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -148,6 +148,27 @@ jobs:
             release-assets/*.tar.gz
             release-assets/*.zip
 
+      - name: Verify SLSA attestations
+        run: |
+          set -e
+          fail=0
+          for f in release-assets/*.tar.gz release-assets/*.zip; do
+            [ -f "$f" ] || continue
+            echo "Verifying attestation for: $f"
+            if gh attestation verify "$f" \
+                --repo "${{ github.repository }}" \
+                --signer-workflow "${{ github.repository }}/.github/workflows/publish-release.yml"; then
+              echo "  OK"
+            else
+              echo "  FAILED"
+              fail=1
+            fi
+          done
+          [ "$fail" -ne 0 ] && exit 1
+          echo "All release artifacts have verified SLSA provenance attestations"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Generate checksums index
         run: |
           cd release-assets

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -577,7 +577,7 @@ jobs:
     
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: artifacts
       
@@ -670,7 +670,7 @@ jobs:
 
     steps:
       - name: Download PHP ${{ matrix.php }} NTS Bundle
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: "${{ matrix.bundle_pattern }}"
           path: bundle

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -629,8 +629,8 @@ jobs:
           files: |
             release-assets/*.tar.gz
             release-assets/*.sha256
+            release-assets/*.md5
             release-assets/*.sbom.cdx.json
-            release-assets/CHECKSUMS-SHA256.txt
           fail_on_unmatched_files: false
           # Create draft release for tag push (immutable releases)
           draft: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -490,8 +490,8 @@ jobs:
           files: |
             release-assets/*.tar.gz
             release-assets/*.sha256
+            release-assets/*.md5
             release-assets/*.sbom.cdx.json
-            release-assets/CHECKSUMS-SHA256.txt
           fail_on_unmatched_files: false
           draft: true
         env:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -440,7 +440,7 @@ jobs:
 
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: artifacts
 
@@ -522,7 +522,7 @@ jobs:
           echo "PHP version: $(php -v | head -1)"
 
       - name: Download Bundle
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: "*macos*${{ matrix.arch }}*"
           path: bundle

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -113,8 +113,6 @@ jobs:
           $sdkPath = "C:\firebird-sdk"
           echo "FIREBIRD_HOME=$sdkPath" >> $env:GITHUB_ENV
           echo "$sdkPath\bin" >> $env:GITHUB_PATH
-          echo "CFLAGS=-I$sdkPath\include" >> $env:GITHUB_ENV
-          echo "LDFLAGS=-L$sdkPath\lib" >> $env:GITHUB_ENV
 
       - name: Build Extension
         uses: php/php-windows-builder/extension@c49dae50774b14e0f358d2efa65637b67f1104f6 # v1

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -148,7 +148,7 @@ jobs:
           fi
 
       - name: Download All Build Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary

Fixes 4 issues found during the v11.0.2-rc.1 E2E release test.

## Changes

### 1. Remove Unix-style CFLAGS/LDFLAGS from Windows build (LNK4044)
`release-windows.yml`: Removed `CFLAGS=-I...` and `LDFLAGS=-L...` env vars.
PHP's `config.w32` already emits MSVC-correct `/libpath:` and `/I` flags
via `CHECK_LIB()` and `CHECK_HEADER_ADD_INCLUDE()`. The Unix `-L` flag
was rejected by `link.exe` (LNK4044 warning).

### 2. Upload missing .md5 checksums, remove per-platform CHECKSUMS
`release-linux.yml` + `release-macos.yml`: Added `*.md5` to softprops upload
patterns (were generated but never uploaded). Removed per-platform
`CHECKSUMS-SHA256.txt` uploads — `publish-release.yml` already generates
consolidated checksums covering all artifacts. Also avoids softprops #767
same-filename collision.

### 3. Bump actions/download-artifact v6 to v7 (Node.js 24)
v6.0.0 still defaulted to Node.js 20 despite preliminary Node 24 support.
v7.0.0 runs on Node.js 24 by default. No breaking changes (unlike v8.0.0
which has ESM + hash-mismatch-error defaults). 5 occurrences across 3 files.

### 4. Add SLSA attestation verification step
`publish-release.yml`: Added `gh attestation verify` step between attestation
generation and release publishing. Uses `--signer-workflow` for stronger
provenance. Fails fast if any artifact lacks valid attestation, keeping
release in draft state. Satisfies `spec-v10.4-supply-chain.md` acceptance
criteria.

## Testing
- [ ] CI green (ci, code-quality, sanitizers, coverage workflows)
- [ ] E2E release test with `v11.0.2-rc.2` tag
- [ ] Verify: no LNK4044, .md5 files present, no Node 20 warning, SLSA verify passes