### PR TITLE
docs(v13.0.0): update CHANGELOG and spec for #422 full API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ downstream (amicron-platform FB3 support complete in v12.1.0).
 - `tests/pdo_fbird/pdo_fbird_mars.phpt` — PDO Multiple Active Result Sets
   (#435): interleaved fetch, close-one-survive-other, re-execute, three
   statements round-robin, commit invalidation, DML-between-SELECTs.
+- `tests/fbird_statement_timeout_api.phpt` — FB4+ statement/session timeout
+  full API (#422 approach B): set/get round-trip for all 3 layers
+  (procedural, PDO, OOP) + timeout enforcement.
 
 #### Changed
 
@@ -85,6 +88,18 @@ downstream (amicron-platform FB3 support complete in v12.1.0).
   (#435)
 - `stubs/pdo-fbird-stubs.php`: Removed "Multiple active result sets" from
   "Not yet implemented" list — MARS was never broken, just untested. (#435)
+- `firebird_utils.h/.cpp`: Added `fbc_set/get_statement_timeout()`,
+  `fbc_set/get_idle_timeout()` C wrappers. (#422)
+- `firebird.c` + `fbird_connection.c`: Added `fbird_set/get_statement_timeout()`,
+  `fbird_set/get_idle_timeout()` procedural functions. (#422)
+- `pdo_fbird/php_pdo_fbird.h` + `pdo_fbird.c` + `pdo_fbird_driver.c`: Added
+  `FBIRD_ATTR_STATEMENT_TIMEOUT=1026`, `FBIRD_ATTR_IDLE_TIMEOUT=1027` PDO
+  attributes with set/get support. (#422)
+- `fbird_class_connection.c`: Added `setStatementTimeout()`,
+  `getStatementTimeout()`, `setIdleTimeout()`, `getIdleTimeout()` OOP methods. (#422)
+- `stubs/firebird-stubs.php`, `stubs/pdo-fbird-stubs.php`,
+  `stubs/firebird-classes.php`, `phpstan/fbird.stub.php`: Updated with
+  timeout API stubs. (#422)
 
 #### Known issues
 

--- a/specs/spec-v13.0-fb4-plus-coverage.md
+++ b/specs/spec-v13.0-fb4-plus-coverage.md
@@ -20,7 +20,7 @@ priority: 2
 2026-07-08
 
 ## Status
-In progress — 11 of 13 issues done (#327, #418, #419, #420, #421, #423, #424, #425, #426, #427, #428, #435). Remaining: #417 (DECFLOAT native type), #422 (full API).
+In progress — 12 of 13 issues done (#327, #418, #419, #420, #421, #422, #423, #424, #425, #426, #427, #428, #435). Remaining: #417 (DECFLOAT native type). Per-statement timeout tracked in #464.
 
 ---
 
@@ -239,7 +239,7 @@ spec (`spec-v13.1-fb6-coverage.md` or similar) will cover:
 | #420 | feat: FB4 SET BIND rule coverage (all rules) | **Done** (P3) |
 | #426 | feat: FB5 scrollable cursors (6 orientations) | **Done** (P4) |
 | #421 | feat: FB4 batch DML API (IBatch) full coverage | **Done** (P5) |
-| #422 | feat: FB4 statement + session idle timeout | SQL-only done — full API TODO (P6) |
+| #422 | feat: FB4 statement + session idle timeout | **Done** (P6) |
 | #425 | feat: FB4 READ CONSISTENCY transaction isolation | **Done** (P7) |
 | #423 | feat: FB4 packages + SQL SECURITY {DEFINER/INVOKER} | **Done** |
 | #424 | feat: FB4 EXECUTE STATEMENT rich form + SET TIME ZONE + AT TIME ZONE | **Done** |


### PR DESCRIPTION
Updates CHANGELOG with timeout API entries. Spec: 12/13 done, #422 marked Done, #464 (per-statement timeout) created as future work.