### PR TITLE
fix(istatus): #526 - verify PDO array_id + fix IStatus leak in fb_array.hpp

### DIFF
--- a/src/cpp/fb_array.hpp
+++ b/src/cpp/fb_array.hpp
@@ -218,7 +218,7 @@ inline bool ArrayUtils::getSlice(
 
     try {
         // jane: fixed IStatus leak — was CheckStatusWrapper, now CheckStatusScope (RAII)
-
+        fb::CheckStatusScope check_status(master);
 
         // Call IAttachment::getSlice
         int result = attachment->getSlice(

--- a/src/cpp/fb_array.hpp
+++ b/src/cpp/fb_array.hpp
@@ -217,14 +217,12 @@ inline bool ArrayUtils::getSlice(
     }
 
     try {
-        // Use CheckStatusWrapper for Firebird template API
-        Firebird::IStatus* raw_status = master->getStatus();
-        Firebird::CheckStatusWrapper check_status(raw_status);
+        // jane: fixed IStatus leak — was CheckStatusWrapper, now CheckStatusScope (RAII)
 
 
         // Call IAttachment::getSlice
         int result = attachment->getSlice(
-            &check_status,
+            check_status.get(),
             transaction,
             array_id,
             static_cast<unsigned>(sdl_length),
@@ -236,17 +234,17 @@ inline bool ArrayUtils::getSlice(
         );
 
 
-        if (statusHasError(raw_status)) {
+        if (check_status.hasError()) {
             if (status_vector) {
-                copyStatus(raw_status, status_vector);
+                copyStatus(check_status.status(), status_vector);
             }
-            raw_status->dispose();
+            
             return false;
         }
 
         // Update buffer_length with actual bytes read
         *buffer_length = static_cast<ISC_LONG>(result);
-        raw_status->dispose();
+        
         return true;
 
     } catch (...) {
@@ -280,14 +278,12 @@ inline bool ArrayUtils::putSlice(
     }
 
     try {
-        // Use CheckStatusWrapper for Firebird template API
-        Firebird::IStatus* raw_status = master->getStatus();
-        Firebird::CheckStatusWrapper check_status(raw_status);
-
+        // jane: fixed IStatus leak — was CheckStatusWrapper(raw_status), now CheckStatusScope (RAII)
+        fb::CheckStatusScope check_status(master);
 
         // Call IAttachment::putSlice
         attachment->putSlice(
-            &check_status,
+            check_status.get(),
             transaction,
             array_id,
             static_cast<unsigned>(sdl_length),
@@ -298,16 +294,12 @@ inline bool ArrayUtils::putSlice(
             static_cast<unsigned char*>(const_cast<void*>(buffer))
         );
 
-
-        if (statusHasError(raw_status)) {
+        if (check_status.hasError()) {
             if (status_vector) {
-                copyStatus(raw_status, status_vector);
+                copyStatus(check_status.status(), status_vector);
             }
-            raw_status->dispose();
             return false;
         }
-
-        raw_status->dispose();
         return true;
 
     } catch (...) {


### PR DESCRIPTION
## Summary

Fixes #526 — PDO array binding `array_id` verification + bonus IStatus leak fix.

## Verification: #526

The audit flagged `array_id` as "potentially uninitialized". Verification:

1. `pdo_fbird_stmt.c:999`: `ISC_QUAD array_id = {0, 0}` — initialized
2. `fba_put_slice(..., &array_id, ...)` → `ArrayUtils::putSlice(..., array_id, ...)`
3. `attachment->putSlice(&check_status, transaction, array_id, ...)` — passes `ISC_QUAD*`
4. Firebird `IAttachment::putSlice()` writes the new array ID into the pointer
5. `memcpy(dest, &array_id, sizeof(ISC_QUAD))` — copies populated ID to destination

**Verdict**: No bug. The array ID IS correctly populated by Firebird.

## Bonus fix: IStatus leak in `fb_array.hpp`

While verifying, found the same leaking pattern in `getSlice()` and `putSlice()`:
- `Firebird::CheckStatusWrapper check_status(master->getStatus())` — leaks IStatus
- Replaced with `fb::CheckStatusScope check_status(master)` — RAII

## Local verification

20/20 tests pass on php84-dev + firebird40.

Refs: #526
