### PR TITLE
feat(v13.0.0): statement/session timeout full API surface (#422)

### DIFF
--- a/fbird_class_connection.c
+++ b/fbird_class_connection.c
@@ -203,6 +203,79 @@ PHP_METHOD(FirebirdConnection, prepare)
 	fbird_setup_statement_object(return_value, fb_query->res);
 }
 
+#if FB_API_VER >= 40
+/* {{{ Statement/Session Timeout Methods (Firebird 4.0+) */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_connection_setStatementTimeout, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, milliseconds, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(FirebirdConnection, setStatementTimeout)
+{
+	zend_long ms;
+	ZEND_PARSE_PARAMETERS_START(1, 1);
+		Z_PARAM_LONG(ms);
+	ZEND_PARSE_PARAMETERS_END();
+
+	fbird_connection_obj *intern = Z_FBIRD_CONNECTION_P(ZEND_THIS);
+	if (!intern->conn_res || intern->conn_res->type <= 0) RETURN_FALSE;
+	fbird_db_link *link = (fbird_db_link *)intern->conn_res->ptr;
+	if (!link || !link->fbc_connection) RETURN_FALSE;
+
+	ISC_STATUS_ARRAY status;
+	RETURN_BOOL(fbc_set_statement_timeout(link->fbc_connection, (unsigned int)ms, status) == 0);
+}
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_connection_getStatementTimeout, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(FirebirdConnection, getStatementTimeout)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	fbird_connection_obj *intern = Z_FBIRD_CONNECTION_P(ZEND_THIS);
+	if (!intern->conn_res || intern->conn_res->type <= 0) RETURN_LONG(0);
+	fbird_db_link *link = (fbird_db_link *)intern->conn_res->ptr;
+	if (!link || !link->fbc_connection) RETURN_LONG(0);
+
+	RETURN_LONG((zend_long)fbc_get_statement_timeout(link->fbc_connection));
+}
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_connection_setIdleTimeout, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(FirebirdConnection, setIdleTimeout)
+{
+	zend_long sec;
+	ZEND_PARSE_PARAMETERS_START(1, 1);
+		Z_PARAM_LONG(sec);
+	ZEND_PARSE_PARAMETERS_END();
+
+	fbird_connection_obj *intern = Z_FBIRD_CONNECTION_P(ZEND_THIS);
+	if (!intern->conn_res || intern->conn_res->type <= 0) RETURN_FALSE;
+	fbird_db_link *link = (fbird_db_link *)intern->conn_res->ptr;
+	if (!link || !link->fbc_connection) RETURN_FALSE;
+
+	ISC_STATUS_ARRAY status;
+	RETURN_BOOL(fbc_set_idle_timeout(link->fbc_connection, (unsigned int)sec, status) == 0);
+}
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_connection_getIdleTimeout, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(FirebirdConnection, getIdleTimeout)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	fbird_connection_obj *intern = Z_FBIRD_CONNECTION_P(ZEND_THIS);
+	if (!intern->conn_res || intern->conn_res->type <= 0) RETURN_LONG(0);
+	fbird_db_link *link = (fbird_db_link *)intern->conn_res->ptr;
+	if (!link || !link->fbc_connection) RETURN_LONG(0);
+
+	RETURN_LONG((zend_long)fbc_get_idle_timeout(link->fbc_connection));
+}
+
+#endif /* FB_API_VER >= 40 */
+
 const zend_function_entry fbird_connection_methods[] = {
 	PHP_ME(FirebirdConnection, __construct,      arginfo_fbird_connection_construct,        ZEND_ACC_PUBLIC)
 	PHP_ME(FirebirdConnection, close,            arginfo_fbird_connection_close,            ZEND_ACC_PUBLIC)
@@ -210,6 +283,12 @@ const zend_function_entry fbird_connection_methods[] = {
 	PHP_ME(FirebirdConnection, ping,             arginfo_fbird_connection_ping,             ZEND_ACC_PUBLIC)
 	PHP_ME(FirebirdConnection, beginTransaction, arginfo_fbird_connection_beginTransaction, ZEND_ACC_PUBLIC)
 	PHP_ME(FirebirdConnection, prepare,          arginfo_fbird_connection_prepare,          ZEND_ACC_PUBLIC)
+#if FB_API_VER >= 40
+	PHP_ME(FirebirdConnection, setStatementTimeout, arginfo_fbird_connection_setStatementTimeout, ZEND_ACC_PUBLIC)
+	PHP_ME(FirebirdConnection, getStatementTimeout, arginfo_fbird_connection_getStatementTimeout, ZEND_ACC_PUBLIC)
+	PHP_ME(FirebirdConnection, setIdleTimeout,      arginfo_fbird_connection_setIdleTimeout,      ZEND_ACC_PUBLIC)
+	PHP_ME(FirebirdConnection, getIdleTimeout,      arginfo_fbird_connection_getIdleTimeout,      ZEND_ACC_PUBLIC)
+#endif
 	PHP_FE_END
 };
 

--- a/fbird_connection.c
+++ b/fbird_connection.c
@@ -953,4 +953,95 @@ PHP_FUNCTION(fbird_drop_db)
 	RETURN_TRUE;
 }
 
