### PR TITLE
feat(v13.0.0): FB5+ scrollable cursor BOF/EOF + edge cases (#426)

### DIFF
--- a/pdo_fbird/pdo_fbird_stmt.c
+++ b/pdo_fbird/pdo_fbird_stmt.c
@@ -306,9 +306,13 @@ static int pdo_fbird_stmt_fetch(pdo_stmt_t *stmt,
 	}
 
 	if (rc == 1) return 1;   /* row fetched */
-	if (rc == 0) {           /* end of data */
-		S->has_rows = 0;
-		fbs_close_cursor(S->fbs_stmt, S->status);
+	if (rc == 0) {           /* end of data (BOF/EOF) */
+		if (!S->scrollable) {
+			/* Forward-only: close cursor on EOF */
+			S->has_rows = 0;
+			fbs_close_cursor(S->fbs_stmt, S->status);
+		}
+		/* Scrollable: keep cursor open for repositioning */
 		return 0;
 	}
 	/* error */

--- a/tests/fb_version_probe.inc
+++ b/tests/fb_version_probe.inc
@@ -301,11 +301,37 @@ function _fb_get_server_version(): float
 
 function _fb_probe_scrollable_cursors(): bool
 {
-    /* Scrollable cursors are a driver/client capability (FB5+ client +
-     * server). The procedural fbird_* API exposes bidirectional fetch via
-     * OOP Firebird\Statement or PDO CURSOR_SCROLL. No simple procedural
-     * probe; fall back to version check. */
-    return _fb_get_server_version() >= 5.0;
+    /* Scrollable cursors require BOTH FB5+ client AND server.
+     * Version check alone is insufficient — a FB4 client against a FB5
+     * server will report version >= 5.0 but fail at fetch time with
+     * "feature is not supported" (335544378).
+     * Probe by attempting a PDO scrollable cursor fetch. */
+    if (!in_array('fbird', PDO::getAvailableDrivers())) return false;
+
+    global $host, $user, $password;
+    $hostStr = ($host !== '' && $host !== null) ? $host : 'localhost';
+
+    $dbEnv = getenv('FIREBIRD_DB_PATH');
+    if ($dbEnv === false || $dbEnv === '') {
+        $dbEnv = getenv('FIREBIRD_DATABASE');
+    }
+    $db = ($dbEnv !== false && $dbEnv !== '') ? $dbEnv : '/firebird/data/test.fdb';
+
+    try {
+        $pdo = new PDO("fbird:host={$hostStr};dbname={$db};charset=UTF8", $user, $password,
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT]);
+        @$pdo->exec("RECREATE TABLE FB_PROBE_SCROLL (id INT)");
+        $pdo->exec("INSERT INTO FB_PROBE_SCROLL VALUES (1)");
+        $stmt = $pdo->prepare("SELECT id FROM FB_PROBE_SCROLL",
+            [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+        $stmt->execute();
+        $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT);
+        $r = @$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_PRIOR);
+        @$pdo->exec("DROP TABLE FB_PROBE_SCROLL");
+        return $r !== false;
+    } catch (Throwable $e) {
+        return false;
+    }
 }
 
 function _fb_probe_parallel_workers(): bool

--- a/tests/pdo_fbird/conformance/pdo_definition_fetch_orientation.phpt
+++ b/tests/pdo_fbird/conformance/pdo_definition_fetch_orientation.phpt
@@ -50,6 +50,14 @@ echo "OK LAST: id=" . $r[0] . "\n";
 $r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_ABS, 3);
 echo "OK ABS(3): id=" . $r[0] . "\n";
 
+// FETCH_ORI_PRIOR
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_PRIOR);
+echo "OK PRIOR: id=" . $r[0] . "\n";
+
+// FETCH_ORI_REL (relative offset)
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_REL, 1);
+echo "OK REL(1): id=" . $r[0] . "\n";
+
 echo "=== DONE ===\n";
 ?>
 --CLEAN--

