### PR TITLE
fix(istatus): #515 - fix per-column-per-row IStatus leak in fbm_call0/fbm_call1

### DIFF
--- a/firebird_utils.cpp
+++ b/firebird_utils.cpp
@@ -2549,24 +2549,28 @@ extern "C" void fbb_free(void* blob_wrapper) {
 
 namespace {
 // Helper to eliminate boilerplate for fbm_* metadata accessors (no-index variants).
+// jane: fixed #515 - was leaking IStatus via CheckStatusWrapper(master->getStatus()),
+//       now uses fb::CheckStatusScope (RAII, disposes in destructor). These templates
+//       are called per-column-per-row during fetch, so the leak was ~80 bytes * columns * rows.
 template <typename R, R error_value, typename F>
 inline R fbm_call0(void* master_ptr, void* metadata_ptr, F&& fn) noexcept {
     if (!master_ptr || !metadata_ptr) return error_value;
     auto* master = static_cast<Firebird::IMaster*>(master_ptr);
     auto* metadata = static_cast<Firebird::IMessageMetadata*>(metadata_ptr);
-    Firebird::CheckStatusWrapper status(master->getStatus());
-    R result = fn(metadata, &status);
-    return (status.getState() & Firebird::IStatus::STATE_ERRORS) ? error_value : result;
+    fb::CheckStatusScope status(master);
+    R result = fn(metadata, status.get());
+    return status.hasError() ? error_value : result;
 }
 // Helper to eliminate boilerplate for fbm_* metadata accessors (with-index variants).
+// jane: fixed #515 - same IStatus leak as fbm_call0, now uses fb::CheckStatusScope.
 template <typename R, R error_value, typename F>
 inline R fbm_call1(void* master_ptr, void* metadata_ptr, unsigned index, F&& fn) noexcept {
     if (!master_ptr || !metadata_ptr) return error_value;
     auto* master = static_cast<Firebird::IMaster*>(master_ptr);
     auto* metadata = static_cast<Firebird::IMessageMetadata*>(metadata_ptr);
-    Firebird::CheckStatusWrapper status(master->getStatus());
-    R result = fn(metadata, &status, index);
-    return (status.getState() & Firebird::IStatus::STATE_ERRORS) ? error_value : result;
+    fb::CheckStatusScope status(master);
+    R result = fn(metadata, status.get(), index);
+    return status.hasError() ? error_value : result;
 }
 } // anonymous namespace
 


### PR DESCRIPTION
## Summary

Fixes #515 — The worst memory leak in the codebase: IStatus leaked per-column-per-row via `fbm_call0`/`fbm_call1` template helpers.

## Problem

The `fbm_call0` and `fbm_call1` templates in `firebird_utils.cpp:2553-2570` used:
```cpp
Firebird::CheckStatusWrapper status(master->getStatus());
```

`CheckStatusWrapper` does NOT call `dispose()` in its destructor (verified against `firebird/Interface.h:316-328`). The IStatus was leaked on every call.

These templates are called by every metadata accessor during result set iteration:
- `fbm_get_offset`, `fbm_get_null_offset`, `fbm_get_type`, `fbm_get_subtype`
- `fbm_get_length`, `fbm_get_scale`
- `fbm_get_message_length`, `fbm_get_count`

**Impact**: A query returning 20 columns x 1000 rows = 20,000 IStatus leaks = ~1.5 MB per query. Over a long-running PHP-FPM worker, this leaks hundreds of MB.

## Fix

Replace with `fb::CheckStatusScope` (RAII, calls `dispose()` in destructor):
```cpp
fb::CheckStatusScope status(master);
R result = fn(metadata, status.get());
return status.hasError() ? error_value : result;
```

## Scope of this PR

This PR fixes **only** the `fbm_call0`/`fbm_call1` templates (the worst leak, per-row). The remaining 22+ IStatus leak sites in `firebird_utils.cpp` (C4 audit finding) will be fixed in a follow-up PR to keep this change small and reviewable.

## Found by

v13.0.0 source code audit (#515, 2026-07-19)
