### PR TITLE
fix(pdo): #519 - fix malformed SPB for service timeout (buffer overread)

### DIFF
--- a/pdo_fbird/pdo_fbird_driver.c
+++ b/pdo_fbird/pdo_fbird_driver.c
@@ -459,7 +459,11 @@ static int _pdo_fbird_service_ensure_attached(pdo_dbh_t *dbh)
 static char *_pdo_fbird_service_query_line(pdo_dbh_t *dbh, char info_action)
 {
 	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
-	static char spb[] = { isc_info_svc_timeout, 10, 0, 0, 0 };
+	/* jane: fixed #519 - SPB cluster format is item(1) + length(2 LE) + value(length bytes).
+	 * Was: { isc_info_svc_timeout, 10, 0, 0, 0 } — length=10 but only 3 bytes follow → buffer overread.
+	 * Now: { isc_info_svc_timeout, 4,0, 10,0,0,0 } — length=4, value=10 (LE int32) = 10 second timeout.
+	 */
+	static const unsigned char spb[] = { isc_info_svc_timeout, 4, 0, 10, 0, 0, 0 };
 	char res_buf[512];
 
 	if (!fbsvc_query(FBG(master_instance), H->fbsvc_service,
@@ -504,7 +508,8 @@ static char *_pdo_fbird_service_query_line(pdo_dbh_t *dbh, char info_action)
 static char *_pdo_fbird_service_query_lines(pdo_dbh_t *dbh)
 {
 	pdo_fbird_db_handle *H = (pdo_fbird_db_handle *)dbh->driver_data;
-	static char spb[] = { isc_info_svc_timeout, 10, 0, 0, 0 };
+	/* jane: fixed #519 - same SPB fix as _pdo_fbird_service_query_line above */
+	static const unsigned char spb[] = { isc_info_svc_timeout, 4, 0, 10, 0, 0, 0 };
 	char info_action = isc_info_svc_line;
 	char res_buf[4096];
 	smart_str output = {0};


### PR DESCRIPTION
## Summary

Fixes #519 — Malformed SPB causing buffer overread and service timeout always 0.

## Problem

The SPB cluster format is: `item (1 byte) + length (2 bytes LE) + value (length bytes)`.

Before:
```c
static char spb[] = { isc_info_svc_timeout, 10, 0, 0, 0 };
```
- `10, 0` is the length field → length = 10
- Only 3 bytes follow (`0, 0, 0`) → server reads 10 bytes → **buffer overread** (7 bytes past end)
- Timeout value = 0 (first 4 bytes are all zeros), not 10 as intended

After:
```c
static const unsigned char spb[] = { isc_info_svc_timeout, 4, 0, 10, 0, 0, 0 };
```
- `4, 0` → length = 4 (correct for int32)
- `10, 0, 0, 0` → value = 10 (LE int32 = 10 second timeout)
- `sizeof(spb)` = 7 (correct)

## Verification

Cross-referenced against `~/external/firebird/src/jrd/svc.cpp:1085-1111`:
```cpp
l = (USHORT) gds__vax_integer(items, 2);  // reads 2 bytes as length
items += 2;
if (items + l <= end_items) {
    switch (item) {
        case isc_info_svc_timeout:
            timeout = (USHORT) gds__vax_integer(items, l);  // reads l bytes as value
```

## Files changed

- `pdo_fbird/pdo_fbird_driver.c:462` — `_pdo_fbird_service_query_line()`
- `pdo_fbird/pdo_fbird_driver.c:507` — `_pdo_fbird_service_query_lines()`

Refs: #519
