### PR TITLE
test(v13.0.0): packages, EXECUTE STATEMENT rich form, profiler (#423, #424, #428)

### DIFF
--- a/tests/fbird_execute_statement_rich_001.phpt
+++ b/tests/fbird_execute_statement_rich_001.phpt
@@ -1,0 +1,137 @@
+--TEST--
+Firebird 4.0+ EXECUTE STATEMENT rich form + SET TIME ZONE + AT TIME ZONE (#424)
+--SKIPIF--
+<?php
+require_once 'skipif.inc';
+require_once __DIR__ . '/fb_version_probe.inc';
+if (!fb_server_supports('TIME_TZ')) die('skip TIME_TZ not supported (requires FB4+)');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/firebird.inc';
+
+$db = fbird_connect($test_base, $user, $password);
+if (!$db) die("Connection failed\n");
+
+echo "=== Test 1: SET TIME ZONE ===\n";
+/* SET TIME ZONE sets the session timezone. */
+$ok = fbird_query($db, "SET TIME ZONE 'UTC'");
+fbird_commit($db);
+echo "SET TIME ZONE 'UTC': " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+/* Verify via LOCALTIMESTAMP format which reflects session TZ */
+$q = fbird_query($db, "SELECT CAST(LOCALTIMESTAMP AS VARCHAR(40)) FROM RDB\$DATABASE");
+$row = fbird_fetch_row($q);
+echo "LOCALTIMESTAMP after SET UTC: " . $row[0] . "\n";
+fbird_free_result($q);
+
+/* Set to a named zone */
+fbird_query($db, "SET TIME ZONE 'Europe/Berlin'");
+fbird_commit($db);
+$q = fbird_query($db, "SELECT CAST(LOCALTIMESTAMP AS VARCHAR(40)) FROM RDB\$DATABASE");
+$row = fbird_fetch_row($q);
+echo "LOCALTIMESTAMP after SET Berlin: " . $row[0] . "\n";
+fbird_free_result($q);
+
+/* Reset to LOCAL */
+fbird_query($db, "SET TIME ZONE LOCAL");
+fbird_commit($db);
+
+echo "\n=== Test 2: EXTRACT(TIMEZONE_HOUR|MINUTE) on TZ literal ===\n";
+/* FB 4.0 supports EXTRACT(TIMEZONE_HOUR|MINUTE) but NOT TIMEZONE_NAME */
+$q = fbird_query($db, "SELECT
+    EXTRACT(TIMEZONE_HOUR FROM TIMESTAMP'2026-07-08 10:00:00 Europe/Berlin'),
+    EXTRACT(TIMEZONE_MINUTE FROM TIMESTAMP'2026-07-08 10:00:00 Europe/Berlin')
+    FROM RDB\$DATABASE");
+$row = fbird_fetch_row($q);
+echo "Berlin TZ hour: " . $row[0] . ", minute: " . $row[1] . "\n";
+fbird_free_result($q);
+
+echo "\n=== Test 3: AT TIME ZONE operator ===\n";
+$q = fbird_query($db, "SELECT
+    CAST(TIMESTAMP'2026-07-08 10:00:00' AT TIME ZONE 'UTC' AS VARCHAR(40))
+    FROM RDB\$DATABASE");
+$row = fbird_fetch_row($q);
+echo "Local timestamp AT TIME ZONE 'UTC': " . $row[0] . "\n";
+fbird_free_result($q);
+
+echo "\n=== Test 4: EXECUTE STATEMENT — basic form (via EXECUTE BLOCK) ===\n";
+/* EXECUTE STATEMENT is a PSQL construct — must be inside EXECUTE BLOCK */
+$q = fbird_query($db, "EXECUTE BLOCK RETURNS (result INTEGER) AS
+    BEGIN
+    EXECUTE STATEMENT 'SELECT 1 + 1 FROM RDB\$DATABASE' INTO result;
+    SUSPEND;
+    END");
+$row = fbird_fetch_row($q);
+echo "EXECUTE STATEMENT 'SELECT 1+1': " . $row[0] . "\n";
+fbird_free_result($q);
+
+echo "\n=== Test 5: EXECUTE STATEMENT — WITH AUTONOMOUS TRANSACTION ===\n";
+/* Autonomous transaction: the inner statement runs in a separate transaction. */
+@fbird_query($db, "RECREATE TABLE ES_TEST (val VARCHAR(50))");
+fbird_commit($db);
+$ok = fbird_query($db, "EXECUTE BLOCK AS
+    BEGIN
+    EXECUTE STATEMENT 'INSERT INTO ES_TEST VALUES (''auto_test'')' WITH AUTONOMOUS TRANSACTION;
+    END");
+fbird_commit($db);
+echo "EXECUTE STATEMENT WITH AUTONOMOUS: " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+$q = @fbird_query($db, "SELECT COUNT(*) FROM ES_TEST WHERE val = 'auto_test'");
+$row = $q ? fbird_fetch_row($q) : [0];
+echo "Autonomous insert verified: " . ($row[0] > 0 ? 'yes' : 'no') . "\n";
+if ($q) fbird_free_result($q);
+@fbird_query($db, "DROP TABLE ES_TEST");
+fbird_commit($db);
+
+echo "\n=== Test 6: EXECUTE STATEMENT — ON EXTERNAL DATA SOURCE ===\n";
+/* ON EXTERNAL executes against a different database. Test with same DB. */
+global $test_base;
+$trans = fbird_trans($db);
+$stmt = @fbird_prepare($trans, "EXECUTE BLOCK RETURNS (result VARCHAR(50)) AS
+    BEGIN
+    EXECUTE STATEMENT 'SELECT CURRENT_USER FROM RDB\$DATABASE'
+        ON EXTERNAL '" . $test_base . "'
+        AS USER 'SYSDBA' PASSWORD 'masterkey'
+        INTO result;
+    SUSPEND;
+    END");
+if ($stmt) {
+    $rs = fbird_execute($stmt);
+    $row = fbird_fetch_row($rs);
+    echo "ON EXTERNAL result: " . $row[0] . "\n";
+    fbird_free_query($rs);
+} else {
+    echo "ON EXTERNAL: not supported or failed\n";
+}
+fbird_commit($trans);
+
+fbird_close($db);
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: SET TIME ZONE ===
+SET TIME ZONE 'UTC': ok
+LOCALTIMESTAMP after SET UTC: %s
+LOCALTIMESTAMP after SET Berlin: %s
+
+=== Test 2: EXTRACT(TIMEZONE_HOUR|MINUTE) on TZ literal ===
+Berlin TZ hour: %d, minute: %d
+
+=== Test 3: AT TIME ZONE operator ===
+Local timestamp AT TIME ZONE 'UTC': %s
+
+=== Test 4: EXECUTE STATEMENT — basic form (via EXECUTE BLOCK) ===
+EXECUTE STATEMENT 'SELECT 1+1': 2
+
+=== Test 5: EXECUTE STATEMENT — WITH AUTONOMOUS TRANSACTION ===
+EXECUTE STATEMENT WITH AUTONOMOUS: ok
+Autonomous insert verified: %s
+
+=== Test 6: EXECUTE STATEMENT — ON EXTERNAL DATA SOURCE ===
+%s
+
+Done.
+
+--CLEAN--
+<?php require_once __DIR__ . '/clean.inc'; ?>

--- a/tests/fbird_packages_001.phpt
+++ b/tests/fbird_packages_001.phpt
@@ -1,0 +1,145 @@
+--TEST--
+Firebird 4.0+ packages and SQL SECURITY clause (#423)
+--SKIPIF--
+<?php
+require_once 'skipif.inc';
+require_once __DIR__ . '/fb_version_probe.inc';
+if (!fb_server_supports('PACKAGES')) die('skip packages not supported (requires FB4+)');
+if (!fb_server_supports('SQL_SECURITY')) die('skip SQL SECURITY not supported (requires FB4+)');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/firebird.inc';
+
+$db = fbird_connect($test_base, $user, $password);
+if (!$db) die("Connection failed\n");
+
+/* Cleanup */
+@fbird_query($db, 'DROP PACKAGE FB_PKG_TEST');
+@fbird_query($db, 'DROP PROCEDURE FB_SS_DEF');
+@fbird_query($db, 'DROP PROCEDURE FB_SS_INV');
+fbird_commit($db);
+
+echo "=== Test 1: CREATE PACKAGE + PACKAGE BODY ===\n";
+$ok = fbird_query($db, "CREATE PACKAGE FB_PKG_TEST AS
+    BEGIN
+    PROCEDURE get_value RETURNS (result INTEGER);
+    END");
+fbird_commit($db);
+echo "CREATE PACKAGE: " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+$ok = fbird_query($db, "CREATE PACKAGE BODY FB_PKG_TEST AS
+    BEGIN
+    PROCEDURE get_value RETURNS (result INTEGER)
+    AS
+    BEGIN
+        result = 42;
+    END
+    END");
+fbird_commit($db);
+echo "CREATE PACKAGE BODY: " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+echo "\n=== Test 2: Call package procedure ===\n";
+$trans = fbird_trans($db);
+$stmt = fbird_prepare($trans, "EXECUTE PROCEDURE FB_PKG_TEST.GET_VALUE");
+$rs = fbird_execute($stmt);
+$row = fbird_fetch_row($rs);
+fbird_free_query($rs);
+fbird_commit($trans);
+echo "Package proc returns: " . $row[0] . "\n";
+
+echo "\n=== Test 3: RECREATE PACKAGE ===\n";
+$ok = fbird_query($db, "RECREATE PACKAGE FB_PKG_TEST AS
+    BEGIN
+    PROCEDURE get_value RETURNS (result INTEGER);
+    PROCEDURE get_double RETURNS (result INTEGER);
+    END");
+fbird_commit($db);
+echo "RECREATE PACKAGE: " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+$ok = fbird_query($db, "RECREATE PACKAGE BODY FB_PKG_TEST AS
+    BEGIN
+    PROCEDURE get_value RETURNS (result INTEGER)
+    AS BEGIN result = 99; END
+
+    PROCEDURE get_double RETURNS (result INTEGER)
+    AS BEGIN result = 198; END
+    END");
+fbird_commit($db);
+echo "RECREATE PACKAGE BODY: " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+$trans = fbird_trans($db);
+$stmt = fbird_prepare($trans, "EXECUTE PROCEDURE FB_PKG_TEST.GET_DOUBLE");
+$rs = fbird_execute($stmt);
+$row = fbird_fetch_row($rs);
+fbird_free_query($rs);
+fbird_commit($trans);
+echo "New proc returns: " . $row[0] . "\n";
+
+echo "\n=== Test 4: SQL SECURITY DEFINER vs INVOKER ===\n";
+fbird_query($db, "CREATE PROCEDURE FB_SS_DEF SQL SECURITY DEFINER AS BEGIN END");
+fbird_query($db, "CREATE PROCEDURE FB_SS_INV SQL SECURITY INVOKER AS BEGIN END");
+fbird_commit($db);
+echo "SQL SECURITY DEFINER: created\n";
+echo "SQL SECURITY INVOKER: created\n";
+
+$trans = fbird_trans($db);
+fbird_query($trans, "EXECUTE PROCEDURE FB_SS_DEF");
+fbird_query($trans, "EXECUTE PROCEDURE FB_SS_INV");
+fbird_commit($trans);
+echo "Both procedures execute: ok\n";
+
+echo "\n=== Test 5: ALTER DATABASE SET DEFAULT SQL SECURITY ===\n";
+$ok = fbird_query($db, "ALTER DATABASE SET DEFAULT SQL SECURITY DEFINER");
+fbird_commit($db);
+echo "SET DEFAULT DEFINER: " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+$ok = fbird_query($db, "ALTER DATABASE SET DEFAULT SQL SECURITY INVOKER");
+fbird_commit($db);
+echo "SET DEFAULT INVOKER: " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+/* Reset to default */
+fbird_query($db, "ALTER DATABASE SET DEFAULT SQL SECURITY DEFINER");
+fbird_commit($db);
+
+echo "\n=== Test 6: DROP PACKAGE ===\n";
+$ok = fbird_query($db, "DROP PACKAGE FB_PKG_TEST");
+fbird_commit($db);
+echo "DROP PACKAGE: " . ($ok ? 'ok' : 'failed: ' . fbird_errmsg()) . "\n";
+
+fbird_query($db, "DROP PROCEDURE FB_SS_DEF");
+fbird_query($db, "DROP PROCEDURE FB_SS_INV");
+fbird_commit($db);
+
+fbird_close($db);
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: CREATE PACKAGE + PACKAGE BODY ===
+CREATE PACKAGE: ok
+CREATE PACKAGE BODY: ok
+
+=== Test 2: Call package procedure ===
+Package proc returns: 42
+
+=== Test 3: RECREATE PACKAGE ===
+RECREATE PACKAGE: ok
+RECREATE PACKAGE BODY: ok
+New proc returns: 198
+
+=== Test 4: SQL SECURITY DEFINER vs INVOKER ===
+SQL SECURITY DEFINER: created
+SQL SECURITY INVOKER: created
+Both procedures execute: ok
+
+=== Test 5: ALTER DATABASE SET DEFAULT SQL SECURITY ===
+SET DEFAULT DEFINER: ok
+SET DEFAULT INVOKER: ok
+
+=== Test 6: DROP PACKAGE ===
+DROP PACKAGE: ok
+
+Done.
+
+--CLEAN--
+<?php require_once __DIR__ . '/clean.inc'; ?>

--- a/tests/fbird_profiler_001.phpt
+++ b/tests/fbird_profiler_001.phpt
@@ -1,0 +1,122 @@
+--TEST--
+Firebird 5.0+ profiler plugin via SQL (#428)
+--SKIPIF--
+<?php
+require_once 'skipif.inc';
+require_once __DIR__ . '/fb_version_probe.inc';
+if (!fb_server_supports('PROFILER')) die('skip profiler not supported (requires FB5+)');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/firebird.inc';
+
+$db = fbird_connect($test_base, $user, $password);
+if (!$db) die("Connection failed\n");
+
+echo "=== Test 1: Start profiler session ===\n";
+/* rdb$profiler.start_session() starts a profiling session.
+ * Args: (description, attachment_id, plugin_name, plugin_options, detailed_requests) */
+$q = @fbird_query($db, "SELECT rdb\$profiler.start_session('test_session', null, null, null, 'DETAILED_REQUESTS') FROM rdb\$database");
+if ($q) {
+    $row = fbird_fetch_row($q);
+    echo "start_session: ok (id=" . $row[0] . ")\n";
+    fbird_free_result($q);
+} else {
+    /* Try without DETAILED_REQUESTS */
+    $q = @fbird_query($db, "SELECT rdb\$profiler.start_session('test_session') FROM rdb\$database");
+    if ($q) {
+        $row = fbird_fetch_row($q);
+        echo "start_session: ok (id=" . $row[0] . ")\n";
+        fbird_free_result($q);
+    } else {
+        echo "start_session: failed (" . fbird_errmsg() . ")\n";
+        fbird_close($db);
+        die("Cannot proceed without profiler\n");
+    }
+}
+fbird_commit($db);
+
+echo "\n=== Test 2: Run a query while profiling ===\n";
+$q = fbird_query($db, "SELECT COUNT(*) FROM RDB\$RELATIONS");
+$row = fbird_fetch_row($q);
+echo "Query result: " . $row[0] . " relations\n";
+fbird_free_result($q);
+fbird_commit($db);
+
+echo "\n=== Test 3: Flush profiler data ===\n";
+/* Flush writes profiling data to the snapshot tables */
+$ok = @fbird_query($db, "EXECUTE PROCEDURE rdb\$profiler.flush");
+echo "flush: " . ($ok ? 'ok' : 'failed (' . fbird_errmsg() . ')') . "\n";
+fbird_commit($db);
+
+echo "\n=== Test 4: Finish profiler session ===\n";
+/* finish_session(true) flushes and finalizes the session */
+$ok = @fbird_query($db, "EXECUTE PROCEDURE rdb\$profiler.finish_session(true)");
+echo "finish_session: " . ($ok ? 'ok' : 'failed (' . fbird_errmsg() . ')') . "\n";
+fbird_commit($db);
+
+echo "\n=== Test 5: Query profiler session data ===\n";
+/* Set search path to access profiler schema objects */
+@fbird_query($db, "SET SEARCH PATH TO plg\$profiler, public, system");
+fbird_commit($db);
+
+/* Check if a session was recorded */
+$q = @fbird_query($db, "SELECT COUNT(*) FROM plg\$prof_sessions");
+if ($q) {
+    $row = fbird_fetch_row($q);
+    echo "prof_sessions count: " . $row[0] . "\n";
+    fbird_free_result($q);
+} else {
+    /* Try without search path */
+    $q = @fbird_query($db, "SELECT COUNT(*) FROM plg\$prof_sessions");
+    echo "prof_sessions: " . ($q ? fbird_fetch_row($q)[0] : '(table not accessible)') . "\n";
+    if ($q) fbird_free_result($q);
+}
+fbird_commit($db);
+
+echo "\n=== Test 6: Query profiler request stats ===\n";
+/* Check if request-level stats were collected */
+$q = @fbird_query($db, "SELECT COUNT(*) FROM plg\$prof_requests");
+if ($q) {
+    $row = fbird_fetch_row($q);
+    echo "prof_requests count: " . $row[0] . "\n";
+    fbird_free_result($q);
+} else {
+    echo "prof_requests: (table not accessible)\n";
+}
+fbird_commit($db);
+
+echo "\n=== Test 7: Discard session (cleanup) ===\n";
+$ok = @fbird_query($db, "EXECUTE PROCEDURE rdb\$profiler.discard_session");
+echo "discard_session: " . ($ok ? 'ok' : 'not needed') . "\n";
+fbird_commit($db);
+
+fbird_close($db);
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: Start profiler session ===
+start_session: ok%s
+
+=== Test 2: Run a query while profiling ===
+Query result: %d relations
+
+=== Test 3: Flush profiler data ===
+flush: %s
+
+=== Test 4: Finish profiler session ===
+finish_session: %s
+
+=== Test 5: Query profiler session data ===
+prof_sessions count: %s
+
+=== Test 6: Query profiler request stats ===
+prof_requests count: %s
+
+=== Test 7: Discard session (cleanup) ===
+discard_session: %s
+
+Done.
+
+--CLEAN--
+<?php require_once __DIR__ . '/clean.inc'; ?>


### PR DESCRIPTION
Phase 1 quick wins: 3 test-only issues, no C code changes.

| Issue | Test file | Tests | FB4 | FB3 |
|-------|-----------|-------|-----|-----|
| #423 | fbird_packages_001.phpt | CREATE/RECREATE/DROP PACKAGE, package proc call, SQL SECURITY DEFINER/INVOKER, ALTER DATABASE SET DEFAULT | PASS | SKIP |
| #424 | fbird_execute_statement_rich_001.phpt | SET TIME ZONE, EXTRACT(TIMEZONE_HOUR/MINUTE), AT TIME ZONE, EXECUTE STATEMENT basic+autonomous+ON EXTERNAL | PASS | SKIP |
| #428 | fbird_profiler_001.phpt | rdb$profiler.start_session, flush, finish_session, query plg$prof_sessions/requests | SKIP (FB5 only) | SKIP |

Closes #423, closes #424, closes #428.