### PR TITLE
fix(packaging/deb): #550 - .ini naming + phpenmod auto-enable

### DIFF
--- a/packaging/debian/build.sh
+++ b/packaging/debian/build.sh
@@ -300,6 +300,25 @@ export FB_ROOT
 export EXT_DIR
 export DEB_ARCH
 
+# Generate per-PHP-version maintainer scripts from templates.
+# Debian Policy: postinst/prerm/postrm must be named debian/php<ver>-<ext>.<script>
+# to be picked up by dpkg-buildpackage for the correct binary package.
+# The templates use @PHP_VERSION@ placeholder (e.g. "8.4") which is substituted here.
+log_info "Generating maintainer scripts for php${PHP_VERSION}-firebird..."
+PKG_NAME="php${PHP_VERSION}-firebird"
+for script in postinst prerm postrm; do
+    TEMPLATE="${DEB_DIR}/php-firebird.${script}.in"
+    OUTPUT="${DEB_DIR}/${PKG_NAME}.${script}"
+    if [ -f "$TEMPLATE" ]; then
+        sed "s/@PHP_VERSION@/${PHP_VERSION}/g" "$TEMPLATE" > "$OUTPUT"
+        chmod 755 "$OUTPUT"
+        log "  Generated ${OUTPUT}"
+    else
+        log_error "  Missing template: ${TEMPLATE}"
+        exit 1
+    fi
+done
+
 # Make rules executable
 chmod +x "${DEB_DIR}/rules"
 

--- a/packaging/debian/php-firebird.postinst.in
+++ b/packaging/debian/php-firebird.postinst.in
@@ -1,0 +1,18 @@
+#!/bin/sh
+# postinst for php@PHP_VERSION@-firebird
+# Enables the firebird + pdo_fbird extensions via phpenmod on install/upgrade.
+# See Debian PHP Policy: maintainer scripts call phpenmod/phpdismod.
+set -e
+
+case "$1" in
+    configure)
+        # Enable both extensions for this PHP version.
+        # phpenmod creates the load-order symlinks in
+        # /etc/php/<ver>/<sapi>/conf.d/20-firebird.ini -> ../mods-available/firebird.ini
+        phpenmod -v @PHP_VERSION@ firebird pdo_fbird
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/packaging/debian/php-firebird.postrm.in
+++ b/packaging/debian/php-firebird.postrm.in
@@ -1,0 +1,17 @@
+#!/bin/sh
+# postrm for php@PHP_VERSION@-firebird
+# Cleanup after purge. phpdismod already removed symlinks in prerm.
+# See Debian PHP Policy: maintainer scripts call phpenmod/phpdismod.
+set -e
+
+case "$1" in
+    purge)
+        # phpdismod already removed conf.d/ symlinks in prerm.
+        # Nothing more to clean up - mods-available/ .ini files are
+        # owned by the package and removed by dpkg automatically.
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/packaging/debian/php-firebird.prerm.in
+++ b/packaging/debian/php-firebird.prerm.in
@@ -1,0 +1,17 @@
+#!/bin/sh
+# prerm for php@PHP_VERSION@-firebird
+# Disables the firebird + pdo_fbird extensions before remove/upgrade.
+# See Debian PHP Policy: maintainer scripts call phpenmod/phpdismod.
+set -e
+
+case "$1" in
+    remove|deconfigure)
+        # Disable both extensions for this PHP version.
+        # phpdismod removes the conf.d/ symlinks but leaves mods-available/ intact.
+        phpdismod -v @PHP_VERSION@ firebird pdo_fbird
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -92,8 +92,8 @@ override_dh_auto_install:
 			patchelf --force-rpath --set-rpath '$$ORIGIN' "$$lib" 2>/dev/null || true; \
 		fi; \
 	done; \
