### PR TITLE
fix(transaction): #518 - replace isDirty() with statusHasError() for FB3 compat

### DIFF
--- a/src/cpp/fb_transaction.hpp
+++ b/src/cpp/fb_transaction.hpp
@@ -196,7 +196,7 @@ inline Transaction Transaction::start(
         tpb
     );
 
-    if (check_status.isDirty() || !raw_transaction) {
+    if (fb::statusHasError(raw_status) || !raw_transaction) {
         throw Exception(raw_status);
     }
 
@@ -270,7 +270,7 @@ inline void Transaction::commit() {
     Firebird::CheckStatusWrapper check_status(raw_status);
     transaction_->commit(&check_status);
 
-    if (check_status.isDirty()) {
+    if (fb::statusHasError(raw_status)) {
         last_status_ = StatusWrapper(master);
         last_status_.get()->setErrors(raw_status->getErrors());
         throw Exception(raw_status);
@@ -295,7 +295,7 @@ inline void Transaction::rollback() {
     Firebird::CheckStatusWrapper check_status(raw_status);
     transaction_->rollback(&check_status);
 
-    if (check_status.isDirty()) {
+    if (fb::statusHasError(raw_status)) {
         last_status_ = StatusWrapper(master);
         last_status_.get()->setErrors(raw_status->getErrors());
         throw Exception(raw_status);
@@ -317,7 +317,7 @@ inline void Transaction::commitRetaining() {
     Firebird::CheckStatusWrapper check_status(raw_status);
     transaction_->commitRetaining(&check_status);
 
-    if (check_status.isDirty()) {
+    if (fb::statusHasError(raw_status)) {
         last_status_ = StatusWrapper(master_);
         last_status_.get()->setErrors(raw_status->getErrors());
         throw Exception(raw_status);
@@ -338,7 +338,7 @@ inline void Transaction::rollbackRetaining() {
     Firebird::CheckStatusWrapper check_status(raw_status);
     transaction_->rollbackRetaining(&check_status);
 
-    if (check_status.isDirty()) {
+    if (fb::statusHasError(raw_status)) {
         last_status_ = StatusWrapper(master_);
         last_status_.get()->setErrors(raw_status->getErrors());
         throw Exception(raw_status);
@@ -358,7 +358,7 @@ inline bool Transaction::rollbackNoThrow() noexcept {
             Firebird::IStatus* raw_status = master->getStatus();
             Firebird::CheckStatusWrapper check_status(raw_status);
             transaction_->rollback(&check_status);
-            if (check_status.isDirty()) {
+            if (fb::statusHasError(raw_status)) {
                 transaction_.reset();
                 return false;
             }


### PR DESCRIPTION
## Summary

Fixes #518 — `isDirty()` misuse in `fb_transaction.hpp` causes transactions to silently fail on FB3.

## Problem

All 6 transaction methods in `fb_transaction.hpp` checked errors with `check_status.isDirty()`. The codebase's own comment at `fb_connection.hpp:340-342` documents:

> In FB3, isDirty() returns true even on success (it means "status was touched"). hasError() correctly checks for actual errors (STATE_ERRORS flag).

On FB3, every successful `commit()`, `rollback()`, `commitRetaining()`, `rollbackRetaining()`, `startTransaction()` threw a spurious "Unknown Firebird error" exception. `rollbackNoThrow()` caught it and called `reset()` (released the transaction), so transactions silently disappeared.

The amicron-platform production stack uses FB3, making this potentially catastrophic.

## Fix

Replaced all 6 `check_status.isDirty()` with `fb::statusHasError(raw_status)`:

| Line | Method |
|------|--------|
| 199 | `Transaction::start()` |
| 273 | `Transaction::commit()` |
| 298 | `Transaction::rollback()` |
| 320 | `Transaction::commitRetaining()` |
| 341 | `Transaction::rollbackRetaining()` |
| 361 | `Transaction::rollbackNoThrow()` |

## Verification

- `fb_connection.hpp:343` already uses `status.hasError()` (the correct pattern) — this PR makes `fb_transaction.hpp` consistent.
- `fb::statusHasError()` (fb_status.hpp:28) checks `STATE_ERRORS` flag, which is FB3/FB4/FB5 compatible.

## Found by

v13.0.0 source code audit (#518, 2026-07-19)
