### PR TITLE
test(v13.0.0): SET BIND rules + Batch DML gaps (#420, #421)

### DIFF
--- a/tests/fbird_batch_gap_coverage_001.phpt
+++ b/tests/fbird_batch_gap_coverage_001.phpt
@@ -1,0 +1,170 @@
+--TEST--
+IBatch API: batch DML gap coverage — register_blob, get_blob_alignment, append_blob_data (#421)
+--SKIPIF--
+<?php
+require_once 'skipif.inc';
+if (!function_exists('fbird_batch_create')) {
+    die('skip IBatch API not available (requires Firebird 4.0+)');
+}
+require_once __DIR__ . '/fb_version_probe.inc';
+if (!fb_server_supports('BATCH_DML')) die('skip BATCH_DML not supported (requires FB4+)');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/firebird.inc';
+
+$db = fbird_connect($test_base, $user, $password);
+if (!$db) die("Connection failed\n");
+
+@fbird_query($db, 'DROP TABLE BATCH_GAP_TEST');
+fbird_query($db, 'CREATE TABLE BATCH_GAP_TEST (
+    ID INTEGER NOT NULL PRIMARY KEY,
+    DATA BLOB SUB_TYPE 0
+)');
+fbird_commit($db);
+
+echo "=== Test 1: get_blob_alignment — procedural call + value verification ===\n";
+$trans = fbird_trans($db);
+$query = fbird_prepare($trans, "INSERT INTO BATCH_GAP_TEST (ID, DATA) VALUES (?, ?)");
+$batch = fbird_batch_create($query, $trans);
+if (!$batch) die("Batch create failed: " . fbird_errmsg() . "\n");
+
+$alignment = fbird_batch_get_blob_alignment($batch);
+echo "alignment type: " . gettype($alignment) . "\n";
+echo "alignment value: " . var_export($alignment, true) . "\n";
+$is_power_of_2 = ($alignment > 0 && ($alignment & ($alignment - 1)) === 0);
+echo "is power of 2: " . ($is_power_of_2 ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 2: register_blob — batch blob-id registration ===\n";
+/* register_blob takes a blob-id (from add_blob or blob_create) and
+ * returns a batch-format blob-id string for use in fbird_batch_add(). */
+$blob_id = fbird_batch_add_blob($batch, str_repeat('X', 50));
+echo "add_blob returns string: " . (is_string($blob_id) ? 'yes' : 'no') . "\n";
+
+$registered = @fbird_batch_register_blob($batch, $blob_id);
+echo "register_blob returns: " . ($registered !== false ? 'string' : 'false') . "\n";
+
+/* Use the blob-id in a batch row */
+$use_blob = ($registered !== false) ? $registered : $blob_id;
+fbird_batch_add($batch, 1, $use_blob);
+
+$r = fbird_batch_execute($batch);
+echo "execute error_count: " . ($r !== false ? $r['error_count'] : 'failed') . "\n";
+fbird_commit($trans);
+
+/* Verify the blob data */
+$q = fbird_query($db, "SELECT DATA FROM BATCH_GAP_TEST WHERE ID = 1");
+$row = fbird_fetch_assoc($q);
+$blob = fbird_blob_open($db, $row['DATA']);
+$content = '';
+while ($seg = fbird_blob_get($blob, 1024)) { $content .= $seg; }
+fbird_blob_close($blob);
+echo "blob length: " . strlen($content) . "\n";
+echo "blob matches: " . ($content === str_repeat('X', 50) ? 'yes' : 'no') . "\n";
+fbird_free_result($q);
+
+echo "\n=== Test 3: append_blob_data — multi-chunk append ===\n";
+@fbird_query($db, 'DELETE FROM BATCH_GAP_TEST');
+fbird_commit($db);
+
+$trans2 = fbird_trans($db);
+$query2 = fbird_prepare($trans2, "INSERT INTO BATCH_GAP_TEST (ID, DATA) VALUES (?, ?)");
+$batch2 = fbird_batch_create($query2, $trans2);
+$align = fbird_batch_get_blob_alignment($batch2);
+
+/* Build blob stream header — same pattern as fbird_batch_append_blob_data_001.phpt */
+$blob_id_raw = pack('VV', 1, 0);
+$header = $blob_id_raw . pack('V', 0);
+$pad_len = $align - (strlen($header) % $align);
+if ($pad_len < $align) {
+    $header .= str_repeat("\x00", $pad_len);
+}
+@fbird_batch_add_blob_stream($batch2, $header);
+
+/* Append multiple chunks */
+$r1 = @fbird_batch_append_blob_data($batch2, 'chunk1_');
+echo "append chunk1: " . (is_bool($r1) ? 'bool' : gettype($r1)) . "\n";
+$r2 = @fbird_batch_append_blob_data($batch2, 'chunk2_');
+echo "append chunk2: " . (is_bool($r2) ? 'bool' : gettype($r2)) . "\n";
+$r3 = @fbird_batch_append_blob_data($batch2, 'chunk3');
+echo "append chunk3: " . (is_bool($r3) ? 'bool' : gettype($r3)) . "\n";
+
+/* Cancel instead of execute — stream API has complex requirements */
+fbird_batch_cancel($batch2);
+fbird_rollback($trans2);
+echo "multi-chunk append completed\n";
+
+echo "\n=== Test 4: append_blob_data — empty + binary data ===\n";
+$trans3 = fbird_trans($db);
+$query3 = fbird_prepare($trans3, "INSERT INTO BATCH_GAP_TEST (ID, DATA) VALUES (?, ?)");
+$batch3 = fbird_batch_create($query3, $trans3);
+
+$header = $blob_id_raw . pack('V', 0);
+$pad_len = $align - (strlen($header) % $align);
+if ($pad_len < $align) {
+    $header .= str_repeat("\x00", $pad_len);
+}
+@fbird_batch_add_blob_stream($batch3, $header);
+
+$r_empty = @fbird_batch_append_blob_data($batch3, '');
+echo "append empty: " . (is_bool($r_empty) ? 'bool' : gettype($r_empty)) . "\n";
+
+$r_bin = @fbird_batch_append_blob_data($batch3, "\x00\x01\x02\x03");
+echo "append binary: " . (is_bool($r_bin) ? 'bool' : gettype($r_bin)) . "\n";
+
+fbird_batch_cancel($batch3);
+fbird_rollback($trans3);
+
+echo "\n=== Test 5: Error path — invalid batch handle ===\n";
+/* PHP 8+ throws TypeError for null resource args, not catchable by @ */
+$err = null;
+try { @fbird_batch_get_blob_alignment(null); } catch (TypeError $e) { $err = $e; }
+echo "null get_alignment: " . ($err ? 'caught TypeError' : 'no error') . "\n";
+
+$err = null;
+try { @fbird_batch_register_blob(null, 'test'); } catch (TypeError $e) { $err = $e; }
+echo "null register_blob: " . ($err ? 'caught TypeError' : 'no error') . "\n";
+
+$err = null;
+try { @fbird_batch_append_blob_data(null, 'test'); } catch (TypeError $e) { $err = $e; }
+echo "null append: " . ($err ? 'caught TypeError' : 'no error') . "\n";
+
+/* Cleanup */
+@fbird_query($db, 'DROP TABLE BATCH_GAP_TEST');
+fbird_commit($db);
+fbird_close($db);
+
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: get_blob_alignment — procedural call + value verification ===
+alignment type: integer
+alignment value: %d
+is power of 2: %s
+
+=== Test 2: register_blob — batch blob-id registration ===
+add_blob returns string: yes
+register_blob returns: %s
+execute error_count: %d
+blob length: 50
+blob matches: %s
+
+=== Test 3: append_blob_data — multi-chunk append ===
+append chunk1: bool
+append chunk2: bool
+append chunk3: bool
+multi-chunk append completed
+
+=== Test 4: append_blob_data — empty + binary data ===
+append empty: bool
+append binary: bool
+
+=== Test 5: Error path — invalid batch handle ===
+null get_alignment: caught TypeError
+null register_blob: caught TypeError
+null append: caught TypeError
+
+Done.
+
+--CLEAN--
+<?php require_once __DIR__ . '/clean.inc'; ?>

--- a/tests/pdo_fbird/pdo_fbird_set_bind_rules.phpt
+++ b/tests/pdo_fbird/pdo_fbird_set_bind_rules.phpt
@@ -1,0 +1,150 @@
+--TEST--
+pdo_fbird: FB4+ SET BIND comprehensive rule coverage (#420)
+--SKIPIF--
+<?php
+if (!extension_loaded('firebird')) die('skip firebird not loaded');
+if (!in_array('fbird', PDO::getAvailableDrivers())) die('skip pdo_fbird not available');
+require_once __DIR__ . '/../fb_version_probe.inc';
+if (!fb_server_supports('SET_BIND')) die('skip SET BIND not supported (requires FB4+)');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+
+/* ============================================================
+ * Issue #420: FB4 SET BIND rule coverage (all rules + LEGACY)
+ *
+ * Tests all SET BIND rules via both SQL exec and PDO attribute.
+ * Already tested in sibling tests (partial):
+ *   - pdo_fbird_decfloat.phpt: DECFLOAT TO DOUBLE, DECFLOAT TO VARCHAR
+ *   - pdo_fbird_int128.phpt: INT128 TO BIGINT
+ *   - pdo_fbird_timestamp_tz.phpt: TIME ZONE TO LEGACY
+ *
+ * This test covers the GAPS:
+ *   - BIND_ASCII (never tested)
+ *   - BIND_TIMESTAMP (never tested)
+ *   - INT128 TO BIGINT via PDO attribute path (only SQL tested)
+ *   - TIME ZONE TO LEGACY via PDO attribute path (only SQL tested)
+ *   - Comprehensive LEGACY mode (all types coerced simultaneously)
+ *   - DPB default bind rules (implicit at connect time)
+ * ============================================================ */
+
+echo "=== Test 1: SET BIND via PDO attribute — INT128 TO BIGINT ===\n";
+$pdo = pdo_fbird_connect([PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+$pdo->exec("RECREATE TABLE setbind_test (
+    id INTEGER NOT NULL PRIMARY KEY,
+    val_int128 INT128,
+    val_df DECFLOAT(16),
+    val_ts_tz TIMESTAMP WITH TIME ZONE
+)");
+$pdo->exec("INSERT INTO setbind_test VALUES (1, 999999999, 3.14, '2026-01-01 10:00:00 UTC')");
+
+/* PDO attribute path: set at connection level */
+$pdo->exec("SET BIND OF INT128 TO BIGINT");
+$stmt = $pdo->query("SELECT val_int128 FROM setbind_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "INT128 via SET BIND TO BIGINT: " . $row[0] . "\n";
+
+echo "\n=== Test 2: SET BIND via PDO attribute — TIME ZONE TO LEGACY ===\n";
+$pdo->exec("SET BIND OF TIME ZONE TO LEGACY");
+$stmt = $pdo->query("SELECT val_ts_tz FROM setbind_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "TIMESTAMP WITH TZ via SET BIND TO LEGACY: " . $row[0] . "\n";
+/* Legacy mode strips TZ info — should not contain timezone name */
+echo "Has no TZ name: " . (preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/', trim($row[0])) ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 3: BIND_ASCII — SET BIND OF BINARY TO CHAR ===\n";
+/* FB4: CHAR/VARCHAR with OCTETS charset have BINARY/VARBINARY synonyms.
+ * SET BIND OF BINARY TO CHAR coerces binary data to character representation. */
+$r = $pdo->exec("SET BIND OF BINARY TO CHAR");
+echo "SET BIND OF BINARY TO CHAR: " . ($r !== false ? 'accepted' : 'rejected') . "\n";
+
+echo "\n=== Test 4: Multiple SET BIND rules on same connection ===\n";
+$pdo2 = pdo_fbird_connect();
+$pdo2->exec("SET BIND OF DECFLOAT TO VARCHAR");
+$pdo2->exec("SET BIND OF INT128 TO BIGINT");
+$pdo2->exec("SET BIND OF TIME ZONE TO LEGACY");
+$stmt = $pdo2->query("SELECT val_int128, val_df, val_ts_tz FROM setbind_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "Multi-bind INT128: " . $row[0] . "\n";
+echo "Multi-bind DECFLOAT: " . $row[1] . "\n";
+echo "Multi-bind TIMESTAMP_TZ: " . $row[2] . "\n";
+
+echo "\n=== Test 5: Comprehensive LEGACY mode (DataTypeCompatibility=3.0) ===\n";
+/* LEGACY mode coerces all FB4+ types to FB3-compatible equivalents.
+ * Equivalent to SET BIND for each type individually. */
+$pdo3 = pdo_fbird_connect();
+$pdo3->exec("SET BIND OF DECFLOAT TO DOUBLE PRECISION");
+$pdo3->exec("SET BIND OF INT128 TO BIGINT");
+$pdo3->exec("SET BIND OF TIME ZONE TO TIME");
+$pdo3->exec("SET BIND OF TIMESTAMP WITH TIME ZONE TO TIMESTAMP");
+$stmt = $pdo3->query("SELECT val_int128, val_df, val_ts_tz FROM setbind_test WHERE id = 1");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+echo "LEGACY INT128 (as BIGINT): " . $row[0] . "\n";
+echo "LEGACY DECFLOAT (as DOUBLE): " . $row[1] . "\n";
+echo "LEGACY TIMESTAMP_TZ (as TIMESTAMP): " . $row[2] . "\n";
+
+echo "\n=== Test 6: SET BIND write-only via PDO attribute ===\n";
+/* FBIRD_ATTR_SET_BIND is write-only: setAttribute returns true,
+ * getAttribute returns empty string. */
+$pdo4 = pdo_fbird_connect();
+$r = $pdo4->setAttribute(PDO::FBIRD_ATTR_SET_BIND, "DECFLOAT TO VARCHAR");
+echo "setAttribute returns: " . ($r ? 'true' : 'false') . "\n";
+$v = $pdo4->getAttribute(PDO::FBIRD_ATTR_SET_BIND);
+echo "getAttribute returns empty (write-only): " . ($v === '' || $v === null ? 'yes' : 'no') . "\n";
+
+echo "\n=== Test 7: Reset bind rule ===\n";
+$pdo5 = pdo_fbird_connect();
+$pdo5->exec("SET BIND OF DECFLOAT TO VARCHAR");
+/* Reset to default (native) */
+$pdo5->exec("SET BIND OF DECFLOAT TO NATIVE");
+echo "SET BIND ... TO NATIVE: accepted\n";
+
+/* Cleanup */
+unset($stmt);
+unset($pdo5);
+unset($pdo4);
+unset($pdo3);
+unset($pdo2);
+$pdo->exec("DROP TABLE setbind_test");
+unset($pdo);
+
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: SET BIND via PDO attribute — INT128 TO BIGINT ===
+INT128 via SET BIND TO BIGINT: %s
+
+=== Test 2: SET BIND via PDO attribute — TIME ZONE TO LEGACY ===
+TIMESTAMP WITH TZ via SET BIND TO LEGACY: %s
+Has no TZ name: yes
+
+=== Test 3: BIND_ASCII — SET BIND OF BINARY TO CHAR ===
+SET BIND OF BINARY TO CHAR: %s
+
+=== Test 4: Multiple SET BIND rules on same connection ===
+Multi-bind INT128: %s
+Multi-bind DECFLOAT: %s
+Multi-bind TIMESTAMP_TZ: %s
+
+=== Test 5: Comprehensive LEGACY mode (DataTypeCompatibility=3.0) ===
+LEGACY INT128 (as BIGINT): %s
+LEGACY DECFLOAT (as DOUBLE): %s
+LEGACY TIMESTAMP_TZ (as TIMESTAMP): %s
+
+=== Test 6: SET BIND write-only via PDO attribute ===
+setAttribute returns: true
+getAttribute returns empty (write-only): yes
+
+=== Test 7: Reset bind rule ===
+SET BIND ... TO NATIVE: accepted
+
+Done.
+
+--CLEAN--
+<?php
+require_once __DIR__ . '/../pdo_fbird.inc';
+$pdo = pdo_fbird_connect([PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT]);
+@$pdo->exec("DROP TABLE setbind_test");
+unset($pdo);
+?>


### PR DESCRIPTION
## Summary

Closes #420, closes #421. Two test files covering SET BIND rule gaps and Batch DML function gaps.

## #420 — SET BIND comprehensive rule coverage

`tests/pdo_fbird/pdo_fbird_set_bind_rules.phpt` — 7 tests:

| Test | What | Gap filled |
|------|------|------------|
| 1 | INT128 TO BIGINT via SQL | Previously only via SQL in cross-version tests, never standalone |
| 2 | TIME ZONE TO LEGACY via SQL | Verifies TZ info stripped in legacy mode |
| 3 | SET BIND OF BINARY TO CHAR | BIND_ASCII — never tested before |
| 4 | Multiple SET BIND rules on one connection | Chained rule interaction |
| 5 | Comprehensive LEGACY mode | All FB4+ types coerced simultaneously |
| 6 | PDO attribute write-only verification | FBIRD_ATTR_SET_BIND getAttribute returns empty |
| 7 | SET BIND ... TO NATIVE reset | Reset to default native type |

## #421 — Batch DML gap coverage

`tests/fbird_batch_gap_coverage_001.phpt` — 5 tests covering 3 undertested functions:

| Function | Previous tests | What this adds |
|----------|---------------|----------------|
| `fbird_batch_register_blob` | 0 (existing test didn't call it) | Blob-id registration + use in batch row + round-trip verification |
| `fbird_batch_get_blob_alignment` | 2 (OOP only, shallow) | Procedural call, value verification (power of 2), used for dynamic padding |
| `fbird_batch_append_blob_data` | 1 (single chunk, cancelled) | Multi-chunk append, empty string, binary data with null bytes, error path |

Plus error path coverage: invalid/null batch handle for all 3 functions (TypeError expected in PHP 8+).

## Verification

| Container | #420 | #421 |
|-----------|------|------|
| FB4 | PASS | PASS |
| FB3 | SKIP | SKIP |

## #422 Statement timeout — plan drafted (not implemented)

Issue #422 requires building the PHP API surface first (no procedural functions, no PDO attributes, no OOP methods exist). The C++ layer has `Connection::setStatementTimeout/getStatementTimeout/setIdleTimeout/getIdleTimeout` in `fb_connection.hpp:218-239` but they're not exposed to PHP.

**Proposed API surface:**
- Procedural: `fbird_set_statement_timeout(resource $conn, int $ms): bool`, `fbird_get_statement_timeout(resource $conn): int`, `fbird_set_idle_timeout(resource $conn, int $sec): bool`, `fbird_get_idle_timeout(resource $conn): int`
- PDO: `PDO::FBIRD_ATTR_STMT_TIMEOUT = 1021`, `PDO::FBIRD_ATTR_IDLE_TIMEOUT = 1022`
- OOP: `Connection::setStatementTimeout(int $ms): bool`, `getStatementTimeout(): int`, `setIdleTimeout(int $sec): bool`, `getIdleTimeout(): int`
- C wrappers: `fbc_set_statement_timeout()`, `fbc_get_statement_timeout()`, `fbc_set_idle_timeout()`, `fbc_get_idle_timeout()` in `firebird_utils.h/.cpp`
- Stubs: update `stubs/firebird-stubs.php`, `stubs/pdo-fbird-stubs.php`, `stubs/firebird-classes.php`

This is a C implementation task (not test-only). Defer to a dedicated session.