### PR TITLE
fix(istatus): #512+#513+#514 - batch fix IStatus leaks in fb_blob/transaction/service

### DIFF
--- a/src/cpp/fb_blob.hpp
+++ b/src/cpp/fb_blob.hpp
@@ -306,10 +306,10 @@ public:
 
             if (statusHasError(status.get())) {
                 // Check for special conditions
-                unsigned state = status.getState();
+                unsigned state = status.get()->getState();
                 if (state & Firebird::IStatus::STATE_WARNINGS) {
                     // EOF or segment - these are not errors
-                    ISC_STATUS err = status.getErrors()[1];
+                    ISC_STATUS err = status.get()->getErrors()[1];
                     if (err == isc_segstr_eof) {
                         clearStatusVector(status_vector);
                         return 1; // EOF
@@ -428,7 +428,7 @@ public:
 
             if (statusHasError(status.get())) {
                 // Ignore "invalid blob handle" error during cancel
-                if (status.getErrors()[1] != isc_bad_segstr_handle) {
+                if (status.get()->getErrors()[1] != isc_bad_segstr_handle) {
                     copyStatusVector(status.get(), status_vector);
                     blob_ = nullptr;
                     owns_blob_ = false;

--- a/src/cpp/fb_blob.hpp
+++ b/src/cpp/fb_blob.hpp
@@ -60,8 +60,8 @@ public:
             // Silent close on destruction - errors ignored
             auto* master = getMaster();
             if (master) {
-                Firebird::CheckStatusWrapper status(master->getStatus());
-                blob_->close(&status);
+                fb::CheckStatusScope status(master);
+                blob_->close(status.get());
             }
             blob_ = nullptr;
         }
@@ -84,8 +84,8 @@ public:
             if (blob_ && owns_blob_) {
                 auto* master = getMaster();
                 if (master) {
-                    Firebird::CheckStatusWrapper status(master->getStatus());
-                    blob_->close(&status);
+                    fb::CheckStatusScope status(master);
+                    blob_->close(status.get());
                 }
             }
             blob_ = other.blob_;
@@ -126,19 +126,19 @@ public:
 
         // Close existing blob if any
         if (blob_ && owns_blob_) {
-            Firebird::CheckStatusWrapper close_status(master->getStatus());
-            blob_->close(&close_status);
+            fb::CheckStatusScope close_status(master);
+            blob_->close(close_status.get());
             blob_ = nullptr;
         }
 
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
-            blob_ = attachment->createBlob(&status, transaction, &blob_id_, bpb_length, bpb);
+            blob_ = attachment->createBlob(status.get(), transaction, &blob_id_, bpb_length, bpb);
 
             // Check both for NULL blob AND error status
-            if (!blob_ || statusHasError(&status)) {
-                copyStatusVector(&status, status_vector);
+            if (!blob_ || statusHasError(status.get())) {
+                copyStatusVector(status.get(), status_vector);
                 if (!blob_ && status_vector && status_vector[1] == 0) {
                     // createBlob returned NULL without setting error
                     status_vector[1] = isc_bad_segstr_handle;
@@ -192,20 +192,20 @@ public:
 
         // Close existing blob if any
         if (blob_ && owns_blob_) {
-            Firebird::CheckStatusWrapper close_status(master->getStatus());
-            blob_->close(&close_status);
+            fb::CheckStatusScope close_status(master);
+            blob_->close(close_status.get());
             blob_ = nullptr;
         }
 
         blob_id_ = *blob_id;
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
-            blob_ = attachment->openBlob(&status, transaction, &blob_id_, bpb_length, bpb);
+            blob_ = attachment->openBlob(status.get(), transaction, &blob_id_, bpb_length, bpb);
 
             // Check both for NULL blob AND error status
-            if (!blob_ || statusHasError(&status)) {
-                copyStatusVector(&status, status_vector);
+            if (!blob_ || statusHasError(status.get())) {
+                copyStatusVector(status.get(), status_vector);
                 if (!blob_ && status_vector && status_vector[1] == 0) {
                     // openBlob returned NULL without setting error
                     status_vector[1] = isc_bad_segstr_handle;
@@ -251,13 +251,13 @@ public:
             return false;
         }
 
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
-            blob_->putSegment(&status, length, buffer);
+            blob_->putSegment(status.get(), length, buffer);
 
-            if (statusHasError(&status)) {
-                copyStatusVector(&status, status_vector);
+            if (statusHasError(status.get())) {
+                copyStatusVector(status.get(), status_vector);
                 return false;
             }
 
@@ -299,12 +299,12 @@ public:
             return -1;
         }
 
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
-            int result = blob_->getSegment(&status, buffer_length, buffer, actual_length);
+            int result = blob_->getSegment(status.get(), buffer_length, buffer, actual_length);
 
-            if (statusHasError(&status)) {
+            if (statusHasError(status.get())) {
                 // Check for special conditions
                 unsigned state = status.getState();
                 if (state & Firebird::IStatus::STATE_WARNINGS) {
@@ -319,7 +319,7 @@ public:
                         return 2; // Segment (partial read)
                     }
                 }
-                copyStatusVector(&status, status_vector);
+                copyStatusVector(status.get(), status_vector);
                 return -1;
             }
 
@@ -369,13 +369,13 @@ public:
             return false;
         }
 
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
-            blob_->close(&status);
+            blob_->close(status.get());
 
-            if (statusHasError(&status)) {
-                copyStatusVector(&status, status_vector);
+            if (statusHasError(status.get())) {
+                copyStatusVector(status.get(), status_vector);
                 // Still mark as closed to avoid double-close
                 blob_ = nullptr;
                 owns_blob_ = false;
@@ -421,15 +421,15 @@ public:
             return false;
         }
 
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
-            blob_->cancel(&status);
+            blob_->cancel(status.get());
 
-            if (statusHasError(&status)) {
+            if (statusHasError(status.get())) {
                 // Ignore "invalid blob handle" error during cancel
                 if (status.getErrors()[1] != isc_bad_segstr_handle) {
-                    copyStatusVector(&status, status_vector);
+                    copyStatusVector(status.get(), status_vector);
                     blob_ = nullptr;
                     owns_blob_ = false;
                     return false;
@@ -480,13 +480,13 @@ public:
             return false;
         }
 
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
-            int new_position = blob_->seek(&status, mode, offset);
+            int new_position = blob_->seek(status.get(), mode, offset);
 
-            if (statusHasError(&status)) {
-                copyStatusVector(&status, status_vector);
+            if (statusHasError(status.get())) {
+                copyStatusVector(status.get(), status_vector);
                 return false;
             }
 
@@ -533,13 +533,13 @@ public:
             return false;
         }
 
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
-            blob_->getInfo(&status, items_length, items, buffer_length, buffer);
+            blob_->getInfo(status.get(), items_length, items, buffer_length, buffer);
 
-            if (statusHasError(&status)) {
-                copyStatusVector(&status, status_vector);
+            if (statusHasError(status.get())) {
+                copyStatusVector(status.get(), status_vector);
                 return false;
             }
 

--- a/src/cpp/fb_service.hpp
+++ b/src/cpp/fb_service.hpp
@@ -92,7 +92,7 @@ public:
         }
 
         m_master = master;
-        Firebird::CheckStatusWrapper status(master->getStatus());
+        fb::CheckStatusScope status(master);
 
         try {
             Firebird::IProvider* provider = master->getDispatcher();
@@ -102,14 +102,14 @@ public:
             }
 
             m_service = provider->attachServiceManager(
-                &status,
+                status.get(),
                 service_name,
                 spb_length,
                 spb
             );
 
             if (status.hasData()) {
-                copy_status_to_sv(status_vector, &status);
+                copy_status_to_sv(status_vector, status.get());
                 m_service = nullptr;
                 return false;
             }
@@ -138,11 +138,11 @@ public:
             return false;
         }
 
-        Firebird::CheckStatusWrapper status(m_master->getStatus());
+        fb::CheckStatusScope status(m_master);
         try {
-            m_service->detach(&status);
+            m_service->detach(status.get());
             if (status.hasData()) {
-                copy_status_to_sv(status_vector, &status);
+                copy_status_to_sv(status_vector, status.get());
                 return false;
             }
             m_service = nullptr;
@@ -169,11 +169,11 @@ public:
             return false;
         }
 
-        Firebird::CheckStatusWrapper status(m_master->getStatus());
+        fb::CheckStatusScope status(m_master);
         try {
-            m_service->start(&status, spb_length, spb);
+            m_service->start(status.get(), spb_length, spb);
             if (status.hasData()) {
-                copy_status_to_sv(status_vector, &status);
+                copy_status_to_sv(status_vector, status.get());
                 return false;
             }
             return true;
@@ -205,12 +205,12 @@ public:
             return false;
         }
 
-        Firebird::CheckStatusWrapper status(m_master->getStatus());
+        fb::CheckStatusScope status(m_master);
         try {
-            m_service->query(&status, send_length, send_items,
+            m_service->query(status.get(), send_length, send_items,
                             recv_length, recv_items, buffer_length, buffer);
             if (status.hasData()) {
-                copy_status_to_sv(status_vector, &status);
+                copy_status_to_sv(status_vector, status.get());
                 return false;
             }
             return true;

--- a/src/cpp/fb_service.hpp
+++ b/src/cpp/fb_service.hpp
@@ -108,7 +108,7 @@ public:
                 spb
             );
 
-            if (status.hasData()) {
+            if (status.get()->hasData()) {
                 copy_status_to_sv(status_vector, status.get());
                 m_service = nullptr;
                 return false;
@@ -141,7 +141,7 @@ public:
         fb::CheckStatusScope status(m_master);
         try {
             m_service->detach(status.get());
-            if (status.hasData()) {
+            if (status.get()->hasData()) {
                 copy_status_to_sv(status_vector, status.get());
                 return false;
             }
@@ -172,7 +172,7 @@ public:
         fb::CheckStatusScope status(m_master);
         try {
             m_service->start(status.get(), spb_length, spb);
-            if (status.hasData()) {
+            if (status.get()->hasData()) {
                 copy_status_to_sv(status_vector, status.get());
                 return false;
             }
@@ -209,7 +209,7 @@ public:
         try {
             m_service->query(status.get(), send_length, send_items,
                             recv_length, recv_items, buffer_length, buffer);
-            if (status.hasData()) {
+            if (status.get()->hasData()) {
                 copy_status_to_sv(status_vector, status.get());
                 return false;
             }

--- a/src/cpp/fb_transaction.hpp
+++ b/src/cpp/fb_transaction.hpp
@@ -185,19 +185,18 @@ inline Transaction Transaction::start(
         throw Exception("Attachment is null - cannot start transaction");
     }
 
-    // Create CheckStatusWrapper for start operation
-    Firebird::IStatus* raw_status = master->getStatus();
-    Firebird::CheckStatusWrapper check_status(raw_status);
+    // jane: fixed #513 - was leaking IStatus via CheckStatusWrapper, now uses CheckStatusScope (RAII)
+    fb::CheckStatusScope status(master);
 
     // Start transaction using OO API
     Firebird::ITransaction* raw_transaction = attachment->startTransaction(
-        &check_status,
+        status.get(),
         tpbLength,
         tpb
     );
 
-    if (fb::statusHasError(raw_status) || !raw_transaction) {
-        throw Exception(raw_status);
+    if (status.hasError() || !raw_transaction) {
+        throw Exception(status.status());
     }
 
     // Wrap in RAII pointer
@@ -266,14 +265,13 @@ inline void Transaction::commit() {
         return;
     }
 
-    Firebird::IStatus* raw_status = master->getStatus();
-    Firebird::CheckStatusWrapper check_status(raw_status);
-    transaction_->commit(&check_status);
+    fb::CheckStatusScope status(master);
+    transaction_->commit(status.get());
 
-    if (fb::statusHasError(raw_status)) {
+    if (status.hasError()) {
         last_status_ = StatusWrapper(master);
-        last_status_.get()->setErrors(raw_status->getErrors());
-        throw Exception(raw_status);
+        last_status_.get()->setErrors(status.status()->getErrors());
+        throw Exception(status.status());
     }
 
     transaction_.reset();
@@ -291,14 +289,13 @@ inline void Transaction::rollback() {
         return;
     }
 
-    Firebird::IStatus* raw_status = master->getStatus();
-    Firebird::CheckStatusWrapper check_status(raw_status);
-    transaction_->rollback(&check_status);
+    fb::CheckStatusScope status(master);
+    transaction_->rollback(status.get());
 
-    if (fb::statusHasError(raw_status)) {
+    if (status.hasError()) {
         last_status_ = StatusWrapper(master);
-        last_status_.get()->setErrors(raw_status->getErrors());
-        throw Exception(raw_status);
+        last_status_.get()->setErrors(status.status()->getErrors());
+        throw Exception(status.status());
     }
 
     transaction_.reset();
@@ -313,14 +310,13 @@ inline void Transaction::commitRetaining() {
         throw Exception("Master interface not available");
     }
 
-    Firebird::IStatus* raw_status = master_->getStatus();
-    Firebird::CheckStatusWrapper check_status(raw_status);
-    transaction_->commitRetaining(&check_status);
+    fb::CheckStatusScope status(master_);
+    transaction_->commitRetaining(status.get());
 
-    if (fb::statusHasError(raw_status)) {
+    if (status.hasError()) {
         last_status_ = StatusWrapper(master_);
-        last_status_.get()->setErrors(raw_status->getErrors());
-        throw Exception(raw_status);
+        last_status_.get()->setErrors(status.status()->getErrors());
+        throw Exception(status.status());
     }
     // Transaction remains active after retaining commit
 }
@@ -334,14 +330,13 @@ inline void Transaction::rollbackRetaining() {
         throw Exception("Master interface not available");
     }
 
-    Firebird::IStatus* raw_status = master_->getStatus();
-    Firebird::CheckStatusWrapper check_status(raw_status);
-    transaction_->rollbackRetaining(&check_status);
+    fb::CheckStatusScope status(master_);
+    transaction_->rollbackRetaining(status.get());
 
-    if (fb::statusHasError(raw_status)) {
+    if (status.hasError()) {
         last_status_ = StatusWrapper(master_);
-        last_status_.get()->setErrors(raw_status->getErrors());
-        throw Exception(raw_status);
+        last_status_.get()->setErrors(status.status()->getErrors());
+        throw Exception(status.status());
     }
     // Transaction remains active after retaining rollback
 }
@@ -355,10 +350,9 @@ inline bool Transaction::rollbackNoThrow() noexcept {
         /* Issue #295: Use getMaster() instead of cached master_ (mirrors 881d375). */
         Firebird::IMaster* master = getMaster();
         if (master) {
-            Firebird::IStatus* raw_status = master->getStatus();
-            Firebird::CheckStatusWrapper check_status(raw_status);
-            transaction_->rollback(&check_status);
-            if (fb::statusHasError(raw_status)) {
+            fb::CheckStatusScope status(master);
+            transaction_->rollback(status.get());
+            if (status.hasError()) {
                 transaction_.reset();
                 return false;
             }


### PR DESCRIPTION
## Summary

Fixes #512, #513, #514 — Systematic IStatus leak fix across 3 C++ wrapper files (22 sites total).

## Pattern fixed

**Before (leaks ~80 bytes per call):**
```cpp
Firebird::CheckStatusWrapper status(master->getStatus());
```
`CheckStatusWrapper` does NOT call `dispose()` in its destructor (verified against `firebird/Interface.h:316-328`).

**After (RAII, no leak):**
```cpp
fb::CheckStatusScope status(master);
```
`CheckStatusScope` calls `status_->dispose()` in its destructor (`fb_status.hpp:273-277`).

## Files changed

| File | Issue | Sites | Methods |
|---|---|---|---|
| `src/cpp/fb_blob.hpp` | #512 | 12 | create, open, close, cancel, seek, getInfo, putSegment, getSegment, destructor, operator= |
| `src/cpp/fb_transaction.hpp` | #513 | 6 | start, commit, rollback, commitRetaining, rollbackRetaining, rollbackNoThrow |
| `src/cpp/fb_service.hpp` | #514 | 4 | attach, detach, start, query |

## Additional changes in fb_transaction.hpp

- `raw_status->getErrors()` → `status.status()->getErrors()` (error propagation)
- `throw Exception(raw_status)` → `throw Exception(status.status())` (exception with IStatus)
- Removed intermediate `Firebird::CheckStatusWrapper check_status(raw_status)` lines

## Scope

Combined with PR #529 (merged, `fbm_call0`/`fbm_call1` per-row leak), this fixes the systemic IStatus leak pattern across **all wrapper code** except:
- #520: `fb_statement.hpp` (17 exception-path leaks) — follow-up PR
- #521: `firebird_utils.cpp` encoding helpers (6 exception-path leaks) — follow-up PR

Refs: #512, #513, #514
