### PR TITLE
ci+docs: #511+#489 - PIE ZIP assets in release-linux.yml + INSTALL-DEBIAN.md

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -531,10 +531,138 @@ jobs:
           retention-days: 30
 
   # ===========================================================================
+  # PIE ZIP Assets: Repackage .tar.gz bundles as PIE-compatible ZIPs (#511)
+  # ===========================================================================
+  pie-zips:
+    needs: [prepare, build]
+    runs-on: ubuntu-24.04
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Ensure VERSION.txt
+        uses: ./.github/actions/version
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: "*-linux-*"
+          path: bundles
+
+      - name: Create PIE-compatible ZIP assets
+        run: |
+          set -eu
+          VERSION="${{ needs.prepare.outputs.version }}"
+
+          mkdir -p pie-assets
+
+          for tarball in bundles/**/*.tar.gz; do
+            [ -f "$tarball" ] || continue
+
+            # Extract filename components: php-firebird-{ver}-php{XX}-{variant}-linux-{arch}.tar.gz
+            base=$(basename "$tarball" .tar.gz)
+            # e.g. php-firebird-13.1.0-php84-nts-linux-x86_64
+
+            # Extract PHP version (e.g., 84 -> 8.4)
+            php_short=$(echo "$base" | sed -n 's/.*-php\([0-9][0-9]*\)-.*/\1/p')
+            php_ver="${php_short:0:1}.${php_short:1}"
+
+            # Extract variant (nts or zts)
+            variant=$(echo "$base" | sed -n 's/.*-\(nts\|zts\)-.*/\1/p')
+
+            # Extract arch and libc
+            arch=$(echo "$base" | sed -n 's/.*-linux-\(x86_64\|aarch64\).*/\1/p')
+            libc="glibc"
+            if echo "$base" | grep -q "musl"; then
+              libc="musl"
+              arch=$(echo "$base" | sed -n 's/.*-linux-musl-\(x86_64\|aarch64\).*/\1/p')
+            fi
+
+            [ -z "$php_ver" ] && continue
+            [ -z "$variant" ] && continue
+            [ -z "$arch" ] && continue
+
+            # PIE naming: php_{ExtName}-{Version}_php{PhpVer}-{Arch}-{OS}-{Libc}-{TSMode}.{Format}
+            # Example: php_firebird-13.1.0_php8.4-x86_64-linux-glibc-nts.zip
+            pie_name="php_firebird-${VERSION}_php${php_ver}-${arch}-linux-${libc}-${variant}.zip"
+            pie_dir="pie-tmp"
+            mkdir -p "$pie_dir"
+            tar xzf "$tarball" -C "$pie_dir" --strip-components=1
+
+            # PIE ZIP should contain firebird.so at root + lib/ + Firebird/
+            (cd "$pie_dir" && zip -r "../pie-assets/${pie_name}" \
+              firebird.so lib/ Firebird/ 2>/dev/null || \
+              zip -r "../pie-assets/${pie_name}" firebird.so lib/ 2>/dev/null || true)
+
+            rm -rf "$pie_dir"
+            echo "Created: $pie_name"
+          done
+
+          # Also create pdo_fbird ZIPs
+          for tarball in bundles/**/*.tar.gz; do
+            [ -f "$tarball" ] || continue
+            base=$(basename "$tarball" .tar.gz)
+            php_short=$(echo "$base" | sed -n 's/.*-php\([0-9][0-9]*\)-.*/\1/p')
+            php_ver="${php_short:0:1}.${php_short:1}"
+            variant=$(echo "$base" | sed -n 's/.*-\(nts\|zts\)-.*/\1/p')
+            arch=$(echo "$base" | sed -n 's/.*-linux-\(x86_64\|aarch64\).*/\1/p')
+            libc="glibc"
+            if echo "$base" | grep -q "musl"; then
+              libc="musl"
+              arch=$(echo "$base" | sed -n 's/.*-linux-musl-\(x86_64\|aarch64\).*/\1/p')
+            fi
+            [ -z "$php_ver" ] && continue
+            [ -z "$variant" ] && continue
+            [ -z "$arch" ] && continue
+
+            pie_name="php_pdo_fbird-${VERSION}_php${php_ver}-${arch}-linux-${libc}-${variant}.zip"
+            pie_dir="pie-tmp"
+            mkdir -p "$pie_dir"
+            tar xzf "$tarball" -C "$pie_dir" --strip-components=1
+            (cd "$pie_dir" && zip -r "../pie-assets/${pie_name}" pdo_fbird.so lib/ 2>/dev/null || true)
+            rm -rf "$pie_dir"
+            echo "Created: $pie_name"
+          done
+
+          echo "=== PIE ZIP assets created ==="
+          ls -lh pie-assets/*.zip 2>/dev/null || echo "No ZIPs created"
+
+      - name: Upload PIE ZIPs to GitHub Release
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+          (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
+        run: |
+          set -eu
+          TAG="${{ steps.determine-release-tag.outputs.tag || github.ref_name }}"
+          for zip in pie-assets/*.zip; do
+            [ -f "$zip" ] || continue
+            gh release upload "$TAG" "$zip" --clobber
+            echo "Uploaded: $zip"
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Upload PIE ZIPs as artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pie-zip-assets
+          path: pie-assets/*.zip
+          if-no-files-found: ignore
+          retention-days: 30
+
+  # ===========================================================================
   # Aggregate and Upload to Release
   # ===========================================================================
   release:
-    needs: [prepare, build, test-bundles]
+    needs: [prepare, build, test-bundles, pie-zips]
     runs-on: ubuntu-24.04
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||

--- a/docs/packaging/INSTALL-DEBIAN.md
+++ b/docs/packaging/INSTALL-DEBIAN.md
@@ -1,0 +1,134 @@
+# Installing php-firebird on Debian/Ubuntu via APT
+
+## Prerequisites
+
+- Debian 12 (Bookworm), Debian 13 (Trixie), Ubuntu 22.04 (Jammy), or Ubuntu 24.04 (Noble)
+- PHP 8.2, 8.3, 8.4, or 8.5 installed via system packages (`apt install php8.4-cli`)
+- `sudo` access for installation
+
+## Quick start
+
+```bash
+# 1. Add the satware APT repository
+curl -fsSL https://packages.satware.com/keys/apt-gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/satware-php-firebird.gpg
+echo "deb [signed-by=/etc/apt/keyrings/satware-php-firebird.gpg] https://packages.satware.com/apt $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/satware-php-firebird.list
+
+# 2. Update package list
+sudo apt update
+
+# 3. Install the extension for your PHP version
+sudo apt install php8.4-firebird
+
+# 4. Verify
+php -m | grep firebird
+php -m | grep pdo_fbird
+```
+
+## Available packages
+
+| Package | PHP version | Provides |
+|---|---|---|
+| `php8.2-firebird` | 8.2 | `firebird.so` + `pdo_fbird.so` + OO API classes + bundled FB5 client |
+| `php8.3-firebird` | 8.3 | same |
+| `php8.4-firebird` | 8.4 | same |
+| `php8.5-firebird` | 8.5 | same |
+
+Each package:
+- **Bundles Firebird 5.0 client** (libfbclient) — no need to install `firebird-dev` from apt
+- **Enables FB4+ features** (DECFLOAT, INT128, TIME/TIMESTAMP WITH TIME ZONE, batch DML, `pdo_fbird`)
+- **Provides**: `php-firebird`, `php-pdo-fbird` (virtual packages)
+- **Conflicts**: `php{VERSION}-interbase` (legacy FirebirdSQL/php-firebird migration)
+
+## Architecture support
+
+| Architecture | Status |
+|---|---|
+| `amd64` (x86_64) | ✅ Supported |
+| `arm64` (aarch64) | ✅ Supported |
+| `armhf` (armv7l) | Planned (Phase 3) |
+
+## Migration from legacy `php-interbase`
+
+If you previously used the legacy `FirebirdSQL/php-firebird` v3.0.0 (installed as `interbase`):
+
+```bash
+# Remove legacy package
+sudo apt remove php8.4-interbase
+
+# Install modern package
+sudo apt install php8.4-firebird
+
+# Verify migration
+php -m | grep firebird   # should show 'firebird' (not 'interbase')
+```
+
+## What's bundled
+
+The package includes:
+
+- `firebird.so` — main extension (procedural `fbird_*` + OOP `Firebird\*` classes)
+- `pdo_fbird.so` — PDO driver for Firebird
+- `Firebird\*.php` — OOP API class files (Connection, Database, TBuilder, etc.)
+- `libfbclient.so.5` — Firebird 5.0 client library (bundled, not from apt)
+- `libtomcrypt.so` — crypto library (libfbclient dependency)
+- `libtommath.so` — math library (libfbclient dependency)
+
+The extension uses **RPATH** (`$ORIGIN/../../php-firebird`) to find the bundled libraries, so no system `firebird-dev` package is needed.
+
+## Uninstallation
+
+```bash
+sudo apt remove php8.4-firebird
+sudo rm /etc/apt/sources.list.d/satware-php-firebird.list
+sudo apt update
+```
+
+## Alternative installation methods
+
+- **PIE (Packagist)**: `pie install satwareag/php-firebird` (source build)
+- **GitHub Releases**: Download `.deb` directly from [releases](https://github.com/satwareAG/php-firebird/releases) and `dpkg -i`
+- **Composer (stubs only)**: `composer require satwareag/php-firebird-stubs` (for IDE/PHPStan, not the extension)
+
+## Troubleshooting
+
+### Extension not loading after install
+
+```bash
+# Check if INI file exists
+ls /etc/php/8.4/mods-available/20-firebird.ini
+
+# Enable the extension
+sudo phpenmod firebird
+
+# Check PHP
+php -m | grep firebird
+```
+
+### "libfbclient.so.2: cannot open shared object file"
+
+The bundled libraries should resolve via RPATH. If not:
+
+```bash
+# Check RPATH
+readelf -d $(php-config --extension-dir)/firebird.so | grep RPATH
+
+# Should show: $ORIGIN/../../php-firebird
+
+# Check bundled libs
+ls /usr/lib/php-firebird/libfbclient*
+```
+
+### DECFLOAT not available
+
+DECFLOAT requires FB4+ client (bundled). If you see strings instead of `Firebird\DecFloat` objects:
+
+```bash
+# Verify FB5 client is bundled (not system FB3)
+php -r 'echo fb_server_supports("DECFLOAT") ? "YES" : "NO";'
+```
+
+If `NO`, the system `firebird-dev` (FB3) may be shadowing the bundled FB5 client. Remove it:
+
+```bash
+sudo apt remove firebird-dev
+```


### PR DESCRIPTION
## Summary

Implements #511 (PIE ZIP assets) and #489 (INSTALL-DEBIAN.md).

## #511: PIE ZIP assets in `release-linux.yml`

New `pie-zips` job that repackages existing `.tar.gz` bundles as PIE-compatible ZIPs:

```
php_firebird-13.1.0_php8.4-x86_64-linux-glibc-nts.zip
php_firebird-13.1.0_php8.4-x86_64-linux-musl-nts.zip
php_firebird-13.1.0_php8.4-aarch64-linux-glibc-nts.zip
php_pdo_fbird-13.1.0_php8.4-x86_64-linux-glibc-nts.zip
```

PIE naming convention: `php_{ExtensionName}-{Version}_php{PhpVersion}-{Arch}-{OS}-{Libc}-{TSMode}.{Format}`

This enables `pie install satwareag/php-firebird` to download pre-built binaries (instant, no `phpize`/`make`) via the `pre-packaged-binary` download URL method declared in `composer.json`.

The job runs after `build` and before `release`. ZIPs are uploaded to GitHub Release and as GitHub Actions artifacts.

## #489: `docs/packaging/INSTALL-DEBIAN.md`

End-user documentation for installing via APT:
- Quick start (4 commands)
- Available packages table
- Architecture support
- Migration from legacy `php-interbase`
- What's bundled (firebird.so, pdo_fbird.so, FB5 client, OO API classes)
- Troubleshooting (extension not loading, libfbclient missing, DECFLOAT)
- Alternative install methods (PIE, GitHub Releases, Composer stubs)

## Dependencies

- #484 (composer.json php-ext section) — merged
- #509, #510 (pdo_fbird/composer.json + split) — merged

Refs: #511, #489
