### PR TITLE
docs(v13.0.0): update CHANGELOG and spec for phases 1-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,23 @@ downstream (amicron-platform FB3 support complete in v12.1.0).
 - `specs/spec-v13.0-fb4-plus-coverage.md` — milestone index spec (#327): FB4+/FB5+
   coverage tables, version gating strategy (capability-probe SKIPIF), downstream
   priority (doctrine-firebird-driver), current implementation state inventory.
+- `tests/fbird_packages_001.phpt` — FB4+ packages and SQL SECURITY (#423):
+  CREATE/RECREATE/DROP PACKAGE, package procedure calls, SQL SECURITY
+  DEFINER vs INVOKER, ALTER DATABASE SET DEFAULT SQL SECURITY.
+- `tests/fbird_execute_statement_rich_001.phpt` — FB4+ EXECUTE STATEMENT rich
+  form + SET/AT TIME ZONE (#424): SET TIME ZONE, EXTRACT(TIMEZONE_HOUR|MINUTE),
+  AT TIME ZONE operator, EXECUTE STATEMENT basic form, WITH AUTONOMOUS
+  TRANSACTION, ON EXTERNAL DATA SOURCE.
+- `tests/fbird_profiler_001.phpt` — FB5+ profiler plugin (#428):
+  rdb$profiler.start_session, flush, finish_session, query plg$prof_sessions
+  and plg$prof_requests.
+- `tests/fbird_read_consistency_001.phpt` — FB4+ READ CONSISTENCY (#425):
+  flag path, array-API path, statement-level snapshot verification, auto-restart
+  on UPDATE conflict, TBuilder isolationReadCommittedReadConsistency().
+- `tests/fbird_parallel_workers_001.phpt` — FB5+ parallel workers (#427):
+  MON$PARALLEL_WORKERS, index creation, query verification.
+- `tests/fbird_statement_timeout_001.phpt` — FB4+ statement timeout via SQL
+  (#422 approach A): SET STATEMENT TIMEOUT, timeout enforcement, reset.
 
 #### Changed
 
@@ -52,6 +69,11 @@ downstream (amicron-platform FB3 support complete in v12.1.0).
   unchanged. (#426)
 - `tests/pdo_fbird/conformance/pdo_definition_fetch_orientation.phpt`: Extended
   from 4/6 to 6/6 FETCH_ORI orientations (added PRIOR, REL). (#426)
+- `src/cpp/fb_dpb_builder.hpp`: Added `setParallelWorkers()` (FB5+). (#427)
+- `src/cpp/fb_connection.hpp`: Added `parallel_workers` to `ConnectionParams`,
+  wired in `Connection::create()`. (#427)
+- `firebird_utils.h/.cpp`: Added `fbc_connect_ex()` C wrapper with
+  parallel_workers parameter. (#427)
 
 #### Known issues
 

--- a/specs/spec-v13.0-fb4-plus-coverage.md
+++ b/specs/spec-v13.0-fb4-plus-coverage.md
@@ -20,7 +20,7 @@ priority: 2
 2026-07-08
 
 ## Status
-In progress — 7 of 13 issues done (#327, #417 partial, #418, #419, #420, #421, #426)
+In progress — 10 of 13 issues done (#327, #418, #419, #420, #421, #423, #424, #425, #426, #427, #428). Remaining: #417 (DECFLOAT native type), #422 (full API), #435 (MARS).
 
 ---
 
@@ -239,12 +239,12 @@ spec (`spec-v13.1-fb6-coverage.md` or similar) will cover:
 | #420 | feat: FB4 SET BIND rule coverage (all rules) | **Done** (P3) |
 | #426 | feat: FB5 scrollable cursors (6 orientations) | **Done** (P4) |
 | #421 | feat: FB4 batch DML API (IBatch) full coverage | **Done** (P5) |
-| #422 | feat: FB4 statement + session idle timeout | Open - P6 |
-| #425 | feat: FB4 READ CONSISTENCY transaction isolation | Open - P7 |
-| #423 | feat: FB4 packages + SQL SECURITY {DEFINER/INVOKER} | Open |
-| #424 | feat: FB4 EXECUTE STATEMENT rich form + SET TIME ZONE + AT TIME ZONE | Open |
-| #427 | feat: FB5 parallel workers | Open |
-| #428 | feat: FB5 profiler plugin | Open |
+| #422 | feat: FB4 statement + session idle timeout | SQL-only done — full API TODO (P6) |
+| #425 | feat: FB4 READ CONSISTENCY transaction isolation | **Done** (P7) |
+| #423 | feat: FB4 packages + SQL SECURITY {DEFINER/INVOKER} | **Done** |
+| #424 | feat: FB4 EXECUTE STATEMENT rich form + SET TIME ZONE + AT TIME ZONE | **Done** |
+| #427 | feat: FB5 parallel workers | **Done** |
+| #428 | feat: FB5 profiler plugin | **Done** |
 | #435 | feat: PDO multiple active result sets | Open |
 
 ### Deferred (7 issues - blocked on FB6 Docker image)


### PR DESCRIPTION
Updates CHANGELOG with 7 new test files + 3 C infrastructure changes. Spec: 10/13 done, 3 remaining (#417, #422 full API, #435 MARS).