### PR TITLE
fix(v13.0.0): review fixes on merged code

### DIFF
--- a/tests/fb_version_probe.inc
+++ b/tests/fb_version_probe.inc
@@ -88,6 +88,7 @@ function _fb_probe_feature(string $feature): bool
         case 'BATCH_DML':        return _fb_probe_batch_dml();
         case 'PACKAGES':         return _fb_probe_packages();
         case 'SQL_SECURITY':     return _fb_probe_sql_security();
+        case 'STATEMENT_TIMEOUT': return _fb_probe_statement_timeout();
         case 'READ_CONSISTENCY': return _fb_probe_read_consistency();
 
         /* ── FB 5.0 features ─────────────────────────────────────────── */
@@ -231,6 +232,19 @@ function _fb_probe_sql_security(): bool
     }
 }
 
+function _fb_probe_statement_timeout(): bool
+{
+    /* Statement timeout is an attachment-level setting (FB4+).
+     * Probe by executing SET STATEMENT TIMEOUT — FB3 will reject the syntax. */
+    $db = _fb_probe_connect();
+    if (!$db) return false;
+    try {
+        return @fbird_query($db, "SET STATEMENT TIMEOUT 1000") !== false;
+    } finally {
+        /* Don't close the shared connection */
+    }
+}
+
 function _fb_probe_read_consistency(): bool
 {
     /* isc_tpb_read_consistency is FB4+ but the TPB tag is silently accepted
@@ -241,9 +255,12 @@ function _fb_probe_read_consistency(): bool
     $db = _fb_probe_connect();
     if (!$db) return false;
     try {
-        /* FBIRD_READ_CONSISTENCY = 32768 bitmask flag. See
-         * firebird_utils.cpp:2879: `if (trans_flags & PHP_FBIRD_READ_CONSISTENCY)`. */
-        $trans = @fbird_trans(FBIRD_READ_CONSISTENCY, $db);
+        /* FBIRD_READ_CONSISTENCY (32768) only takes effect when combined
+         * with FBIRD_COMMITTED (8) — see firebird_utils.cpp TPB builder:
+         * isc_tpb_read_consistency is only inserted inside the
+         * PHP_FBIRD_COMMITTED branch. Without it, falls through to
+         * default SNAPSHOT (isc_tpb_concurrency). */
+        $trans = @fbird_trans(FBIRD_COMMITTED | FBIRD_READ_CONSISTENCY, $db);
         if ($trans) {
             fbird_commit($trans);
             return true;

--- a/tests/pdo_fbird/pdo_fbird_decfloat.phpt
+++ b/tests/pdo_fbird/pdo_fbird_decfloat.phpt
@@ -68,7 +68,7 @@ $pdo->exec("INSERT INTO decfloat_test VALUES (6, 1.23E10, 1.23456789012345678901
 $stmt = $pdo->query("SELECT df16, df34 FROM decfloat_test WHERE id = 6");
 $row = $stmt->fetch(PDO::FETCH_NUM);
 echo "df16 (1.23E10): " . $row[0] . "\n";
-echo "df34 (1.23E-20): " . $row[0] . "\n";
+echo "df34 (1.23E-20): " . $row[1] . "\n";
 
 echo "\n=== Test 6: NULL values ===\n";
 $pdo->exec("INSERT INTO decfloat_test (id, df16, df34) VALUES (7, NULL, NULL)");


### PR DESCRIPTION
## Summary

3 fixes from code review of merged v13.0.0 PRs (#447-#450).

## Fixes

| # | Bug | Severity | File |
|---|-----|----------|------|
| 1 | DECFLOAT test: `$row[0]` used twice instead of `$row[1]` for df34 — test claimed to verify DECFLOAT(34) but printed df16's value twice (masked by `%s` wildcard) | Medium | `pdo_fbird_decfloat.phpt:71` |
| 2 | READ_CONSISTENCY probe: used `FBIRD_READ_CONSISTENCY` alone, but C code only inserts `isc_tpb_read_consistency` when `FBIRD_COMMITTED` is also set — fell through to default SNAPSHOT, returning true for wrong reason | Medium | `fb_version_probe.inc:246` |
| 3 | `STATEMENT_TIMEOUT` listed in spec as supported feature key but missing from `_fb_probe_feature()` switch — calling it triggered warning + returned false | Low | `fb_version_probe.inc` |

## Verification

- DECFLOAT test: PASS on FB4
- `STATEMENT_TIMEOUT`: yes on FB4, no on FB3
- `READ_CONSISTENCY`: yes on FB4, no on FB3