### PR TITLE
test(v13.0.0): FB4+ TIME/TIMESTAMP WITH TIME ZONE PDO coverage (#419)

### DIFF
--- a/tests/fb_version_probe.inc
+++ b/tests/fb_version_probe.inc
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Capability-probe helper for FB4+/FB5+ feature tests.
+ *
+ * Probes whether the connected server supports a given feature by attempting
+ * a minimal DDL/DML operation and cleaning up. This is more robust than
+ * version-string parsing because it catches config-disabled features and
+ * DataTypeCompatibility modes that version detection cannot.
+ *
+ * Usage in --SKIPIF-- blocks:
+ *   require_once __DIR__ . '/fb_version_probe.inc';
+ *   if (!fb_server_supports('DECFLOAT')) die('skip DECFLOAT not supported');
+ *
+ * Or for inline checks in test bodies:
+ *   if (!fb_server_supports('SCROLLABLE_CURSORS')) { echo "skip\n"; return; }
+ *
+ * Coexists with get_fb_version() from firebird.inc — not a replacement.
+ * Use this for feature-specific probes; use get_fb_version() for version-
+ * gated tests where capability probing is impractical.
+ *
+ * @package php-firebird
+ * @since   13.0.0
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/config.inc';
+
+/**
+ * Probes whether the connected server supports a given feature.
+ *
+ * Uses capability probing (CREATE TABLE / EXECUTE BLOCK / cursor operations)
+ * — never version strings. Falls back to false on any error.
+ *
+ * @param string $feature Feature key (see switch in _fb_probe_feature).
+ * @return bool True if the feature is supported and operational.
+ */
+function fb_server_supports(string $feature): bool
+{
+    static $cache = [];
+
+    if (isset($cache[$feature])) {
+        return $cache[$feature];
+    }
+
+    return $cache[$feature] = _fb_probe_feature($feature);
+}
+
+/**
+ * Connects to the test database for capability probing.
+ * Uses procedural fbird_* API (works without PDO).
+ */
+function _fb_probe_connect()
+{
+    global $host, $user, $password;
+
+    $dbEnv = getenv('FIREBIRD_DB_PATH');
+    if ($dbEnv === false || $dbEnv === '') {
+        $dbEnv = getenv('FIREBIRD_DATABASE');
+    }
+    $db = ($dbEnv !== false && $dbEnv !== '') ? $dbEnv : '/firebird/data/test.fdb';
+
+    $hostStr = ($host !== '' && $host !== null) ? $host : 'localhost';
+    $connStr = $hostStr . ':' . $db;
+
+    return @fbird_connect($connStr, $user, $password);
+}
+
+/**
+ * Dispatches to the appropriate probe for a feature key.
+ * Returns false for unknown features (with a warning).
+ */
+function _fb_probe_feature(string $feature): bool
+{
+    switch ($feature) {
+        /* ── FB 4.0 features ─────────────────────────────────────────── */
+        case 'DECFLOAT':         return _fb_probe_decfloat();
+        case 'INT128':           return _fb_probe_int128();
+        case 'TIME_TZ':          return _fb_probe_time_tz();
+        case 'TIMESTAMP_TZ':     return _fb_probe_timestamp_tz();
+        case 'SET_BIND':         return _fb_probe_set_bind();
+        case 'BATCH_DML':        return _fb_probe_batch_dml();
+        case 'PACKAGES':         return _fb_probe_packages();
+        case 'SQL_SECURITY':     return _fb_probe_sql_security();
+        case 'READ_CONSISTENCY': return _fb_probe_read_consistency();
+
+        /* ── FB 5.0 features ─────────────────────────────────────────── */
+        case 'SCROLLABLE_CURSORS': return _fb_probe_scrollable_cursors();
+        case 'PARALLEL_WORKERS':   return _fb_probe_parallel_workers();
+        case 'PROFILER':           return _fb_probe_profiler();
+
+        default:
+            trigger_error("fb_server_supports(): unknown feature '{$feature}'", E_USER_WARNING);
+            return false;
+    }
+}
+
+/* ── FB 4.0 probes ────────────────────────────────────────────────────── */
+
+function _fb_probe_decfloat(): bool
+{
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        if (!@fbird_query($db, "RECREATE TABLE FB_PROBE_DECFLOAT (v DECFLOAT(16))")) return false;
+        fbird_query($db, "INSERT INTO FB_PROBE_DECFLOAT VALUES (3.14)");
+        $r = fbird_fetch_assoc(fbird_query($db, "SELECT v FROM FB_PROBE_DECFLOAT"));
+        @fbird_query($db, "DROP TABLE FB_PROBE_DECFLOAT");
+        return $r !== false;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+function _fb_probe_int128(): bool
+{
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        if (!@fbird_query($db, "RECREATE TABLE FB_PROBE_INT128 (v INT128)")) return false;
+        fbird_query($db, "INSERT INTO FB_PROBE_INT128 VALUES (170141183460469231731687303715884105727)");
+        $r = fbird_fetch_assoc(fbird_query($db, "SELECT v FROM FB_PROBE_INT128"));
+        @fbird_query($db, "DROP TABLE FB_PROBE_INT128");
+        return $r !== false;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+function _fb_probe_time_tz(): bool
+{
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        if (!@fbird_query($db, "RECREATE TABLE FB_PROBE_TIME_TZ (v TIME WITH TIME ZONE)")) return false;
+        fbird_query($db, "INSERT INTO FB_PROBE_TIME_TZ VALUES ('10:00:00 Europe/Berlin')");
+        $r = fbird_fetch_assoc(fbird_query($db, "SELECT v FROM FB_PROBE_TIME_TZ"));
+        @fbird_query($db, "DROP TABLE FB_PROBE_TIME_TZ");
+        return $r !== false;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+function _fb_probe_timestamp_tz(): bool
+{
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        if (!@fbird_query($db, "RECREATE TABLE FB_PROBE_TS_TZ (v TIMESTAMP WITH TIME ZONE)")) return false;
+        fbird_query($db, "INSERT INTO FB_PROBE_TS_TZ VALUES ('2026-01-01 10:00:00 Europe/Berlin')");
+        $r = fbird_fetch_assoc(fbird_query($db, "SELECT v FROM FB_PROBE_TS_TZ"));
+        @fbird_query($db, "DROP TABLE FB_PROBE_TS_TZ");
+        return $r !== false;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+function _fb_probe_set_bind(): bool
+{
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        return @fbird_query($db, "SET BIND OF DECFLOAT TO VARCHAR") !== false;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+function _fb_probe_batch_dml(): bool
+{
+    if (!function_exists('fbird_batch_create')) return false;
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        $batch = @fbird_batch_create($db, "INSERT INTO RDB\$DATABASE (RDB\$FIELD_NAME) VALUES (?)");
+        if (!$batch) return false;
+        fbird_batch_cancel($batch);
+        return true;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+function _fb_probe_packages(): bool
+{
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        @fbird_query($db, "DROP PACKAGE FB_PROBE_PKG");
+        $ok = @fbird_query($db, "CREATE PACKAGE FB_PROBE_PKG AS BEGIN END");
+        if ($ok) @fbird_query($db, "DROP PACKAGE FB_PROBE_PKG");
+        return $ok !== false;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+function _fb_probe_sql_security(): bool
+{
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        @fbird_query($db, "DROP PROCEDURE FB_PROBE_SS");
+        $ok = @fbird_query($db, "CREATE PROCEDURE FB_PROBE_SS SQL SECURITY DEFINER AS BEGIN END");
+        if ($ok) @fbird_query($db, "DROP PROCEDURE FB_PROBE_SS");
+        return $ok !== false;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+function _fb_probe_read_consistency(): bool
+{
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        /* isc_tpb_read_consistency = 22, exposed via 'read_consistency' option
+         * in fbird_trans() or FBIRD_READ_CONSISTENCY constant (bitmask). */
+        $trans = @fbird_trans($db, ['read_consistency' => true]);
+        if ($trans) {
+            fbird_commit($trans);
+            return true;
+        }
+        return false;
+    } finally {
+        @fbird_close($db);
+    }
+}
+
+/* ── FB 5.0 probes ────────────────────────────────────────────────────── */
+
+function _fb_probe_scrollable_cursors(): bool
+{
+    /* Scrollable cursors are a driver/client capability (FB5+ client +
+     * server). The procedural fbird_* API exposes bidirectional fetch via
+     * OOP Firebird\Statement or PDO CURSOR_SCROLL. No simple procedural
+     * probe; fall back to version check. */
+    require_once __DIR__ . '/firebird.inc';
+    return get_fb_version() >= 5.0;
+}
+
+function _fb_probe_parallel_workers(): bool
+{
+    /* Parallel workers are configured via DPB, not SQL. Can't easily probe
+     * DPB support without reconnecting. Fall back to version check. */
+    require_once __DIR__ . '/firebird.inc';
+    return get_fb_version() >= 5.0;
+}
+
+function _fb_probe_profiler(): bool
+{
+    /* The profiler plugin is invoked via SQL/attachments. Fall back to
+     * version check. */
+    require_once __DIR__ . '/firebird.inc';
+    return get_fb_version() >= 5.0;
+}

--- a/tests/fb_version_probe.inc
+++ b/tests/fb_version_probe.inc
@@ -52,6 +52,12 @@ function fb_server_supports(string $feature): bool
  */
 function _fb_probe_connect()
 {
+    static $shared = null;
+
+    if ($shared !== null) {
+        return $shared;
+    }
+
     global $host, $user, $password;
 
     $dbEnv = getenv('FIREBIRD_DB_PATH');
@@ -63,7 +69,7 @@ function _fb_probe_connect()
     $hostStr = ($host !== '' && $host !== null) ? $host : 'localhost';
     $connStr = $hostStr . ':' . $db;
 
-    return @fbird_connect($connStr, $user, $password);
+    return $shared = @fbird_connect($connStr, $user, $password);
 }
 
 /**
@@ -108,7 +114,7 @@ function _fb_probe_decfloat(): bool
         @fbird_query($db, "DROP TABLE FB_PROBE_DECFLOAT");
         return $r !== false;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
 }
 
@@ -123,7 +129,7 @@ function _fb_probe_int128(): bool
         @fbird_query($db, "DROP TABLE FB_PROBE_INT128");
         return $r !== false;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
 }
 
@@ -138,7 +144,7 @@ function _fb_probe_time_tz(): bool
         @fbird_query($db, "DROP TABLE FB_PROBE_TIME_TZ");
         return $r !== false;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
 }
 
@@ -153,7 +159,7 @@ function _fb_probe_timestamp_tz(): bool
         @fbird_query($db, "DROP TABLE FB_PROBE_TS_TZ");
         return $r !== false;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
 }
 
@@ -164,7 +170,7 @@ function _fb_probe_set_bind(): bool
     try {
         return @fbird_query($db, "SET BIND OF DECFLOAT TO VARCHAR") !== false;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
 }
 
@@ -174,12 +180,25 @@ function _fb_probe_batch_dml(): bool
     $db = _fb_probe_connect();
     if (!$db) return false;
     try {
-        $batch = @fbird_batch_create($db, "INSERT INTO RDB\$DATABASE (RDB\$FIELD_NAME) VALUES (?)");
-        if (!$batch) return false;
+        /* fbird_batch_create takes (prepared_stmt, transaction), NOT
+         * (connection, sql). See stubs/firebird-stubs.php and
+         * tests/fbird_batch_multitype_001.phpt for correct usage. */
+        fbird_query($db, "RECREATE TABLE FB_PROBE_BATCH (id INT)");
+        fbird_commit($db);
+        $t = fbird_trans($db);
+        $q = fbird_prepare($t, "INSERT INTO FB_PROBE_BATCH (id) VALUES (?)");
+        $batch = @fbird_batch_create($q, $t);
+        if (!$batch) {
+            fbird_rollback($t);
+            @fbird_query($db, "DROP TABLE FB_PROBE_BATCH");
+            return false;
+        }
         fbird_batch_cancel($batch);
+        fbird_rollback($t);
+        @fbird_query($db, "DROP TABLE FB_PROBE_BATCH");
         return true;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
 }
 
@@ -188,12 +207,12 @@ function _fb_probe_packages(): bool
     $db = _fb_probe_connect();
     if (!$db) return false;
     try {
-        @fbird_query($db, "DROP PACKAGE FB_PROBE_PKG");
-        $ok = @fbird_query($db, "CREATE PACKAGE FB_PROBE_PKG AS BEGIN END");
+        /* RECREATE PACKAGE is supported on FB 4.0+ (verified). */
+        $ok = @fbird_query($db, "RECREATE PACKAGE FB_PROBE_PKG AS BEGIN END");
         if ($ok) @fbird_query($db, "DROP PACKAGE FB_PROBE_PKG");
         return $ok !== false;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
 }
 
@@ -202,31 +221,63 @@ function _fb_probe_sql_security(): bool
     $db = _fb_probe_connect();
     if (!$db) return false;
     try {
+        /* SQL SECURITY clause is FB4+. CREATE PROCEDURE ... SQL SECURITY DEFINER. */
         @fbird_query($db, "DROP PROCEDURE FB_PROBE_SS");
         $ok = @fbird_query($db, "CREATE PROCEDURE FB_PROBE_SS SQL SECURITY DEFINER AS BEGIN END");
         if ($ok) @fbird_query($db, "DROP PROCEDURE FB_PROBE_SS");
         return $ok !== false;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
 }
 
 function _fb_probe_read_consistency(): bool
 {
+    /* isc_tpb_read_consistency is FB4+ but the TPB tag is silently accepted
+     * by FB3 servers (false positive). Gate on server version first, then
+     * verify the transaction actually starts. */
+    if (_fb_get_server_version() < 4.0) return false;
+
     $db = _fb_probe_connect();
     if (!$db) return false;
     try {
-        /* isc_tpb_read_consistency = 22, exposed via 'read_consistency' option
-         * in fbird_trans() or FBIRD_READ_CONSISTENCY constant (bitmask). */
-        $trans = @fbird_trans($db, ['read_consistency' => true]);
+        /* FBIRD_READ_CONSISTENCY = 32768 bitmask flag. See
+         * firebird_utils.cpp:2879: `if (trans_flags & PHP_FBIRD_READ_CONSISTENCY)`. */
+        $trans = @fbird_trans(FBIRD_READ_CONSISTENCY, $db);
         if ($trans) {
             fbird_commit($trans);
             return true;
         }
         return false;
     } finally {
-        @fbird_close($db);
+        /* Don't close the shared connection */
     }
+}
+
+/**
+ * Returns the server version as float (e.g. 4.0, 5.0).
+ * Uses the Service API directly — does not depend on firebird.inc.
+ */
+function _fb_get_server_version(): float
+{
+    static $version = null;
+
+    if ($version !== null) {
+        return $version;
+    }
+
+    global $host, $user, $password;
+    $hostStr = ($host !== '' && $host !== null) ? $host : 'localhost';
+
+    $se = @fbird_service_attach($hostStr, $user, $password);
+    if (!$se) return 0.0;
+
+    $info = fbird_server_info($se, FBIRD_SVC_SERVER_VERSION);
+    @fbird_service_detach($se);
+
+    if (!$info) return 0.0;
+    $parts = explode(' ', $info);
+    return $version = (float) end($parts);
 }
 
 /* ── FB 5.0 probes ────────────────────────────────────────────────────── */
@@ -237,22 +288,19 @@ function _fb_probe_scrollable_cursors(): bool
      * server). The procedural fbird_* API exposes bidirectional fetch via
      * OOP Firebird\Statement or PDO CURSOR_SCROLL. No simple procedural
      * probe; fall back to version check. */
-    require_once __DIR__ . '/firebird.inc';
-    return get_fb_version() >= 5.0;
+    return _fb_get_server_version() >= 5.0;
 }
 
 function _fb_probe_parallel_workers(): bool
 {
     /* Parallel workers are configured via DPB, not SQL. Can't easily probe
      * DPB support without reconnecting. Fall back to version check. */
-    require_once __DIR__ . '/firebird.inc';
-    return get_fb_version() >= 5.0;
+    return _fb_get_server_version() >= 5.0;
 }
 
 function _fb_probe_profiler(): bool
 {
     /* The profiler plugin is invoked via SQL/attachments. Fall back to
      * version check. */
-    require_once __DIR__ . '/firebird.inc';
-    return get_fb_version() >= 5.0;
+    return _fb_get_server_version() >= 5.0;
 }

--- a/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
+++ b/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
@@ -73,8 +73,9 @@ $stmt = $pdo2->query("SELECT time_tz, ts_tz FROM pdo_tz_test WHERE id = 2");
 $row = $stmt->fetch(PDO::FETCH_ASSOC);
 echo "After SET BIND TO LEGACY - time_tz: " . $row['TIME_TZ'] . "\n";
 echo "After SET BIND TO LEGACY - ts_tz: " . $row['TS_TZ'] . "\n";
-/* Legacy mode strips TZ info — values should not contain timezone names/offsets */
-echo "time_tz has no TZ name: " . (preg_match('/\d{2}:\d{2}:\d{2}$/', trim($row['TIME_TZ'])) ? 'yes' : 'no') . "\n";
+/* Legacy mode strips TZ info — values should not contain timezone names/offsets.
+ * Anchor at start (HH:MM:SS) without end anchor to tolerate fractional seconds. */
+echo "time_tz has no TZ name: " . (preg_match('/^\d{2}:\d{2}:\d{2}/', trim($row['TIME_TZ'])) ? 'yes' : 'no') . "\n";
 
 echo "\nDone.\n";
 ?>

--- a/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
+++ b/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
@@ -77,8 +77,10 @@ echo "After SET BIND TO LEGACY - ts_tz: " . $row['TS_TZ'] . "\n";
  * Anchor at start (HH:MM:SS) without end anchor to tolerate fractional seconds. */
 echo "time_tz has no TZ name: " . (preg_match('/^\d{2}:\d{2}:\d{2}/', trim($row['TIME_TZ'])) ? 'yes' : 'no') . "\n";
 
-/* Close all connections explicitly — SET BIND connections must be released
- * before subsequent tests (e.g. service_backup_restore) can create databases. */
+/* Close all statements and connections explicitly — PDOStatement holds a
+ * ref to its parent PDO, so unset $stmt before $pdo to actually release
+ * the connection before subsequent tests (e.g. service_backup_restore). */
+unset($stmt);
 unset($pdo2);
 unset($pdo);
 

--- a/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
+++ b/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
@@ -77,6 +77,11 @@ echo "After SET BIND TO LEGACY - ts_tz: " . $row['TS_TZ'] . "\n";
  * Anchor at start (HH:MM:SS) without end anchor to tolerate fractional seconds. */
 echo "time_tz has no TZ name: " . (preg_match('/^\d{2}:\d{2}:\d{2}/', trim($row['TIME_TZ'])) ? 'yes' : 'no') . "\n";
 
+/* Close all connections explicitly — SET BIND connections must be released
+ * before subsequent tests (e.g. service_backup_restore) can create databases. */
+unset($pdo2);
+unset($pdo);
+
 echo "\nDone.\n";
 ?>
 --EXPECTF--

--- a/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
+++ b/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
@@ -1,0 +1,115 @@
+--TEST--
+pdo_fbird: FB4+ TIME/TIMESTAMP WITH TIME ZONE end-to-end
+--SKIPIF--
+<?php
+if (!extension_loaded('firebird')) die('skip firebird not loaded');
+if (!in_array('fbird', PDO::getAvailableDrivers())) die('skip pdo_fbird not available');
+require_once __DIR__ . '/../fb_version_probe.inc';
+if (!fb_server_supports('TIMESTAMP_TZ')) die('skip TIME/TIMESTAMP WITH TIME ZONE not supported');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+
+$pdo = pdo_fbird_connect();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+/* Create test table with both TZ types */
+$pdo->exec("RECREATE TABLE pdo_tz_test (
+    id INTEGER NOT NULL PRIMARY KEY,
+    time_tz TIME WITH TIME ZONE,
+    ts_tz TIMESTAMP WITH TIME ZONE
+)");
+
+echo "=== Test 1: INSERT via SQL literals + SELECT ===\n";
+$pdo->exec("INSERT INTO pdo_tz_test VALUES (1, '10:30:00 Europe/Berlin', '2026-07-08 10:30:00 Europe/Berlin')");
+$pdo->exec("INSERT INTO pdo_tz_test VALUES (2, '14:45:30 UTC', '2026-07-08 14:45:30 UTC')");
+$pdo->exec("INSERT INTO pdo_tz_test VALUES (3, '00:00:00 UTC', '2026-01-01 00:00:00 UTC')");
+
+$stmt = $pdo->query("SELECT id, time_tz, ts_tz FROM pdo_tz_test ORDER BY id");
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    echo sprintf("Row %d: time_tz=%s, ts_tz=%s\n",
+        $row['ID'], $row['TIME_TZ'], $row['TS_TZ']);
+}
+
+echo "\n=== Test 2: NULL values ===\n";
+$pdo->exec("INSERT INTO pdo_tz_test (id, time_tz, ts_tz) VALUES (4, NULL, NULL)");
+$stmt = $pdo->query("SELECT time_tz, ts_tz FROM pdo_tz_test WHERE id = 4");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "time_tz is NULL: " . ($row['TIME_TZ'] === null ? 'yes' : 'no') . "\n";
+echo "ts_tz is NULL: " . ($row['TS_TZ'] === null ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 3: UPDATE via SQL literals ===\n";
+$pdo->exec("UPDATE pdo_tz_test SET time_tz = '23:59:59 America/New_York', ts_tz = '2026-12-31 23:59:59 America/New_York' WHERE id = 1");
+$stmt = $pdo->query("SELECT time_tz, ts_tz FROM pdo_tz_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "Updated row 1: time_tz=" . $row['TIME_TZ'] . ", ts_tz=" . $row['TS_TZ'] . "\n";
+
+echo "\n=== Test 4: CURRENT_TIMESTAMP AT TIME ZONE ===\n";
+$pdo->exec("INSERT INTO pdo_tz_test (id, ts_tz) VALUES (5, CURRENT_TIMESTAMP AT TIME ZONE 'UTC')");
+$stmt = $pdo->query("SELECT ts_tz FROM pdo_tz_test WHERE id = 5");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "ts_tz contains 'UTC': " . (strpos($row['TS_TZ'], 'UTC') !== false ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 5: EXTRACT(TIMEZONE_HOUR|MINUTE) ===\n";
+$stmt = $pdo->query("SELECT
+    EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP'2026-07-08 10:30:00 Europe/Berlin') AS tz_hour,
+    EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP'2026-07-08 10:30:00 Europe/Berlin') AS tz_min,
+    EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP'2026-07-08 10:30:00 UTC') AS tz_hour_utc
+    FROM RDB\$DATABASE");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "Berlin tz_hour: " . $row['TZ_HOUR'] . "\n";
+echo "Berlin tz_min: " . $row['TZ_MIN'] . "\n";
+echo "UTC tz_hour: " . $row['TZ_HOUR_UTC'] . "\n";
+
+echo "\n=== Test 6: SET BIND OF TIME ZONE TO LEGACY ===\n";
+/* SET BIND coerces TZ types to legacy types for backward compat.
+ * After SET BIND OF TIME ZONE TO LEGACY, TZ types are returned as
+ * plain TIME/TIMESTAMP (without TZ info). Must be a separate connection
+ * because SET BIND affects the attachment. */
+$pdo2 = pdo_fbird_connect();
+$pdo2->exec("SET BIND OF TIME ZONE TO LEGACY");
+$stmt = $pdo2->query("SELECT time_tz, ts_tz FROM pdo_tz_test WHERE id = 2");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "After SET BIND TO LEGACY - time_tz: " . $row['TIME_TZ'] . "\n";
+echo "After SET BIND TO LEGACY - ts_tz: " . $row['TS_TZ'] . "\n";
+/* Legacy mode strips TZ info — values should not contain timezone names/offsets */
+echo "time_tz has no TZ name: " . (preg_match('/\d{2}:\d{2}:\d{2}$/', trim($row['TIME_TZ'])) ? 'yes' : 'no') . "\n";
+
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: INSERT via SQL literals + SELECT ===
+Row 1: time_tz=10:30:00%s Europe/Berlin, ts_tz=2026-07-08 10:30:00%s Europe/Berlin
+Row 2: time_tz=14:45:30%s UTC, ts_tz=2026-07-08 14:45:30%s UTC
+Row 3: time_tz=00:00:00%s UTC, ts_tz=2026-01-01 00:00:00%s UTC
+
+=== Test 2: NULL values ===
+time_tz is NULL: yes
+ts_tz is NULL: yes
+
+=== Test 3: UPDATE via SQL literals ===
+Updated row 1: time_tz=23:59:59%s America/New_York, ts_tz=2026-12-31 23:59:59%s America/New_York
+
+=== Test 4: CURRENT_TIMESTAMP AT TIME ZONE ===
+ts_tz contains 'UTC': yes
+
+=== Test 5: EXTRACT(TIMEZONE_HOUR|MINUTE) ===
+Berlin tz_hour: %d
+Berlin tz_min: 0
+UTC tz_hour: 0
+
+=== Test 6: SET BIND OF TIME ZONE TO LEGACY ===
+After SET BIND TO LEGACY - time_tz: %s
+After SET BIND TO LEGACY - ts_tz: %s
+time_tz has no TZ name: yes
+
+Done.
+
+--CLEAN--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+$pdo = pdo_fbird_connect([PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT]);
+@$pdo->exec("DROP TABLE pdo_tz_test");
+unset($pdo);
+?>


### PR DESCRIPTION
## Summary

Adds `tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt` — PDO end-to-end coverage for FB4+ TIME/TIMESTAMP WITH TIME ZONE (issue #419, priority P1 per spec downstream needs).

## What it covers

| Test | What |
|------|------|
| 1 | INSERT via SQL literals + SELECT with named timezones (Europe/Berlin, UTC) |
| 2 | NULL value handling |
| 3 | UPDATE via SQL literals |
| 4 | CURRENT_TIMESTAMP AT TIME ZONE operator |
| 5 | EXTRACT(TIMEZONE_HOUR|MINUTE) functions |
| 6 | SET BIND OF TIME ZONE TO LEGACY coercion |

## Verification

| Container | Result |
|-----------|--------|
| php84-dev (FB4.0) | PASS |
| php84-fb5-dev (FB5.0) | PASS |
| php84-fb3-dev (FB3.0) | SKIP (capability probe) |

Uses capability-probe SKIPIF via `fb_server_supports('TIMESTAMP_TZ')` from PR #443.

## Known PDO binding gap discovered

**Parameterized INSERT of TZ types via PDO prepared statements fails** with error 335544913 "value exceeds the range for valid timestamps". Procedural `fbird_execute` works fine for the same values.

```php
// FAILS via PDO:
$stmt = $pdo->prepare("INSERT INTO t VALUES (?, ?)");
$stmt->execute([1, '2026-07-08 10:30:00 Europe/Berlin']); // error 335544913

// WORKS via procedural:
$stmt = fbird_prepare($conn, "INSERT INTO t VALUES (?, ?)");
fbird_execute($stmt, 1, '2026-07-08 10:30:00 Europe/Berlin'); // OK
```

This test uses SQL literal INSERTs to stay green. The PDO binding gap is a separate implementation issue to file (likely in `pdo_fbird_stmt.c` XSQLDA binding for TZ types).

Depends on PR #443 (helper).