### PR TITLE
feat(pie): #509+#510 - pdo_fbird/composer.json + split-stubs.yml extension for PDO

### DIFF
--- a/.github/workflows/split-stubs.yml
+++ b/.github/workflows/split-stubs.yml
@@ -1,7 +1,8 @@
-# Mono-repo subtree split workflow for php-firebird-stubs
-# Splits the stubs/ directory to the dedicated satwareAG/php-firebird-stubs repository
+# Mono-repo subtree split workflow
+# Splits stubs/ to satwareAG/php-firebird-stubs and
+# pdo_fbird/ to satwareAG/pdo-fbird (PIE packages for Packagist)
 
-name: Split Stubs Package
+name: Split Packages
 
 on:
   push:
@@ -9,6 +10,8 @@ on:
       - satware-main
     paths:
       - 'stubs/**'
+      - 'pdo_fbird/**'
+      - 'composer.json'
     tags:
       - 'v*'
   workflow_dispatch:
@@ -17,29 +20,24 @@ permissions:
   contents: read
 
 concurrency:
-  group: split-stubs-${{ github.ref }}
+  group: split-packages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  split:
-    name: Split stubs/ to dedicated repository
+  split-stubs:
+    name: Split stubs/ to satwareAG/php-firebird-stubs
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0  # Full history required for subtree split
+          fetch-depth: 0
 
       - name: Delete existing tag in stubs repo (if re-tagging)
         if: github.ref_type == 'tag'
         run: |
-          # If the tag already exists in the stubs repo (e.g. from a previous split),
-          # try to delete it so the split action can recreate it.
-          # Tag protection rules may block deletion — in that case, the split
-          # action will fail with "tag already exists", which is acceptable
-          # (the stubs repo already has the correct tag from the previous run).
           if gh api -X DELETE "repos/satwareAG/php-firebird-stubs/git/refs/tags/${{ github.ref_name }}" 2>/dev/null; then
             echo "Deleted existing tag ${{ github.ref_name }} in stubs repo"
           else
@@ -51,22 +49,47 @@ jobs:
       - name: Split stubs directory
         uses: danharrin/monorepo-split-github-action@19b2e0cbe3fe3de17309fd0fe95d4e05454f3ab3 # v2.4.0
         env:
-          # PAT environment variable required by the action
           PAT: ${{ secrets.STUBS_REPO_TOKEN }}
         with:
-          # Source directory containing the package
           package_directory: 'stubs'
-          
-          # Target repository in format: organization/repository
           repository_organization: 'satwareAG'
           repository_name: 'php-firebird-stubs'
-          
-          # Git commit identity
           user_email: 'github-actions[bot]@users.noreply.github.com'
           user_name: 'github-actions[bot]'
-          
-          # Branch to push to in the target repository
           branch: 'main'
-          
-          # Preserve tag in split repository (for Packagist versioning)
+          tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+
+  split-pdo-fbird:
+    name: Split pdo_fbird/ to satwareAG/pdo-fbird
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Delete existing tag in pdo-fbird repo (if re-tagging)
+        if: github.ref_type == 'tag'
+        run: |
+          if gh api -X DELETE "repos/satwareAG/pdo-fbird/git/refs/tags/${{ github.ref_name }}" 2>/dev/null; then
+            echo "Deleted existing tag ${{ github.ref_name }} in pdo-fbird repo"
+          else
+            echo "Tag ${{ github.ref_name }} could not be deleted (protected or not found) — split will use existing tag"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.PDO_FBIRD_REPO_TOKEN }}
+
+      - name: Split pdo_fbird directory
+        uses: danharrin/monorepo-split-github-action@19b2e0cbe3fe3de17309fd0fe95d4e05454f3ab3 # v2.4.0
+        env:
+          PAT: ${{ secrets.PDO_FBIRD_REPO_TOKEN }}
+        with:
+          package_directory: 'pdo_fbird'
+          repository_organization: 'satwareAG'
+          repository_name: 'pdo-fbird'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          user_name: 'github-actions[bot]'
+          branch: 'main'
           tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}

--- a/.github/workflows/split-stubs.yml
+++ b/.github/workflows/split-stubs.yml
@@ -11,7 +11,6 @@ on:
     paths:
       - 'stubs/**'
       - 'pdo_fbird/**'
-      - 'composer.json'
     tags:
       - 'v*'
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ Tag push v*
   +-- Release (macOS)   -> prepare -> build -> test-bundles -> upload (draft:true)
   +-- Release (Windows) -> get-matrix -> build -> upload (draft:true)
   |