--- a/tests/pdo_fbird/pdo_fbird_scrollable_cursor_edge_cases.phpt
+++ b/tests/pdo_fbird/pdo_fbird_scrollable_cursor_edge_cases.phpt
@@ -1,0 +1,188 @@
+--TEST--
+pdo_fbird: FB5+ scrollable cursor BOF/EOF and edge cases (#426)
+--SKIPIF--
+<?php
+if (!extension_loaded('firebird')) die('skip firebird not loaded');
+if (!in_array('fbird', PDO::getAvailableDrivers())) die('skip pdo_fbird not available');
+require_once __DIR__ . '/../fb_version_probe.inc';
+if (!fb_server_supports('SCROLLABLE_CURSORS')) die('skip scrollable cursors not supported (requires FB5+)');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+
+$pdo = pdo_fbird_connect();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+/* ============================================================
+ * Issue #426: FB5 scrollable cursors — BOF/EOF detection + edge cases
+ *
+ * Tests the behavior fix: scrollable cursors must remain open after
+ * BOF/EOF so the user can reposition. Previously the cursor was closed
+ * on any 0 return, making repositioning impossible.
+ * ============================================================ */
+
+echo "=== Test 1: EOF detection — NEXT past last row ===\n";
+$pdo->exec("RECREATE TABLE scroll_edge (id INT, val VARCHAR(10))");
+for ($i = 1; $i <= 3; $i++) {
+    $pdo->exec("INSERT INTO scroll_edge VALUES ($i, 'r$i')");
+}
+$stmt = $pdo->prepare("SELECT id FROM scroll_edge ORDER BY id", [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+$stmt->execute();
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT); /* row 1 */
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT); /* row 2 */
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT); /* row 3 */
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT); /* EOF */
+echo "EOF returns false: " . ($r === false ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 2: BOF detection — PRIOR before first row ===\n";
+$stmt->closeCursor();
+$stmt->execute();
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT); /* row 1 */
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_PRIOR); /* BOF */
+echo "BOF returns false: " . ($r === false ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 3: Cursor usable after EOF — reposition to LAST ===\n";
+$stmt->closeCursor();
+$stmt->execute();
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_LAST);  /* row 3 */
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT);   /* EOF */
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_LAST); /* reposition */
+echo "Usable after EOF: " . ($r !== false ? "yes, id=" . $r[0] : 'no') . "\n";
+
+echo "\n=== Test 4: Cursor usable after BOF — reposition to FIRST ===\n";
+$stmt->closeCursor();
+$stmt->execute();
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT);   /* row 1 */
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_PRIOR);   /* BOF */
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_FIRST); /* reposition */
+echo "Usable after BOF: " . ($r !== false ? "yes, id=" . $r[0] : 'no') . "\n";
+
+echo "\n=== Test 5: Empty result set ===\n";
+$pdo->exec("RECREATE TABLE scroll_empty (id INT)");
+$stmt2 = $pdo->prepare("SELECT id FROM scroll_empty", [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+$stmt2->execute();
+$r = $stmt2->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT);
+echo "Empty NEXT: " . ($r === false ? 'false (correct)' : 'unexpected row') . "\n";
+$r = $stmt2->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_FIRST);
+echo "Empty FIRST: " . ($r === false ? 'false (correct)' : 'unexpected row') . "\n";
+$r = $stmt2->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_LAST);
+echo "Empty LAST: " . ($r === false ? 'false (correct)' : 'unexpected row') . "\n";
+$stmt2->closeCursor();
+
+echo "\n=== Test 6: Single row — FIRST==LAST==ABS(1) ===\n";
+$pdo->exec("RECREATE TABLE scroll_one (id INT)");
+$pdo->exec("INSERT INTO scroll_one VALUES (42)");
+$stmt3 = $pdo->prepare("SELECT id FROM scroll_one", [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+$stmt3->execute();
+$r = $stmt3->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_FIRST);
+echo "Single FIRST: id=" . $r[0] . "\n";
+$r = $stmt3->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_LAST);
+echo "Single LAST: id=" . $r[0] . "\n";
+$r = $stmt3->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_ABS, 1);
+echo "Single ABS(1): id=" . $r[0] . "\n";
+$stmt3->closeCursor();
+
+echo "\n=== Test 7: Out-of-bounds ABS ===\n";
+$stmt->closeCursor();
+$stmt->execute();
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_ABS, 0);
+echo "ABS(0): " . ($r === false ? 'false (correct)' : 'unexpected row') . "\n";
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_ABS, 99);
+echo "ABS(99): " . ($r === false ? 'false (correct)' : 'unexpected row') . "\n";
+/* Cursor still usable after out-of-bounds */
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_FIRST);
+echo "After OOB, FIRST: " . ($r !== false ? "yes, id=" . $r[0] : 'no') . "\n";
+
+echo "\n=== Test 8: REL beyond boundaries ===\n";
+$stmt->closeCursor();
+$stmt->execute();
+$stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT); /* row 1 */
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_REL, -99);
+echo "REL(-99) from row 1: " . ($r === false ? 'false (BOF, correct)' : 'unexpected row') . "\n";
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_REL, 99);
+echo "REL(+99) from BOF: " . ($r === false ? 'false (EOF, correct)' : 'unexpected row') . "\n";
+/* Cursor still usable */
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_ABS, 2);
+echo "After REL OOB, ABS(2): " . ($r !== false ? "yes, id=" . $r[0] : 'no') . "\n";
+
+echo "\n=== Test 9: Cross-orientation navigation ===\n";
+$stmt->closeCursor();
+$stmt->execute();
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT);     /* 1 */
+echo "NEXT: " . $r[0] . "\n";
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_NEXT);     /* 2 */
+echo "NEXT: " . $r[0] . "\n";
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_LAST);     /* 3 */
+echo "LAST: " . $r[0] . "\n";
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_PRIOR);    /* 2 */
+echo "PRIOR: " . $r[0] . "\n";
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_FIRST);    /* 1 */
+echo "FIRST: " . $r[0] . "\n";
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_ABS, 3);   /* 3 */
+echo "ABS(3): " . $r[0] . "\n";
+$r = $stmt->fetch(PDO::FETCH_NUM, PDO::FETCH_ORI_REL, -1);  /* 2 */
+echo "REL(-1): " . $r[0] . "\n";
+
+/* Cleanup */
+$stmt->closeCursor();
+unset($stmt);
+unset($stmt2);
+unset($stmt3);
+unset($pdo);
+
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: EOF detection — NEXT past last row ===
+EOF returns false: yes
+
+=== Test 2: BOF detection — PRIOR before first row ===
+BOF returns false: yes
+
+=== Test 3: Cursor usable after EOF — reposition to LAST ===
+Usable after EOF: yes, id=3
+
+=== Test 4: Cursor usable after BOF — reposition to FIRST ===
+Usable after BOF: yes, id=1
+
+=== Test 5: Empty result set ===
+Empty NEXT: false (correct)
+Empty FIRST: false (correct)
+Empty LAST: false (correct)
+
+=== Test 6: Single row — FIRST==LAST==ABS(1) ===
+Single FIRST: id=42
+Single LAST: id=42
+Single ABS(1): id=42
+
+=== Test 7: Out-of-bounds ABS ===
+ABS(0): false (correct)
+ABS(99): false (correct)
+After OOB, FIRST: yes, id=1
+
+=== Test 8: REL beyond boundaries ===
+REL(-99) from row 1: false (BOF, correct)
+REL(+99) from BOF: false (EOF, correct)
+After REL OOB, ABS(2): yes, id=2
+
+=== Test 9: Cross-orientation navigation ===
+NEXT: 1
+NEXT: 2
+LAST: 3
+PRIOR: 2
+FIRST: 1
+ABS(3): 3
+REL(-1): 2
+
+Done.
+
+--CLEAN--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+$pdo = pdo_fbird_connect([PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT]);
+@$pdo->exec("DROP TABLE scroll_edge");
+@$pdo->exec("DROP TABLE scroll_empty");
+@$pdo->exec("DROP TABLE scroll_one");
+unset($pdo);
+?>


