### PR TITLE
fix: #522+#525 - ctor_args in fetch_object + zval refcount in blob_export

### DIFF
--- a/fbird_blobs.c
+++ b/fbird_blobs.c
@@ -1227,12 +1227,16 @@ PHP_FUNCTION(fbird_blob_export)
 	}
 
 	/* Call fbird_blob_open to get blob handle */
+	/* jane: fixed #525 - use ZVAL_COPY instead of shallow copy to properly
+	 * increment refcounts. call_user_function may modify args. */
 	zval fn_name, open_args[2], blob_ret;
 	ZVAL_STRING(&fn_name, "fbird_blob_open");
-	open_args[0] = *link_arg;
-	open_args[1] = *blob_id_arg;
+	ZVAL_COPY(&open_args[0], link_arg);
+	ZVAL_COPY(&open_args[1], blob_id_arg);
 	call_user_function(EG(function_table), NULL, &fn_name, &blob_ret, 2, open_args);
 	zval_ptr_dtor(&fn_name);
+	zval_ptr_dtor(&open_args[0]);
+	zval_ptr_dtor(&open_args[1]);
 
 	if (Z_TYPE(blob_ret) == IS_FALSE) {
 		zval_ptr_dtor(&blob_ret);
@@ -1242,7 +1246,8 @@ PHP_FUNCTION(fbird_blob_export)
 
 	/* Read blob in chunks and write to file */
 	zval get_args[2], get_ret;
-	get_args[0] = blob_ret;
+	/* jane: fixed #525 - ZVAL_COPY instead of shallow copy */
+	ZVAL_COPY(&get_args[0], &blob_ret);
 	ZVAL_LONG(&get_args[1], 8192);
 	ZVAL_STRING(&fn_name, "fbird_blob_get");
 
@@ -1257,8 +1262,7 @@ PHP_FUNCTION(fbird_blob_export)
 		zval_ptr_dtor(&get_ret);
 	}
 	zval_ptr_dtor(&fn_name);
-
-	/* Close blob */
+	zval_ptr_dtor(&get_args[0]); /* jane: #525 - free ZVAL_COPY'd arg */
 	ZVAL_STRING(&fn_name, "fbird_blob_close");
 	zval close_ret;
 	call_user_function(EG(function_table), NULL, &fn_name, &close_ret, 1, &blob_ret);

--- a/fbird_result.c
+++ b/fbird_result.c
@@ -1049,9 +1049,30 @@ PHP_FUNCTION(fbird_fetch_object)
 			zend_class_entry *ce = zend_lookup_class(class_name);
 			if (ce) {
 				/* Create object and copy array properties into it */
-				zval obj;
-				object_init_ex(&obj, ce);
-				zval *val;
+			zval obj;
+			object_init_ex(&obj, ce);
+			/* jane: fixed #522 - call constructor with ctor_args if provided */
+			if (ctor_args && Z_TYPE_P(ctor_args) == IS_ARRAY) {
+				uint32_t num_args = zend_hash_num_elements(Z_ARRVAL_P(ctor_args));
+				if (num_args > 0) {
+					zend_function *constructor = Z_OBJCE(obj)->constructor;
+					if (constructor) {
+						zval *args = safe_emalloc(num_args, sizeof(zval), 0);
+						zval *src;
+						uint32_t i = 0;
+						ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(ctor_args), src) {
+							ZVAL_COPY(&args[i], src);
+							i++;
+						} ZEND_HASH_FOREACH_END();
+						zend_call_known_instance_method(constructor, Z_OBJ(obj), NULL, num_args, args);
+						for (i = 0; i < num_args; i++) {
+							zval_ptr_dtor(&args[i]);
+						}
+						efree(args);
+					}
+				}
+			}
+			zval *val;
 				zend_string *key;
 				ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(return_value), key, val) {
 					if (key) {


### PR DESCRIPTION
## Summary

Fixes #522 (ctor_args ignored) and #525 (zval shallow copy without refcount).

## #522: `fbird_fetch_object()` ignores `ctor_args`

`fbird_result.c:1053`: `object_init_ex()` only calls the default constructor. The `ctor_args` parameter was parsed but never passed to the constructor.

**Fix**: After `object_init_ex`, extract args from the `ctor_args` array and call the constructor via `zend_call_known_instance_method()`.

## #525: `fbird_blob_export()` shallow-copies zvals

`fbird_blobs.c:1244-1245`: `open_args[0] = *link_arg` copies the zval without incrementing refcount. If `call_user_function` modifies the arg (by-reference parameter), the caller's zval could be corrupted.

**Fix**: Use `ZVAL_COPY()` (increments refcount) + `zval_ptr_dtor()` after the call.

Same fix applied to:
- `open_args[1]` (blob_id_arg)
- `get_args[0]` (blob_ret)

## Local verification

9/9 tests pass on php84-dev + firebird40 (blob + fetch tests).

Refs: #522, #525