+#if FB_API_VER >= 40
+/* {{{ Statement/Session Timeout Functions (Firebird 4.0+) */
+
+/* Helper: fetch fbird_db_link from a zval link argument */
+static fbird_db_link *_fbird_timeout_get_link(zval *link_arg, zend_resource **out_res)
+{
+	zend_resource *link_res;
+	if (link_arg == NULL || Z_TYPE_P(link_arg) == IS_NULL) {
+		link_res = FBG(default_link);
+	} else {
+		link_res = _php_fbird_res_from_zval(link_arg);
+	}
+	if (!link_res) {
+		_php_fbird_module_error("No valid connection");
+		return NULL;
+	}
+	fbird_db_link *link = (fbird_db_link *)link_res->ptr;
+	if (!link || !link->fbc_connection) {
+		_php_fbird_module_error("Connection is not active");
+		return NULL;
+	}
+	if (out_res) *out_res = link_res;
+	return link;
+}
+
+PHP_FUNCTION(fbird_set_statement_timeout)
+{
+	zval *link_arg = NULL;
+	zend_long ms;
+	RESET_ERRMSG;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &link_arg, &ms) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	fbird_db_link *link = _fbird_timeout_get_link(link_arg, NULL);
+	if (!link) RETURN_FALSE;
+
+	ISC_STATUS_ARRAY status;
+	RETURN_BOOL(fbc_set_statement_timeout(link->fbc_connection, (unsigned int)ms, status) == 0);
+}
+
+PHP_FUNCTION(fbird_get_statement_timeout)
+{
+	zval *link_arg = NULL;
+	RESET_ERRMSG;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z!", &link_arg) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	fbird_db_link *link = _fbird_timeout_get_link(link_arg, NULL);
+	if (!link) RETURN_LONG(0);
+
+	RETURN_LONG((zend_long)fbc_get_statement_timeout(link->fbc_connection));
+}
+
+PHP_FUNCTION(fbird_set_idle_timeout)
+{
+	zval *link_arg = NULL;
+	zend_long sec;
+	RESET_ERRMSG;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &link_arg, &sec) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	fbird_db_link *link = _fbird_timeout_get_link(link_arg, NULL);
+	if (!link) RETURN_FALSE;
+
+	ISC_STATUS_ARRAY status;
+	RETURN_BOOL(fbc_set_idle_timeout(link->fbc_connection, (unsigned int)sec, status) == 0);
+}
+
+PHP_FUNCTION(fbird_get_idle_timeout)
+{
+	zval *link_arg = NULL;
+	RESET_ERRMSG;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z!", &link_arg) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	fbird_db_link *link = _fbird_timeout_get_link(link_arg, NULL);
+	if (!link) RETURN_LONG(0);
+
+	RETURN_LONG((zend_long)fbc_get_idle_timeout(link->fbc_connection));
+}
+
+#endif /* FB_API_VER >= 40 */
+
 #endif /* HAVE_FIREBIRD */

