### PR TITLE
docs(v13.0.0): fix #417 status in spec

### DIFF
--- a/specs/spec-v13.0-fb4-plus-coverage.md
+++ b/specs/spec-v13.0-fb4-plus-coverage.md
@@ -234,7 +234,7 @@ spec (`spec-v13.1-fb6-coverage.md` or similar) will cover:
 |-------|-------|--------|
 | #327 | spec: write this file (this spec) | **Done** |
 | #419 | feat: FB4 TIME/TIMESTAMP WITH TIME ZONE | **Done** (P1) |
-| #417 | feat: FB4 DECFLOAT(16/34) native type support | **Done** (P2) |
+| #417 | feat: FB4 DECFLOAT(16/34) native type support | Test coverage done — native type TODO (P2) |
 | #418 | feat: FB4 INT128 native type support | **Done** (P2) |
 | #420 | feat: FB4 SET BIND rule coverage (all rules) | Open - P3 |
 | #426 | feat: FB5 scrollable cursors (6 orientations) | **Done** (P4) |


### PR DESCRIPTION
Spec marked #417 as Done but the issue is still open — native PHP type (not string) is not yet implemented. Updated to 'Test coverage done — native type TODO'.