-  +-- Split Stubs       -> split stubs/ to satwareAG/php-firebird-stubs
+  +-- Split Packages     -> split stubs/ to satwareAG/php-firebird-stubs
   |                      -> split pdo_fbird/ to satwareAG/pdo-fbird (PIE)
   |
   +-- Publish Release   -> waits for all 3 platform workflows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ Tag push v*
   +-- Release (Windows) -> get-matrix -> build -> upload (draft:true)
   |
   +-- Split Stubs       -> split stubs/ to satwareAG/php-firebird-stubs
+  |                      -> split pdo_fbird/ to satwareAG/pdo-fbird (PIE)
   |
   +-- Publish Release   -> waits for all 3 platform workflows
                            -> generates SLSA attestations

--- a/pdo_fbird/composer.json
+++ b/pdo_fbird/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": ">=8.2",
-        "ext-pdo": "*"
+        "ext-pdo": "*",
+        "ext-firebird": "*"
     },
     "config": {
         "sort-packages": true,
@@ -27,13 +28,8 @@
         "support-nts": true,
         "configure-options": [
             {
-                "name": "with-pdo-fbird",
-                "description": "Path to Firebird client installation (e.g. /opt/firebird). If not specified, the system default is used.",
-                "needs-value": true
-            },
-            {
                 "name": "with-firebird",
-                "description": "Path to Firebird client installation (alternative to with-pdo-fbird).",
+                "description": "Path to Firebird client installation (e.g. /opt/firebird). If not specified, the system default is used.",
                 "needs-value": true
             }
         ],

--- a/pdo_fbird/composer.json
+++ b/pdo_fbird/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "satwareag/pdo-fbird",
+    "description": "PDO driver for Firebird SQL (pdo_fbird) — separate from the main php-firebird extension",
+    "type": "php-ext",
+    "license": "PHP-3.01",
+    "authors": [
+        {
+            "name": "satware AG",
+            "email": "info@satware.com",
+            "homepage": "https://satware.com"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "ext-pdo": "*"
+    },
+    "config": {
+        "sort-packages": true,
+        "platform": {
+            "php": "8.2.0"
+        }
+    },
+    "php-ext": {
+        "extension-name": "pdo_fbird",
+        "priority": 15,
+        "support-zts": true,
+        "support-nts": true,
+        "configure-options": [
+            {
+                "name": "with-pdo-fbird",
+                "description": "Path to Firebird client installation (e.g. /opt/firebird). If not specified, the system default is used.",
+                "needs-value": true
+            },
+            {
+                "name": "with-firebird",
+                "description": "Path to Firebird client installation (alternative to with-pdo-fbird).",
+                "needs-value": true
+            }
+        ],
+        "download-url-method": ["pre-packaged-binary", "composer-default"]
+    }
+}


### PR DESCRIPTION
## Summary

Implements #509 (pdo_fbird/composer.json for PIE split package) and #510 (extend split workflow).

## #509: `pdo_fbird/composer.json`

New file: `pdo_fbird/composer.json` — PIE-compatible package descriptor for the PDO driver:

```json
{
    "name": "satwareag/pdo-fbird",
    "type": "php-ext",
    "require": { "php": ">=8.2", "ext-pdo": "*" },
    "php-ext": {
        "extension-name": "pdo_fbird",
        "priority": 15,
        "support-zts": true,
        "support-nts": true,
        "configure-options": [
            { "name": "with-pdo-fbird", "needs-value": true },
            { "name": "with-firebird", "needs-value": true }
        ],
        "download-url-method": ["pre-packaged-binary", "composer-default"]
    }
}
```

`composer validate --no-check-publish` passes.

## #510: Extended split-stubs.yml

- **Renamed** workflow: "Split Stubs Package" → "Split Packages"
- **Added** second job: `split-pdo-fbird` — splits `pdo_fbird/` to `satwareAG/pdo-fbird` repo
- **Updated** path triggers: `pdo_fbird/**`, `composer.json`
- **Updated** concurrency group: `split-packages-*`
- Uses `PDO_FBIRD_REPO_TOKEN` secret (needs to be configured in repo settings)

## Infrastructure created

- `satwareAG/pdo-fbird` GitHub repo created (private): https://github.com/satwareAG/pdo-fbird
- `AGENTS.md` updated: Release Pipeline Architecture mentions PDO split

## What needs to happen next

1. **Configure secret**: Add `PDO_FBIRD_REPO_TOKEN` to repo settings (GitHub Settings → Secrets and variables → Actions). This is a PAT that can push to `satwareAG/pdo-fbird`.
2. **Push a tag** (e.g., `v13.1.0-rc.1`): The split workflow will run, pushing `pdo_fbird/` contents to `satwareAG/pdo-fbird` repo.
3. **Submit to Packagist** (#485): After the split repo has a tag, submit both `satwareAG/php-firebird` and `satwareAG/pdo-fbird` to https://packagist.org/packages/submit

## Dependencies

- Depends on #484 (php-ext section in root composer.json) — **merged**

Refs: #509, #510, #484, #485
