### PR TITLE
fix(pdo): #517 - add missing fbb_free() after fbb_close() in BLOB fetch

### DIFF
--- a/pdo_fbird/pdo_fbird_stmt.c
+++ b/pdo_fbird/pdo_fbird_stmt.c
@@ -749,6 +749,7 @@ static int pdo_fbird_stmt_get_col(pdo_stmt_t *stmt, int colno,
 				if (rc == 0) continue; /* more data */
 			}
 			fbb_close(FBG(master_instance), blob, S->H->status);
+			fbb_free(blob); /* jane: fixed #517 - was missing, leaked BlobWrapper struct on every BLOB fetch */
 
 			if (type && *type == PDO_PARAM_LOB) {
 				/* Return as PHP stream for LOB binding */


### PR DESCRIPTION
## Summary

Fixes #517 — PDO BLOB fetch leaks BlobWrapper struct (missing `fbb_free()`).

## Problem

`pdo_fbird_stmt.c:751` calls `fbb_close()` but never `fbb_free()`:
```c
fbb_close(FBG(master_instance), blob, S->H->status);
// Missing: fbb_free(blob);
```

The main driver (`fbird_blobs.c:649, 661, 806, 905`) always calls `fbb_free(blob)` after `fbb_close(blob)`. The PDO driver was missing this.

**Impact**: Every BLOB column fetch leaks the `BlobWrapper` struct (~100-200 bytes). A query returning 5 BLOB columns × 1000 rows = 5000 leaks = ~1 MB.

## Fix

Added `fbb_free(blob);` after `fbb_close()`:
```c
fbb_close(FBG(master_instance), blob, S->H->status);
fbb_free(blob); /* jane: fixed #517 */
```

## Files changed

- `pdo_fbird/pdo_fbird_stmt.c:751` — added `fbb_free(blob)` call

Refs: #517
