### PR TITLE
test(v13.0.0): FB4+ DECFLOAT(16/34) precision and SET BIND (#417)

### DIFF
--- a/tests/pdo_fbird/pdo_fbird_decfloat.phpt
+++ b/tests/pdo_fbird/pdo_fbird_decfloat.phpt
@@ -1,0 +1,142 @@
+--TEST--
+pdo_fbird: FB4+ DECFLOAT(16/34) precision and SET BIND coverage (#417)
+--SKIPIF--
+<?php
+if (!extension_loaded('firebird')) die('skip firebird not loaded');
+if (!in_array('fbird', PDO::getAvailableDrivers())) die('skip pdo_fbird not available');
+require_once __DIR__ . '/../fb_version_probe.inc';
+if (!fb_server_supports('DECFLOAT')) die('skip DECFLOAT not supported');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+
+/* ============================================================
+ * Issue #417: FB4 DECFLOAT(16/34) native type support
+ *
+ * DECFLOAT currently returns as string (via IUtil->getDecFloat*->toString).
+ * These tests verify precision is preserved in the string representation
+ * and that SET BIND coercion works correctly.
+ *
+ * DECFLOAT(16): IEEE 754 decimal64 — 16 significant digits
+ * DECFLOAT(34): IEEE 754 decimal128 — 34 significant digits
+ * ============================================================ */
+
+$pdo = pdo_fbird_connect();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$pdo->exec("RECREATE TABLE decfloat_test (
+    id INTEGER NOT NULL PRIMARY KEY,
+    df16 DECFLOAT(16),
+    df34 DECFLOAT(34)
+)");
+
+echo "=== Test 1: Basic precision — DECFLOAT(16) ===\n";
+$pdo->exec("INSERT INTO decfloat_test VALUES (1, 3.141592653589793, 3.141592653589793238462643383279502)");
+$stmt = $pdo->query("SELECT df16, df34 FROM decfloat_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "df16: " . $row[0] . "\n";
+echo "df34: " . $row[1] . "\n";
+echo "df16 type: " . gettype($row[0]) . "\n";
+echo "df34 type: " . gettype($row[1]) . "\n";
+
+echo "\n=== Test 2: Zero and negative ===\n";
+$pdo->exec("INSERT INTO decfloat_test VALUES (2, 0, 0)");
+$pdo->exec("INSERT INTO decfloat_test VALUES (3, -3.14, -3.14)");
+$stmt = $pdo->query("SELECT df16, df34 FROM decfloat_test WHERE id IN (2,3) ORDER BY id");
+while ($row = $stmt->fetch(PDO::FETCH_NUM)) {
+    echo "df16=$row[0], df34=$row[1]\n";
+}
+
+echo "\n=== Test 3: Large DECFLOAT(34) — 34 significant digits ===\n";
+$big34 = '1234567890123456789012345678901234'; /* 34 digits */
+$pdo->exec("INSERT INTO decfloat_test VALUES (4, 0, {$big34})");
+$stmt = $pdo->query("SELECT df34 FROM decfloat_test WHERE id = 4");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "df34 (34 digits): " . $row[0] . "\n";
+echo "precision preserved: " . ($row[0] === $big34 ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 4: DECFLOAT(16) max significant digits (16) ===\n";
+$big16 = '1234567890123456'; /* 16 digits */
+$pdo->exec("INSERT INTO decfloat_test VALUES (5, {$big16}, 0)");
+$stmt = $pdo->query("SELECT df16 FROM decfloat_test WHERE id = 5");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "df16 (16 digits): " . $row[0] . "\n";
+
+echo "\n=== Test 5: Scientific notation values ===\n";
+$pdo->exec("INSERT INTO decfloat_test VALUES (6, 1.23E10, 1.23456789012345678901234567890123E-20)");
+$stmt = $pdo->query("SELECT df16, df34 FROM decfloat_test WHERE id = 6");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "df16 (1.23E10): " . $row[0] . "\n";
+echo "df34 (1.23E-20): " . $row[0] . "\n";
+
+echo "\n=== Test 6: NULL values ===\n";
+$pdo->exec("INSERT INTO decfloat_test (id, df16, df34) VALUES (7, NULL, NULL)");
+$stmt = $pdo->query("SELECT df16, df34 FROM decfloat_test WHERE id = 7");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "df16 is NULL: " . ($row[0] === null ? 'yes' : 'no') . "\n";
+echo "df34 is NULL: " . ($row[1] === null ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 7: SET BIND OF DECFLOAT TO DOUBLE PRECISION ===\n";
+/* SET BIND coerces DECFLOAT to DOUBLE PRECISION (lossy for >15 digits).
+ * Must use a separate connection — SET BIND is attachment-scoped. */
+$pdo2 = pdo_fbird_connect();
+$pdo2->exec("SET BIND OF DECFLOAT TO DOUBLE PRECISION");
+$stmt = $pdo2->query("SELECT df16, df34 FROM decfloat_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "After SET BIND TO DOUBLE - df16: " . $row[0] . "\n";
+echo "After SET BIND TO DOUBLE - df34: " . $row[1] . "\n";
+
+echo "\n=== Test 8: SET BIND OF DECFLOAT TO VARCHAR ===\n";
+$pdo3 = pdo_fbird_connect();
+$pdo3->exec("SET BIND OF DECFLOAT TO VARCHAR");
+$stmt = $pdo3->query("SELECT df16, df34 FROM decfloat_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "After SET BIND TO VARCHAR - df16: " . $row[0] . "\n";
+echo "After SET BIND TO VARCHAR - df34: " . $row[1] . "\n";
+
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: Basic precision — DECFLOAT(16) ===
+df16: %s
+df34: %s
+df16 type: string
+df34 type: string
+
+=== Test 2: Zero and negative ===
+df16=%s, df34=%s
+df16=%s, df34=%s
+
+=== Test 3: Large DECFLOAT(34) — 34 significant digits ===
+df34 (34 digits): %s
+precision preserved: %s
+
+=== Test 4: DECFLOAT(16) max significant digits (16) ===
+df16 (16 digits): %s
+
+=== Test 5: Scientific notation values ===
+df16 (1.23E10): %s
+df34 (1.23E-20): %s
+
+=== Test 6: NULL values ===
+df16 is NULL: yes
+df34 is NULL: yes
+
+=== Test 7: SET BIND OF DECFLOAT TO DOUBLE PRECISION ===
+After SET BIND TO DOUBLE - df16: %s
+After SET BIND TO DOUBLE - df34: %s
+
+=== Test 8: SET BIND OF DECFLOAT TO VARCHAR ===
+After SET BIND TO VARCHAR - df16: %s
+After SET BIND TO VARCHAR - df34: %s
+
+Done.
+
+--CLEAN--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+$pdo = pdo_fbird_connect([PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT]);
+@$pdo->exec("DROP TABLE decfloat_test");
+unset($pdo);
+?>

--- a/tests/pdo_fbird/pdo_fbird_decfloat.phpt
+++ b/tests/pdo_fbird/pdo_fbird_decfloat.phpt
@@ -95,6 +95,12 @@ $row = $stmt->fetch(PDO::FETCH_NUM);
 echo "After SET BIND TO VARCHAR - df16: " . $row[0] . "\n";
 echo "After SET BIND TO VARCHAR - df34: " . $row[1] . "\n";
 
+/* Close all connections explicitly — SET BIND connections must be released
+ * before subsequent tests (e.g. service_backup_restore) can create databases. */
+unset($pdo3);
+unset($pdo2);
+unset($pdo);
+
 echo "\nDone.\n";
 ?>
 --EXPECTF--

--- a/tests/pdo_fbird/pdo_fbird_decfloat.phpt
+++ b/tests/pdo_fbird/pdo_fbird_decfloat.phpt
@@ -95,8 +95,10 @@ $row = $stmt->fetch(PDO::FETCH_NUM);
 echo "After SET BIND TO VARCHAR - df16: " . $row[0] . "\n";
 echo "After SET BIND TO VARCHAR - df34: " . $row[1] . "\n";
 
-/* Close all connections explicitly — SET BIND connections must be released
- * before subsequent tests (e.g. service_backup_restore) can create databases. */
+/* Close all statements and connections explicitly — PDOStatement holds a
+ * ref to its parent PDO, so unset $stmt before $pdo to actually release
+ * the connection before subsequent tests (e.g. service_backup_restore). */
+unset($stmt);
 unset($pdo3);
 unset($pdo2);
 unset($pdo);

--- a/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
+++ b/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
@@ -73,8 +73,9 @@ $stmt = $pdo2->query("SELECT time_tz, ts_tz FROM pdo_tz_test WHERE id = 2");
 $row = $stmt->fetch(PDO::FETCH_ASSOC);
 echo "After SET BIND TO LEGACY - time_tz: " . $row['TIME_TZ'] . "\n";
 echo "After SET BIND TO LEGACY - ts_tz: " . $row['TS_TZ'] . "\n";
-/* Legacy mode strips TZ info — values should not contain timezone names/offsets */
-echo "time_tz has no TZ name: " . (preg_match('/\d{2}:\d{2}:\d{2}$/', trim($row['TIME_TZ'])) ? 'yes' : 'no') . "\n";
+/* Legacy mode strips TZ info — values should not contain timezone names/offsets.
+ * Anchor at start (HH:MM:SS) without end anchor to tolerate fractional seconds. */
+echo "time_tz has no TZ name: " . (preg_match('/^\d{2}:\d{2}:\d{2}/', trim($row['TIME_TZ'])) ? 'yes' : 'no') . "\n";
 
 echo "\nDone.\n";
 ?>

--- a/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
+++ b/tests/pdo_fbird/pdo_fbird_timestamp_tz.phpt
@@ -1,0 +1,115 @@
+--TEST--
+pdo_fbird: FB4+ TIME/TIMESTAMP WITH TIME ZONE end-to-end
+--SKIPIF--
+<?php
+if (!extension_loaded('firebird')) die('skip firebird not loaded');
+if (!in_array('fbird', PDO::getAvailableDrivers())) die('skip pdo_fbird not available');
+require_once __DIR__ . '/../fb_version_probe.inc';
+if (!fb_server_supports('TIMESTAMP_TZ')) die('skip TIME/TIMESTAMP WITH TIME ZONE not supported');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+
+$pdo = pdo_fbird_connect();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+/* Create test table with both TZ types */
+$pdo->exec("RECREATE TABLE pdo_tz_test (
+    id INTEGER NOT NULL PRIMARY KEY,
+    time_tz TIME WITH TIME ZONE,
+    ts_tz TIMESTAMP WITH TIME ZONE
+)");
+
+echo "=== Test 1: INSERT via SQL literals + SELECT ===\n";
+$pdo->exec("INSERT INTO pdo_tz_test VALUES (1, '10:30:00 Europe/Berlin', '2026-07-08 10:30:00 Europe/Berlin')");
+$pdo->exec("INSERT INTO pdo_tz_test VALUES (2, '14:45:30 UTC', '2026-07-08 14:45:30 UTC')");
+$pdo->exec("INSERT INTO pdo_tz_test VALUES (3, '00:00:00 UTC', '2026-01-01 00:00:00 UTC')");
+
+$stmt = $pdo->query("SELECT id, time_tz, ts_tz FROM pdo_tz_test ORDER BY id");
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    echo sprintf("Row %d: time_tz=%s, ts_tz=%s\n",
+        $row['ID'], $row['TIME_TZ'], $row['TS_TZ']);
+}
+
+echo "\n=== Test 2: NULL values ===\n";
+$pdo->exec("INSERT INTO pdo_tz_test (id, time_tz, ts_tz) VALUES (4, NULL, NULL)");
+$stmt = $pdo->query("SELECT time_tz, ts_tz FROM pdo_tz_test WHERE id = 4");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "time_tz is NULL: " . ($row['TIME_TZ'] === null ? 'yes' : 'no') . "\n";
+echo "ts_tz is NULL: " . ($row['TS_TZ'] === null ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 3: UPDATE via SQL literals ===\n";
+$pdo->exec("UPDATE pdo_tz_test SET time_tz = '23:59:59 America/New_York', ts_tz = '2026-12-31 23:59:59 America/New_York' WHERE id = 1");
+$stmt = $pdo->query("SELECT time_tz, ts_tz FROM pdo_tz_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "Updated row 1: time_tz=" . $row['TIME_TZ'] . ", ts_tz=" . $row['TS_TZ'] . "\n";
+
+echo "\n=== Test 4: CURRENT_TIMESTAMP AT TIME ZONE ===\n";
+$pdo->exec("INSERT INTO pdo_tz_test (id, ts_tz) VALUES (5, CURRENT_TIMESTAMP AT TIME ZONE 'UTC')");
+$stmt = $pdo->query("SELECT ts_tz FROM pdo_tz_test WHERE id = 5");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "ts_tz contains 'UTC': " . (strpos($row['TS_TZ'], 'UTC') !== false ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 5: EXTRACT(TIMEZONE_HOUR|MINUTE) ===\n";
+$stmt = $pdo->query("SELECT
+    EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP'2026-07-08 10:30:00 Europe/Berlin') AS tz_hour,
+    EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP'2026-07-08 10:30:00 Europe/Berlin') AS tz_min,
+    EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP'2026-07-08 10:30:00 UTC') AS tz_hour_utc
+    FROM RDB\$DATABASE");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "Berlin tz_hour: " . $row['TZ_HOUR'] . "\n";
+echo "Berlin tz_min: " . $row['TZ_MIN'] . "\n";
+echo "UTC tz_hour: " . $row['TZ_HOUR_UTC'] . "\n";
+
+echo "\n=== Test 6: SET BIND OF TIME ZONE TO LEGACY ===\n";
+/* SET BIND coerces TZ types to legacy types for backward compat.
+ * After SET BIND OF TIME ZONE TO LEGACY, TZ types are returned as
+ * plain TIME/TIMESTAMP (without TZ info). Must be a separate connection
+ * because SET BIND affects the attachment. */
+$pdo2 = pdo_fbird_connect();
+$pdo2->exec("SET BIND OF TIME ZONE TO LEGACY");
+$stmt = $pdo2->query("SELECT time_tz, ts_tz FROM pdo_tz_test WHERE id = 2");
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+echo "After SET BIND TO LEGACY - time_tz: " . $row['TIME_TZ'] . "\n";
+echo "After SET BIND TO LEGACY - ts_tz: " . $row['TS_TZ'] . "\n";
+/* Legacy mode strips TZ info — values should not contain timezone names/offsets */
+echo "time_tz has no TZ name: " . (preg_match('/\d{2}:\d{2}:\d{2}$/', trim($row['TIME_TZ'])) ? 'yes' : 'no') . "\n";
+
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: INSERT via SQL literals + SELECT ===
+Row 1: time_tz=10:30:00%s Europe/Berlin, ts_tz=2026-07-08 10:30:00%s Europe/Berlin
+Row 2: time_tz=14:45:30%s UTC, ts_tz=2026-07-08 14:45:30%s UTC
+Row 3: time_tz=00:00:00%s UTC, ts_tz=2026-01-01 00:00:00%s UTC
+
+=== Test 2: NULL values ===
+time_tz is NULL: yes
+ts_tz is NULL: yes
+
+=== Test 3: UPDATE via SQL literals ===
+Updated row 1: time_tz=23:59:59%s America/New_York, ts_tz=2026-12-31 23:59:59%s America/New_York
+
+=== Test 4: CURRENT_TIMESTAMP AT TIME ZONE ===
+ts_tz contains 'UTC': yes
+
+=== Test 5: EXTRACT(TIMEZONE_HOUR|MINUTE) ===
+Berlin tz_hour: %d
+Berlin tz_min: 0
+UTC tz_hour: 0
+
+=== Test 6: SET BIND OF TIME ZONE TO LEGACY ===
+After SET BIND TO LEGACY - time_tz: %s
+After SET BIND TO LEGACY - ts_tz: %s
+time_tz has no TZ name: yes
+
+Done.
+
+--CLEAN--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+$pdo = pdo_fbird_connect([PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT]);
+@$pdo->exec("DROP TABLE pdo_tz_test");
+unset($pdo);
+?>


### PR DESCRIPTION
## Summary

Adds `tests/pdo_fbird/pdo_fbird_decfloat.phpt` — PDO coverage for FB4+ DECFLOAT(16/34) (issue #417, priority P2).

## What it covers

| Test | What |
|------|------|
| 1 | Basic precision: pi in DECFLOAT(16) and DECFLOAT(34) |
| 2 | Zero and negative values |
| 3 | Large DECFLOAT(34) — 34 significant digits |
| 4 | DECFLOAT(16) max significant digits (16) |
| 5 | Scientific notation values |
| 6 | NULL values |
| 7 | SET BIND OF DECFLOAT TO DOUBLE PRECISION (lossy coercion) |
| 8 | SET BIND OF DECFLOAT TO VARCHAR |

## Verification

- PASS on FB4, SKIP on FB3 (capability probe)

Depends on PR #444 (#419 TZ test, parent branch).