### PR DESCRIPTION
## Summary

Closes #426. Scrollable cursor BOF/EOF fix + comprehensive edge case coverage.

## C fix: cursor stays open after BOF/EOF (behavior change)

`pdo_fbird/pdo_fbird_stmt.c:308-312`: Previously, any `0` return (BOF/EOF) closed the cursor and set `has_rows=0`, making repositioning impossible. Now only forward-only cursors close on EOF; scrollable cursors keep `has_rows=1`.

**Before**: After hitting EOF on a scrollable cursor, any subsequent fetch returns `false` (cursor dead).
**After**: After hitting EOF/BOF, the cursor remains usable for `FIRST`/`LAST`/`ABS`/`REL` repositioning.

Forward-only cursor behavior is unchanged.

## Deliverables

| File | What |
|------|------|
| `pdo_fbird/pdo_fbird_stmt.c` | C fix: scrollable cursors stay open after BOF/EOF |
| `tests/pdo_fbird/pdo_fbird_scrollable_cursor_edge_cases.phpt` | 9 new tests: BOF/EOF, repositioning, empty, single-row, out-of-bounds, cross-orientation |
| `tests/pdo_fbird/conformance/pdo_definition_fetch_orientation.phpt` | Extended: 4/6 → 6/6 orientations (added PRIOR, REL) |
| `tests/fb_version_probe.inc` | Probe fix: actual PDO capability probe instead of version check (detects FB4 client → FB5 server) |

## Procedural API gap

The `fbird_*` procedural API has no scrollable cursor support (only forward-only `fbird_fetch_row/assoc/object`). C wrappers (`fbs_fetch_prior/first/last/absolute/relative`) exist but are consumed exclusively by PDO. Procedural scrollable support is tracked by #362 (`fbird_data_seek`), Unscheduled milestone.

## Verification

| Container | Result |
|-----------|--------|
| php84-dev (FB4 client + FB4 server) | Existing tests PASS, scrollable tests SKIP |
| php84-dev (FB4 client → FB5 server) | Scrollable tests SKIP (FB4 client) |
| CI (FB5 client + FB5 server) | Pending |