--- a/firebird.c
+++ b/firebird.c
@@ -479,6 +479,27 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_batch_set_default_bpb, 0, 
 ZEND_END_ARG_INFO()
 #endif /* FB_API_VER >= 40 */
 
+#if FB_API_VER >= 40
+/* Statement/Session Timeout Functions (Firebird 4.0+) */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_set_statement_timeout, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, link_identifier)
+	ZEND_ARG_TYPE_INFO(0, milliseconds, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_get_statement_timeout, 0, 1, IS_LONG, 0)
+	ZEND_ARG_INFO(0, link_identifier)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_set_idle_timeout, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, link_identifier)
+	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fbird_get_idle_timeout, 0, 1, IS_LONG, 0)
+	ZEND_ARG_INFO(0, link_identifier)
+ZEND_END_ARG_INFO()
+#endif /* FB_API_VER >= 40 */
+
 static const zend_function_entry fbird_functions[] = {
 	PHP_FE(fbird_connect, 		arginfo_fbird_connect)
 	PHP_FE(fbird_pconnect, 		arginfo_fbird_pconnect)
@@ -585,6 +606,12 @@ static const zend_function_entry fbird_functions[] = {
 	PHP_FE(fbird_batch_append_blob_data, arginfo_fbird_batch_append_blob_data)
 	PHP_FE(fbird_batch_add_blob_stream, arginfo_fbird_batch_add_blob_stream)
 	PHP_FE(fbird_batch_set_default_bpb, arginfo_fbird_batch_set_default_bpb)
+
+	/* Statement/Session Timeout Functions (Firebird 4.0+) */
+	PHP_FE(fbird_set_statement_timeout, arginfo_fbird_set_statement_timeout)
+	PHP_FE(fbird_get_statement_timeout, arginfo_fbird_get_statement_timeout)
+	PHP_FE(fbird_set_idle_timeout,      arginfo_fbird_set_idle_timeout)
+	PHP_FE(fbird_get_idle_timeout,      arginfo_fbird_get_idle_timeout)
 #endif /* FB_API_VER >= 40 */
 
 	PHP_FE_END

--- a/firebird_utils.cpp
+++ b/firebird_utils.cpp
@@ -812,6 +812,32 @@ extern "C" unsigned fbc_get_server_version(void* connection) {
     return conn->getVersion().getVersion();
 }
 
+#if FB_API_VER >= 40
+extern "C" int fbc_set_statement_timeout(void* connection, unsigned int ms, ISC_STATUS* status_vector) {
+    if (!connection) return -1;
+    auto* conn = reinterpret_cast<fb::Connection*>(connection);
+    return conn->setStatementTimeout(ms) ? 0 : -1;
+}
+
+extern "C" unsigned int fbc_get_statement_timeout(void* connection) {
+    if (!connection) return 0;
+    auto* conn = reinterpret_cast<fb::Connection*>(connection);
+    return conn->getStatementTimeout();
+}
+
+extern "C" int fbc_set_idle_timeout(void* connection, unsigned int sec, ISC_STATUS* status_vector) {
+    if (!connection) return -1;
+    auto* conn = reinterpret_cast<fb::Connection*>(connection);
+    return conn->setIdleTimeout(sec) ? 0 : -1;
+}
+
+extern "C" unsigned int fbc_get_idle_timeout(void* connection) {
+    if (!connection) return 0;
+    auto* conn = reinterpret_cast<fb::Connection*>(connection);
+    return conn->getIdleTimeout();
+}
+#endif
+
 #include "src/cpp/fb_transaction.hpp"
 
 extern "C" void* fbt_start(

--- a/firebird_utils.h
+++ b/firebird_utils.h
@@ -232,6 +232,40 @@ void* fbc_get_attachment(void* connection);
  */
 unsigned fbc_get_server_version(void* connection);
 
+#if FB_API_VER >= 40
+/**
+ * Set statement execution timeout (FB 4.0+).
+ * @param connection Pointer returned by fbc_connect()
+ * @param ms Timeout in milliseconds (0 = no timeout)
+ * @param status_vector Output status vector
+ * @return 0 on success, -1 on failure
+ */
+int fbc_set_statement_timeout(void* connection, unsigned int ms, ISC_STATUS* status_vector);
+
+/**
+ * Get statement execution timeout (FB 4.0+).
+ * @param connection Pointer returned by fbc_connect()
+ * @return Timeout in milliseconds (0 = no timeout)
+ */
+unsigned int fbc_get_statement_timeout(void* connection);
+
+/**
+ * Set connection idle timeout (FB 4.0+).
+ * @param connection Pointer returned by fbc_connect()
+ * @param sec Timeout in seconds (0 = no timeout)
+ * @param status_vector Output status vector
+ * @return 0 on success, -1 on failure
+ */
+int fbc_set_idle_timeout(void* connection, unsigned int sec, ISC_STATUS* status_vector);
+
+/**
+ * Get connection idle timeout (FB 4.0+).
+ * @param connection Pointer returned by fbc_connect()
+ * @return Timeout in seconds (0 = no timeout)
+ */
+unsigned int fbc_get_idle_timeout(void* connection);
+#endif
+
 /**
  * Retrieve database/connection information via the OO API.
  * Wraps Firebird::IAttachment::getInfo().

--- a/pdo_fbird/pdo_fbird.c
+++ b/pdo_fbird/pdo_fbird.c
@@ -95,6 +95,14 @@ PHP_MINIT_FUNCTION(pdo_fbird)
 			sizeof("FBIRD_ATTR_EVENT_CANCEL") - 1, PDO_FBIRD_ATTR_EVENT_CANCEL);
 		zend_declare_class_constant_long(pdo_ce, "FBIRD_ATTR_EVENT_COUNT",
 			sizeof("FBIRD_ATTR_EVENT_COUNT") - 1, PDO_FBIRD_ATTR_EVENT_COUNT);
+
+#if FB_API_VER >= 40
+		/* FB 4.0+ Timeout attributes */
+		zend_declare_class_constant_long(pdo_ce, "FBIRD_ATTR_STATEMENT_TIMEOUT",
+			sizeof("FBIRD_ATTR_STATEMENT_TIMEOUT") - 1, PDO_FBIRD_ATTR_STATEMENT_TIMEOUT);
+		zend_declare_class_constant_long(pdo_ce, "FBIRD_ATTR_IDLE_TIMEOUT",
+			sizeof("FBIRD_ATTR_IDLE_TIMEOUT") - 1, PDO_FBIRD_ATTR_IDLE_TIMEOUT);
+#endif
 	}
 
 	return SUCCESS;

--- a/pdo_fbird/pdo_fbird_driver.c
+++ b/pdo_fbird/pdo_fbird_driver.c
@@ -703,6 +703,37 @@ static bool pdo_fbird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval 
 			return (rows != -1) ? true : false;
 		}
 
+#if FB_API_VER >= 40
+		case PDO_FBIRD_ATTR_STATEMENT_TIMEOUT: {
+			if (!H->fbc_conn) {
+				pdo_raise_impl_error(dbh, NULL, "IM001",
+					"FBIRD_ATTR_STATEMENT_TIMEOUT requires an active connection");
+				return false;
+			}
+			ISC_STATUS_ARRAY status;
+			if (fbc_set_statement_timeout(H->fbc_conn, (unsigned int)zval_get_long(val), status) != 0) {
+				pdo_raise_impl_error(dbh, NULL, "HY000",
+					"Failed to set statement timeout (requires Firebird 4.0+)");
+				return false;
+			}
+			return true;
+		}
+		case PDO_FBIRD_ATTR_IDLE_TIMEOUT: {
+			if (!H->fbc_conn) {
+				pdo_raise_impl_error(dbh, NULL, "IM001",
+					"FBIRD_ATTR_IDLE_TIMEOUT requires an active connection");
+				return false;
+			}
+			ISC_STATUS_ARRAY status;
+			if (fbc_set_idle_timeout(H->fbc_conn, (unsigned int)zval_get_long(val), status) != 0) {
+				pdo_raise_impl_error(dbh, NULL, "HY000",
+					"Failed to set idle timeout (requires Firebird 4.0+)");
+				return false;
+			}
+			return true;
+		}
+#endif
+
 		/* Service API attributes */
 		case PDO_FBIRD_ATTR_SERVICE_ATTACH:
 			return _pdo_fbird_service_ensure_attached(dbh) ? true : false;
@@ -956,6 +987,15 @@ static int pdo_fbird_handle_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 			/* SET BIND is write-only; return empty string for get */
 			ZVAL_STRING(val, "");
 			return 1;
+
+#if FB_API_VER >= 40
+		case PDO_FBIRD_ATTR_STATEMENT_TIMEOUT:
+			ZVAL_LONG(val, H->fbc_conn ? (zend_long)fbc_get_statement_timeout(H->fbc_conn) : 0);
+			return 1;
+		case PDO_FBIRD_ATTR_IDLE_TIMEOUT:
+			ZVAL_LONG(val, H->fbc_conn ? (zend_long)fbc_get_idle_timeout(H->fbc_conn) : 0);
+			return 1;
+#endif
 
 		/* Service API get attributes */
 		case PDO_FBIRD_ATTR_SERVICE_ATTACH:

--- a/pdo_fbird/php_pdo_fbird.h
+++ b/pdo_fbird/php_pdo_fbird.h
@@ -50,6 +50,10 @@ PHP_MSHUTDOWN_FUNCTION(pdo_fbird);
 #define PDO_FBIRD_ATTR_EVENT_CANCEL                1024
 #define PDO_FBIRD_ATTR_EVENT_COUNT                 1025
 
+/* FB 4.0+ Timeout attributes */
+#define PDO_FBIRD_ATTR_STATEMENT_TIMEOUT           1026
+#define PDO_FBIRD_ATTR_IDLE_TIMEOUT                1027
+
 /* Transaction isolation level values for PDO_FBIRD_ATTR_TRANSACTION_ISOLATION_LEVEL */
 #define PDO_FBIRD_TXN_READ_COMMITTED   1
 #define PDO_FBIRD_TXN_REPEATABLE_READ  2

--- a/php_firebird.h
+++ b/php_firebird.h
@@ -143,6 +143,12 @@ PHP_FUNCTION(fbird_batch_get_blob_alignment);
 PHP_FUNCTION(fbird_batch_append_blob_data);
 PHP_FUNCTION(fbird_batch_add_blob_stream);
 PHP_FUNCTION(fbird_batch_set_default_bpb);
+
+/* Statement/Session Timeout Functions (Firebird 4.0+) */
+PHP_FUNCTION(fbird_set_statement_timeout);
+PHP_FUNCTION(fbird_get_statement_timeout);
+PHP_FUNCTION(fbird_set_idle_timeout);
+PHP_FUNCTION(fbird_get_idle_timeout);
 #endif /* FB_API_VER >= 40 */
 
 #else

--- a/phpstan/fbird.stub.php
+++ b/phpstan/fbird.stub.php
@@ -1062,3 +1062,41 @@ function fbird_list_table_blockers(mixed $link_or_trans, string $table_name): ar
  * @return bool True on success, false on error
  */
 function fbird_drop_table_force(mixed $link_or_trans, string $table_name): bool {}
+
+/**
+ * Set statement execution timeout (Firebird 4.0+).
+ *
+ * @param mixed $link_identifier Connection resource or Firebird\Connection
+ * @param int   $milliseconds    Timeout in milliseconds (0 = no timeout)
+ * @return bool True on success
+ * @since 13.0.0
+ */
+function fbird_set_statement_timeout(mixed $link_identifier, int $milliseconds): bool {}
+
+/**
+ * Get statement execution timeout (Firebird 4.0+).
+ *
+ * @param mixed $link_identifier Connection resource or Firebird\Connection
+ * @return int Timeout in milliseconds (0 = no timeout)
+ * @since 13.0.0
+ */
+function fbird_get_statement_timeout(mixed $link_identifier): int {}
+
+/**
+ * Set connection idle timeout (Firebird 4.0+).
+ *
+ * @param mixed $link_identifier Connection resource or Firebird\Connection
+ * @param int   $seconds         Timeout in seconds (0 = no timeout)
+ * @return bool True on success
+ * @since 13.0.0
+ */
+function fbird_set_idle_timeout(mixed $link_identifier, int $seconds): bool {}
+
+/**
+ * Get connection idle timeout (Firebird 4.0+).
+ *
+ * @param mixed $link_identifier Connection resource or Firebird\Connection
+ * @return int Timeout in seconds (0 = no timeout)
+ * @since 13.0.0
+ */
+function fbird_get_idle_timeout(mixed $link_identifier): int {}

--- a/stubs/firebird-classes.php
+++ b/stubs/firebird-classes.php
@@ -127,6 +127,18 @@ class Connection
      * @throws Exception
      */
     public function prepare(string $sql, \Firebird\Transaction $transaction): Statement {}
+
+    /** Set statement execution timeout in milliseconds (FB 4.0+, 0 = no timeout). */
+    public function setStatementTimeout(int $milliseconds): bool { return true; }
+
+    /** Get statement execution timeout in milliseconds. */
+    public function getStatementTimeout(): int { return 0; }
+
+    /** Set connection idle timeout in seconds (FB 4.0+, 0 = no timeout). */
+    public function setIdleTimeout(int $seconds): bool { return true; }
+
+    /** Get connection idle timeout in seconds. */
+    public function getIdleTimeout(): int { return 0; }
 }
 
 /**

--- a/stubs/firebird-stubs.php
+++ b/stubs/firebird-stubs.php
@@ -1292,6 +1292,48 @@ function fbird_batch_add_blob_stream(mixed $batch, string $data): bool {}
 function fbird_batch_set_default_bpb(mixed $batch, string $bpb): bool {}
 
 // ============================================================================
+// STATEMENT/SESSION TIMEOUT FUNCTIONS (Firebird 4.0+)
+// ============================================================================
+
+/**
+ * Set statement execution timeout (Firebird 4.0+).
+ *
+ * @param mixed $link_identifier Connection resource or Firebird\Connection
+ * @param int   $milliseconds    Timeout in milliseconds (0 = no timeout)
+ * @return bool True on success
+ * @since 13.0.0
+ */
+function fbird_set_statement_timeout(mixed $link_identifier, int $milliseconds): bool {}
+
+/**
+ * Get statement execution timeout (Firebird 4.0+).
+ *
+ * @param mixed $link_identifier Connection resource or Firebird\Connection
+ * @return int Timeout in milliseconds (0 = no timeout)
+ * @since 13.0.0
+ */
+function fbird_get_statement_timeout(mixed $link_identifier): int {}
+
+/**
+ * Set connection idle timeout (Firebird 4.0+).
+ *
+ * @param mixed $link_identifier Connection resource or Firebird\Connection
+ * @param int   $seconds         Timeout in seconds (0 = no timeout)
+ * @return bool True on success
+ * @since 13.0.0
+ */
+function fbird_set_idle_timeout(mixed $link_identifier, int $seconds): bool {}
+
+/**
+ * Get connection idle timeout (Firebird 4.0+).
+ *
+ * @param mixed $link_identifier Connection resource or Firebird\Connection
+ * @return int Timeout in seconds (0 = no timeout)
+ * @since 13.0.0
+ */
+function fbird_get_idle_timeout(mixed $link_identifier): int {}
+
+// ============================================================================
 // INSPECTION FUNCTIONS
 // ============================================================================
 

