### PR TITLE
fix(packaging): #492 - simplify OO API autoloader (no auto_prepend_file)

### DIFF
--- a/packaging/firebird-autoload.php
+++ b/packaging/firebird-autoload.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * php-firebird OO API autoloader (optional helper).
+ *
+ * Registers a PSR-4 autoloader for the Firebird\ namespace.
+ *
+ * WHEN IS THIS NEEDED?
+ *
+ * The C extension (firebird.so) provides the internal classes:
+ *   - Firebird\Connection (internal, no PHP file needed)
+ *   - Firebird\Statement (internal, no PHP file needed)
+ *
+ * The user-defined classes in this directory provide:
+ *   - Firebird\Database, Firebird\TBuilder, Firebird\TransactionManager
+ *   - Firebird\Batch, Firebird\BatchError, Firebird\BatchResult
+ *   - Firebird\BlobId, Firebird\DbInfo
+ *   - Firebird\EventPollerInterface, Firebird\EventPoller
+ *   - Firebird\FiberEventPoller, Firebird\PcntlEventPoller, Firebird\ProcessEventPoller
+ *   - Firebird\functions (fbird_query_params, fbird_trans_begin, etc.)
+ *
+ * COMPOSER USERS: Autoloading is handled automatically by composer.json:
+ *   "autoload": { "psr-4": { "Firebird\\": "src/Firebird/" } }
+ *   Do NOT require this file - Composer's autoloader already handles it.
+ *
+ * NON-COMPOSER USERS (e.g., native package installs without Composer):
+ *   require_once '/usr/share/php/Firebird/autoload.php';
+ *
+ * WHY NOT auto_prepend_file?
+ *
+ * The auto_prepend_file INI directive does not work reliably in CLI mode
+ * (it's ignored by php -r, php -m, and some SAPI configurations). Instead,
+ * users who need the OOP API should either:
+ *   1. Use Composer (recommended), or
+ *   2. Add `require_once '/usr/share/php/Firebird/autoload.php';` to their
+ *      bootstrap file
+ *
+ * @internal This file is part of the php-firebird package.
+ */
+
+$firebirdClassDir = dirname(__FILE__);
+
+// Allow override via environment variable (for testing/PIE source builds)
+$envOverride = getenv('PHP_FIREBIRD_CLASS_DIR');
+if ($envOverride !== false && is_dir($envOverride)) {
+    $firebirdClassDir = $envOverride;
+}
+
+if (!is_dir($firebirdClassDir)) {
+    return;
+}
+
+spl_autoload_register(function (string $class) use ($firebirdClassDir): void {
+    // Only handle Firebird\ namespace
+    if (!str_starts_with($class, 'Firebird\\')) {
+        return;
+    }
+
+    // PSR-4: Firebird\Database -> Database.php
+    $relativeClass = substr($class, strlen('Firebird\\'));
+    $file = $firebirdClassDir . '/' . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (is_file($file)) {
+        require $file;
+    }
+});


### PR DESCRIPTION
## Summary

Resolves #492 — Simplify the Firebird OOP API class autoloader for native packages.

## Problem

The previous approach used `auto_prepend_file` in the INI to load the autoloader. This did not work in CLI mode (`php -r`, `php -m` ignore `auto_prepend_file`), causing `spl_autoload_functions()` to return 0.

## Solution

Keep `packaging/firebird-autoload.php` as an **optional** helper. Do NOT use `auto_prepend_file` in the INI file.

| User type | How OOP classes load |
|---|---|
| Composer users | Automatic via `composer.json` PSR-4 (`"Firebird\\": "src/Firebird/"`) |
| Non-Composer (native package) | `require_once '/usr/share/php/Firebird/autoload.php';` in their bootstrap |

## What the package installs

```
usr/share/php/Firebird/
  autoload.php           # Optional helper
  Connection.php         # (not needed - internal class, but stub for IDE)
  Database.php
  TBuilder.php
  TransactionManager.php
  ... (14 PHP files total)
```

The INI file (`/etc/php/8.4/mods-available/20-firebird.ini`) contains only:
```
extension=firebird.so
```
(No `auto_prepend_file`)

## Verification

Tested in clean Docker (`php:8.4-cli-bookworm` + v13.0.0 release bundle):

```
require "/pkg/usr/share/php/Firebird/autoload.php";
// spl_autoload_functions() returns 1
// All 15 Firebird\* classes load (2 internal + 13 user-defined)
// TBuilder instantiation works
```

## Key insight

No downstream consumer (amicron-platform, satis, doctrine-firebird-driver) uses `Firebird\*` OOP classes directly. They all use procedural `fbird_*` via Doctrine DBAL. The OOP API is primarily for standalone use and future migration.

Refs: #492