-	echo "extension=firebird.so" > $${PKG_DIR}/etc/php/$(PHP_VERSION)/mods-available/20-firebird.ini; \
-	echo "extension=pdo_fbird.so" > $${PKG_DIR}/etc/php/$(PHP_VERSION)/mods-available/20-pdo_fbird.ini
+	echo "extension=firebird.so" > $${PKG_DIR}/etc/php/$(PHP_VERSION)/mods-available/firebird.ini; \
+	echo "extension=pdo_fbird.so" > $${PKG_DIR}/etc/php/$(PHP_VERSION)/mods-available/pdo_fbird.ini
 
 # =============================================================================
 # Skip auto-test (PHPT tests require a running Firebird server)


### PR DESCRIPTION
## Root cause

The `.deb` package wrote `.ini` files with a `20-` prefix into `etc/php/<ver>/mods-available/`, but Debian's `phpenmod` expects **bare names** (`firebird.ini`, not `20-firebird.ini`) in `mods-available/`.

The `20-` prefix belongs in `conf.d/` (load-order symlinks created by `phpenmod`), not in `mods-available/`.

Additionally, no maintainer scripts (`postinst`/`prerm`/`postrm`) existed, so the extension was never auto-enabled after `apt install`.

## Changes

| File | Change |
|---|---|
| `packaging/debian/rules:95-96` | Remove `20-` prefix from `.ini` filenames |
| `packaging/debian/php-firebird.postinst.in` (NEW) | `phpenmod -v @PHP_VERSION@ firebird pdo_fbird` |
| `packaging/debian/php-firebird.prerm.in` (NEW) | `phpdismod -v @PHP_VERSION@ firebird pdo_fbird` |
| `packaging/debian/php-firebird.postrm.in` (NEW) | No-op (prerm already removed symlinks) |
| `packaging/debian/build.sh` | Generate per-PHP-version maintainer scripts from templates via `sed @PHP_VERSION@` substitution |

## How it works

1. `rules` writes bare `firebird.ini` and `pdo_fbird.ini` to `mods-available/`
2. `postinst` runs `phpenmod -v 8.4 firebird pdo_fbird` which creates symlinks:
   - `/etc/php/8.4/cli/conf.d/20-firebird.ini` -> `../mods-available/firebird.ini`
   - `/etc/php/8.4/cli/conf.d/20-pdo_fbird.ini` -> `../mods-available/pdo_fbird.ini`
3. Extension loads automatically after `apt install` — no manual steps

## Verification

Tested in clean `debian:12` + sury PPA container:

```
=== Install .deb ===
Setting up php8.4-firebird (13.0.0-1) ...

=== After install: mods-available ===
firebird.ini    (bare name - correct)
pdo_fbird.ini   (bare name - correct)

=== After install: conf.d symlinks (auto-created by postinst) ===
20-firebird.ini -> /etc/php/8.4/mods-available/firebird.ini
20-pdo_fbird.ini -> /etc/php/8.4/mods-available/pdo_fbird.ini

=== php -m | grep firebird ===
firebird        (auto-enabled!)
pdo_fbird       (auto-enabled!)

=== phpdismod + phpenmod round-trip ===
phpdismod -v 8.4 firebird pdo_fbird  ->  conf.d empty, php -m shows nothing
phpenmod  -v 8.4 firebird pdo_fbird  ->  conf.d re-created, php -m shows firebird + pdo_fbird
```

## Acceptance criteria (#550)

- [x] `packaging/debian/rules` writes `firebird.ini` and `pdo_fbird.ini` (no `20-` prefix) to `mods-available/`
- [x] After `dpkg -i` on clean Debian 12 + sury PPA: `php -m | grep firebird` shows `firebird` without any manual `phpenmod`
- [x] After `dpkg -i`: `php -m | grep fbird` shows `pdo_fbird` without any manual step
- [x] `phpenmod firebird pdo_fbird` succeeds (no warning)
- [x] `phpdismod firebird pdo_fbird` disables the extension (symlinks removed from `conf.d/`)

Refs: #550
Found by: satis spec 007 Phase A validation (`docs/spec-007/phase-a-validation.md` in satis repo)