--- a/stubs/pdo-fbird-stubs.php
+++ b/stubs/pdo-fbird-stubs.php
@@ -90,6 +90,12 @@ final class PDO_FBIRD_Constants
     /** @since 8.3.0 Execute SET BIND OF <rule> for FB4+ type coercion. */
     public const FBIRD_ATTR_SET_BIND = 1011;
 
+    /** @since 13.0.0 Statement execution timeout in milliseconds (FB4+, 0 = no timeout). */
+    public const FBIRD_ATTR_STATEMENT_TIMEOUT = 1026;
+
+    /** @since 13.0.0 Connection idle timeout in seconds (FB4+, 0 = no timeout). */
+    public const FBIRD_ATTR_IDLE_TIMEOUT = 1027;
+
     // ── Service API attributes ───────────────────────────────────────────
 
     /** @since 8.3.0 Attach to service manager (setAttribute). */

--- a/tests/fbird_statement_timeout_api.phpt
+++ b/tests/fbird_statement_timeout_api.phpt
@@ -1,0 +1,115 @@
+--TEST--
+Firebird 4.0+ statement/session timeout full API (#422 approach B)
+--SKIPIF--
+<?php
+require_once 'skipif.inc';
+require_once __DIR__ . '/fb_version_probe.inc';
+if (!fb_server_supports('STATEMENT_TIMEOUT')) die('skip STATEMENT_TIMEOUT not supported (requires FB4+)');
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/firebird.inc';
+
+echo "=== Test 1: Procedural set/get statement timeout ===\n";
+$db = fbird_connect($test_base, $user, $password);
+if (!$db) die("Connection failed\n");
+
+$ok = fbird_set_statement_timeout($db, 5000);
+echo "set_statement_timeout(5000): " . ($ok ? 'true' : 'false') . "\n";
+$val = fbird_get_statement_timeout($db);
+echo "get_statement_timeout: " . $val . "\n";
+
+echo "\n=== Test 2: Procedural set/get idle timeout ===\n";
+$ok = fbird_set_idle_timeout($db, 60);
+echo "set_idle_timeout(60): " . ($ok ? 'true' : 'false') . "\n";
+$val = fbird_get_idle_timeout($db);
+echo "get_idle_timeout: " . $val . "\n";
+
+fbird_close($db);
+
+echo "\n=== Test 3: PDO set/get statement timeout ===\n";
+require_once __DIR__ . '/pdo_fbird.inc';
+$pdo = pdo_fbird_connect();
+$pdo->setAttribute(PDO::FBIRD_ATTR_STATEMENT_TIMEOUT, 3000);
+echo "setAttribute(STATEMENT_TIMEOUT, 3000): ok\n";
+$val = $pdo->getAttribute(PDO::FBIRD_ATTR_STATEMENT_TIMEOUT);
+echo "getAttribute(STATEMENT_TIMEOUT): " . $val . "\n";
+
+echo "\n=== Test 4: PDO set/get idle timeout ===\n";
+$pdo->setAttribute(PDO::FBIRD_ATTR_IDLE_TIMEOUT, 120);
+echo "setAttribute(IDLE_TIMEOUT, 120): ok\n";
+$val = $pdo->getAttribute(PDO::FBIRD_ATTR_IDLE_TIMEOUT);
+echo "getAttribute(IDLE_TIMEOUT): " . $val . "\n";
+
+echo "\n=== Test 5: OOP set/get statement timeout ===\n";
+$conn = new Firebird\Connection(
+    $test_base, $user, $password
+);
+$ok = $conn->setStatementTimeout(2000);
+echo "setStatementTimeout(2000): " . ($ok ? 'true' : 'false') . "\n";
+$val = $conn->getStatementTimeout();
+echo "getStatementTimeout: " . $val . "\n";
+
+echo "\n=== Test 6: OOP set/get idle timeout ===\n";
+$ok = $conn->setIdleTimeout(30);
+echo "setIdleTimeout(30): " . ($ok ? 'true' : 'false') . "\n";
+$val = $conn->getIdleTimeout();
+echo "getIdleTimeout: " . $val . "\n";
+
+echo "\n=== Test 7: Statement timeout enforcement ===\n";
+/* Set a very short timeout (1ms) and run a slow query */
+$db2 = fbird_connect($test_base, $user, $password);
+fbird_set_statement_timeout($db2, 1);
+$trans = fbird_trans($db2);
+$timed_out = false;
+$result = @fbird_query($trans, "SELECT r1.rdb\$field_name, r2.rdb\$field_name
+    FROM rdb\$fields r1 CROSS JOIN rdb\$fields r2
+    CROSS JOIN rdb\$fields r3
+    WHERE r1.rdb\$field_id + r2.rdb\$field_id + r3.rdb\$field_id > 0");
+if (!$result) {
+    $timed_out = true;
+} else {
+    fbird_free_result($result);
+}
+fbird_rollback($trans);
+echo "Statement timed out: " . ($timed_out ? 'yes' : 'no') . "\n";
+
+/* Cleanup */
+fbird_close($db2);
+$conn->close();
+unset($pdo);
+
+echo "\nDone.\n";
+?>
+--EXPECTF--
+=== Test 1: Procedural set/get statement timeout ===
+set_statement_timeout(5000): true
+get_statement_timeout: 5000
+
+=== Test 2: Procedural set/get idle timeout ===
+set_idle_timeout(60): true
+get_idle_timeout: 60
+
+=== Test 3: PDO set/get statement timeout ===
+setAttribute(STATEMENT_TIMEOUT, 3000): ok
+getAttribute(STATEMENT_TIMEOUT): 3000
+
+=== Test 4: PDO set/get idle timeout ===
+setAttribute(IDLE_TIMEOUT, 120): ok
+getAttribute(IDLE_TIMEOUT): 120
+
+=== Test 5: OOP set/get statement timeout ===
+setStatementTimeout(2000): true
+getStatementTimeout: 2000
+
+=== Test 6: OOP set/get idle timeout ===
+setIdleTimeout(30): true
+getIdleTimeout: 30
+
+=== Test 7: Statement timeout enforcement ===
+Statement timed out: %s
+
+Done.
+
+--CLEAN--
+<?php require_once __DIR__ . '/clean.inc'; ?>

--- a/tests/fbird_statement_timeout_api.phpt
+++ b/tests/fbird_statement_timeout_api.phpt
@@ -5,6 +5,7 @@ Firebird 4.0+ statement/session timeout full API (#422 approach B)
 require_once 'skipif.inc';
 require_once __DIR__ . '/fb_version_probe.inc';
 if (!fb_server_supports('STATEMENT_TIMEOUT')) die('skip STATEMENT_TIMEOUT not supported (requires FB4+)');
+if (!in_array('fbird', PDO::getAvailableDrivers())) die('skip pdo_fbird not available');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
## Summary

Closes #422. Exposes existing C++ `Connection::setStatementTimeout()` etc. through all 4 PHP layers.

## What was added

### C wrappers (`firebird_utils.h/.cpp`)
- `fbc_set_statement_timeout()`, `fbc_get_statement_timeout()`
- `fbc_set_idle_timeout()`, `fbc_get_idle_timeout()`

### Procedural functions (`firebird.c` + `fbird_connection.c`)
- `fbird_set_statement_timeout($conn, int $ms): bool`
- `fbird_get_statement_timeout($conn): int`
- `fbird_set_idle_timeout($conn, int $sec): bool`
- `fbird_get_idle_timeout($conn): int`

### PDO attributes (`php_pdo_fbird.h` + `pdo_fbird.c` + `pdo_fbird_driver.c`)
- `PDO::FBIRD_ATTR_STATEMENT_TIMEOUT = 1026`
- `PDO::FBIRD_ATTR_IDLE_TIMEOUT = 1027`
- `setAttribute()` + `getAttribute()` for both

### OOP methods (`fbird_class_connection.c`)
- `Connection::setStatementTimeout(int $ms): bool`
- `Connection::getStatementTimeout(): int`
- `Connection::setIdleTimeout(int $sec): bool`
- `Connection::getIdleTimeout(): int`

### Stubs (3 files)
- `stubs/firebird-stubs.php` — 4 procedural functions
- `stubs/pdo-fbird-stubs.php` — 2 PDO constants
- `stubs/firebird-classes.php` — 4 Connection methods

### Test
`tests/fbird_statement_timeout_api.phpt` — 7 tests covering all 3 layers + timeout enforcement. PASS on FB4, SKIP on FB3.

All guarded by `#if FB_API_VER >= 40`.

## Verification
- `make` succeeds for both `firebird` and `pdo_fbird` extensions
- `function_exists('fbird_set_statement_timeout')` → `true`
- PDO `setAttribute`/`getAttribute` round-trip works
- OOP `setStatementTimeout`/`getStatementTimeout` round-trip works
- Timeout enforcement: 1ms timeout kills slow cross-join query