### PR TITLE
fix(istatus): #520+#521 - re-apply IStatus leak fixes + fix zend_symtable_str_find_ptr bug (#549)

### DIFF
--- a/fbird_metadata.c
+++ b/fbird_metadata.c
@@ -50,7 +50,7 @@ void _php_fbird_insert_alias(HashTable *ht, const char *alias)
 		alias_len = strlen(alias);
 	}
 
-	while (zend_symtable_str_find_ptr(ht, alias, alias_len) != NULL) {
+	while (zend_symtable_str_find(ht, alias, alias_len) != NULL) {
 		snprintf(buf, sizeof(buf), "%s_%02d", base, i++);
 		alias = buf;
 		alias_len = strlen(alias);

--- a/firebird_utils.cpp
+++ b/firebird_utils.cpp
@@ -1167,12 +1167,12 @@ extern "C" int fbu_encode_time_tz(void *master_ptr, ISC_TIME_TZ* time_tz,
     try {
         auto* master = static_cast<Firebird::IMaster*>(master_ptr);
         Firebird::IUtil* util = master->getUtilInterface();
-        Firebird::IStatus* fb_status = master->getStatus();
-        Firebird::CheckStatusWrapper status(fb_status);
+        fb::CheckStatusScope status(master);
+        /* RAII: CheckStatusScope handles IStatus lifecycle */
 
-        util->encodeTimeTz(&status, time_tz, hours, minutes, seconds, fractions, time_zone);
+        util->encodeTimeTz(status.get(), time_tz, hours, minutes, seconds, fractions, time_zone);
 
-        if (status.isDirty()) {
+        if (status.hasError()) {
             return -1;
         }
         return 0;
@@ -1188,14 +1188,14 @@ extern "C" int fbu_int128_to_string(void *master_ptr, const void *value, int sca
     if (!master_ptr || !value || !buffer || buffer_length == 0) return -1;
     try {
         auto* master = static_cast<Firebird::IMaster*>(master_ptr);
-        Firebird::IStatus* fb_status = master->getStatus();
-        Firebird::CheckStatusWrapper status(fb_status);
+        fb::CheckStatusScope status(master);
+        /* RAII: CheckStatusScope handles IStatus lifecycle */
         Firebird::IUtil* util = master->getUtilInterface();
-        Firebird::IInt128* i128 = util->getInt128(&status);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        i128->toString(&status, static_cast<const FB_I128*>(value), scale, buffer_length, buffer);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        fb_status->dispose();
+        Firebird::IInt128* i128 = util->getInt128(status.get());
+        if (status.hasError()) {  return -1; }
+        i128->toString(status.get(), static_cast<const FB_I128*>(value), scale, buffer_length, buffer);
+        if (status.hasError()) {  return -1; }
+        
         return 0;
     } catch (...) {
         return -1;
@@ -1209,14 +1209,14 @@ extern "C" int fbu_decfloat16_to_string(void *master_ptr, const void *value,
     if (!master_ptr || !value || !buffer || buffer_length == 0) return -1;
     try {
         auto* master = static_cast<Firebird::IMaster*>(master_ptr);
-        Firebird::IStatus* fb_status = master->getStatus();
-        Firebird::CheckStatusWrapper status(fb_status);
+        fb::CheckStatusScope status(master);
+        /* RAII: CheckStatusScope handles IStatus lifecycle */
         Firebird::IUtil* util = master->getUtilInterface();
-        Firebird::IDecFloat16* df16 = util->getDecFloat16(&status);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        df16->toString(&status, static_cast<const FB_DEC16*>(value), buffer_length, buffer);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        fb_status->dispose();
+        Firebird::IDecFloat16* df16 = util->getDecFloat16(status.get());
+        if (status.hasError()) {  return -1; }
+        df16->toString(status.get(), static_cast<const FB_DEC16*>(value), buffer_length, buffer);
+        if (status.hasError()) {  return -1; }
+        
         return 0;
     } catch (...) {
         return -1;
@@ -1230,14 +1230,14 @@ extern "C" int fbu_decfloat34_to_string(void *master_ptr, const void *value,
     if (!master_ptr || !value || !buffer || buffer_length == 0) return -1;
     try {
         auto* master = static_cast<Firebird::IMaster*>(master_ptr);
-        Firebird::IStatus* fb_status = master->getStatus();
-        Firebird::CheckStatusWrapper status(fb_status);
+        fb::CheckStatusScope status(master);
+        /* RAII: CheckStatusScope handles IStatus lifecycle */
         Firebird::IUtil* util = master->getUtilInterface();
-        Firebird::IDecFloat34* df34 = util->getDecFloat34(&status);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        df34->toString(&status, static_cast<const FB_DEC34*>(value), buffer_length, buffer);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        fb_status->dispose();
+        Firebird::IDecFloat34* df34 = util->getDecFloat34(status.get());
+        if (status.hasError()) {  return -1; }
+        df34->toString(status.get(), static_cast<const FB_DEC34*>(value), buffer_length, buffer);
+        if (status.hasError()) {  return -1; }
+        
         return 0;
     } catch (...) {
         return -1;
@@ -1250,14 +1250,14 @@ extern "C" int fbu_string_to_decfloat16(void *master_ptr, const char *str, void 
     if (!master_ptr || !str || !value) return -1;
     try {
         auto* master = static_cast<Firebird::IMaster*>(master_ptr);
-        Firebird::IStatus* fb_status = master->getStatus();
-        Firebird::CheckStatusWrapper status(fb_status);
+        fb::CheckStatusScope status(master);
+        /* RAII: CheckStatusScope handles IStatus lifecycle */
         Firebird::IUtil* util = master->getUtilInterface();
-        Firebird::IDecFloat16* df16 = util->getDecFloat16(&status);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        df16->fromString(&status, str, static_cast<FB_DEC16*>(value));
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        fb_status->dispose();
+        Firebird::IDecFloat16* df16 = util->getDecFloat16(status.get());
+        if (status.hasError()) {  return -1; }
+        df16->fromString(status.get(), str, static_cast<FB_DEC16*>(value));
+        if (status.hasError()) {  return -1; }
+        
         return 0;
     } catch (...) {
         return -1;
@@ -1270,14 +1270,14 @@ extern "C" int fbu_string_to_decfloat34(void *master_ptr, const char *str, void 
     if (!master_ptr || !str || !value) return -1;
     try {
         auto* master = static_cast<Firebird::IMaster*>(master_ptr);
-        Firebird::IStatus* fb_status = master->getStatus();
-        Firebird::CheckStatusWrapper status(fb_status);
+        fb::CheckStatusScope status(master);
+        /* RAII: CheckStatusScope handles IStatus lifecycle */
         Firebird::IUtil* util = master->getUtilInterface();
-        Firebird::IDecFloat34* df34 = util->getDecFloat34(&status);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        df34->fromString(&status, str, static_cast<FB_DEC34*>(value));
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        fb_status->dispose();
+        Firebird::IDecFloat34* df34 = util->getDecFloat34(status.get());
+        if (status.hasError()) {  return -1; }
+        df34->fromString(status.get(), str, static_cast<FB_DEC34*>(value));
+        if (status.hasError()) {  return -1; }
+        
         return 0;
     } catch (...) {
         return -1;
@@ -1290,14 +1290,14 @@ extern "C" int fbu_string_to_int128(void *master_ptr, const char *str, int scale
     if (!master_ptr || !str || !value) return -1;
     try {
         auto* master = static_cast<Firebird::IMaster*>(master_ptr);
-        Firebird::IStatus* fb_status = master->getStatus();
-        Firebird::CheckStatusWrapper status(fb_status);
+        fb::CheckStatusScope status(master);
+        /* RAII: CheckStatusScope handles IStatus lifecycle */
         Firebird::IUtil* util = master->getUtilInterface();
-        Firebird::IInt128* i128 = util->getInt128(&status);
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        i128->fromString(&status, scale, str, static_cast<FB_I128*>(value));
-        if (status.isDirty()) { fb_status->dispose(); return -1; }
-        fb_status->dispose();
+        Firebird::IInt128* i128 = util->getInt128(status.get());
+        if (status.hasError()) {  return -1; }
+        i128->fromString(status.get(), scale, str, static_cast<FB_I128*>(value));
+        if (status.hasError()) {  return -1; }
+        
         return 0;
     } catch (...) {
         return -1;
@@ -1317,13 +1317,13 @@ extern "C" int fbu_encode_timestamp_tz(void *master_ptr, ISC_TIMESTAMP_TZ* times
     try {
         auto* master = static_cast<Firebird::IMaster*>(master_ptr);
         Firebird::IUtil* util = master->getUtilInterface();
-        Firebird::IStatus* fb_status = master->getStatus();
-        Firebird::CheckStatusWrapper status(fb_status);
+        fb::CheckStatusScope status(master);
+        /* RAII: CheckStatusScope handles IStatus lifecycle */
 
-        util->encodeTimeStampTz(&status, timestamp_tz, year, month, day,
+        util->encodeTimeStampTz(status.get(), timestamp_tz, year, month, day,
                                 hours, minutes, seconds, fractions, time_zone);
 
-        if (status.isDirty()) {
+        if (status.hasError()) {
             return -1;
         }
         return 0;

--- a/src/cpp/fb_statement.hpp
+++ b/src/cpp/fb_statement.hpp
@@ -112,7 +112,7 @@ public:
         }
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
+            fb::CheckStatusScope status(master);
             /* CRITICAL: Clear status before call.
              * Firebird's IMaster::getStatus() may return a reusable IStatus instance.
              * If previous calls populated errors, they can leak into subsequent calls
@@ -120,12 +120,10 @@ public:
              *
              * Fixes: tests/003.phpt (stale validation error after suppressed query)
              */
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
 
             // Prepare the statement
             statement_ = attachment->prepare(
-                &status,
+                status.get(),
                 transaction,
                 sql_length ? sql_length : static_cast<unsigned>(std::strlen(sql)),
                 sql,
@@ -133,15 +131,15 @@ public:
                 Firebird::IStatement::PREPARE_PREFETCH_METADATA
             );
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return false;
             }
 
             master_ = master;  // Store for FB4+ closeCursor/free status handling
             prepared_ = (statement_ != nullptr);
-            fb_status->dispose();
+            
             return prepared_;
 
         } catch (...) {
@@ -169,12 +167,10 @@ public:
         }
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
             statement_->execute(
-                &status,
+                status.get(),
                 transaction,
                 in_metadata,
                 static_cast<unsigned char*>(in_msg),
@@ -182,13 +178,13 @@ public:
                 static_cast<unsigned char*>(out_msg)
             );
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return false;
             }
 
-            fb_status->dispose();
+            
             return true;
 
         } catch (...) {
@@ -215,13 +211,11 @@ public:
         }
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
             // Close any existing cursor first
             if (result_set_) {
-                result_set_->close(&status);
+                result_set_->close(status.get());
                 result_set_->release();
                 result_set_ = nullptr;
                 cursor_open_ = false;
@@ -229,7 +223,7 @@ public:
 
             // Open new cursor
             result_set_ = statement_->openCursor(
-                &status,
+                status.get(),
                 transaction,
                 in_metadata,
                 static_cast<unsigned char*>(in_msg),
@@ -237,14 +231,14 @@ public:
                 cursor_flags
             );
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return false;
             }
 
             cursor_open_ = (result_set_ != nullptr);
-            fb_status->dispose();
+            
             return cursor_open_;
 
         } catch (...) {
@@ -268,29 +262,27 @@ public:
         }
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
             int fetch_result = result_set_->fetchNext(
-                &status,
+                status.get(),
                 static_cast<unsigned char*>(out_msg)
             );
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
                 cursor_open_ = false;
-                fb_status->dispose();
+                
                 return -1;
             }
 
             // Firebird::IStatus::RESULT_OK = 0, RESULT_NO_DATA = 100
             if (fetch_result != Firebird::IStatus::RESULT_OK) {
                 cursor_open_ = false;
-                fb_status->dispose();
+                
                 return 0;
             }
-            fb_status->dispose();
+            
             return 1;
 
         } catch (...) {
@@ -311,12 +303,10 @@ public:
     ) noexcept {
         if (!result_set_ || !master) return -1;
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
-            int r = result_set_->fetchPrior(&status, static_cast<unsigned char*>(out_msg));
-            if (statusHasError(fb_status)) { copyStatusToVector(fb_status, status_vector); fb_status->dispose(); return -1; }
-            fb_status->dispose();
+            fb::CheckStatusScope status(master);
+            int r = result_set_->fetchPrior(status.get(), static_cast<unsigned char*>(out_msg));
+            if (status.hasError()) { copyStatusToVector(status.status(), status_vector);  return -1; }
+            
             return (r == Firebird::IStatus::RESULT_OK) ? 1 : 0;
         } catch (...) { return -1; }
     }
@@ -332,12 +322,10 @@ public:
     ) noexcept {
         if (!result_set_ || !master) return -1;
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
-            int r = result_set_->fetchFirst(&status, static_cast<unsigned char*>(out_msg));
-            if (statusHasError(fb_status)) { copyStatusToVector(fb_status, status_vector); fb_status->dispose(); return -1; }
-            fb_status->dispose();
+            fb::CheckStatusScope status(master);
+            int r = result_set_->fetchFirst(status.get(), static_cast<unsigned char*>(out_msg));
+            if (status.hasError()) { copyStatusToVector(status.status(), status_vector);  return -1; }
+            
             return (r == Firebird::IStatus::RESULT_OK) ? 1 : 0;
         } catch (...) { return -1; }
     }
@@ -353,12 +341,10 @@ public:
     ) noexcept {
         if (!result_set_ || !master) return -1;
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
-            int r = result_set_->fetchLast(&status, static_cast<unsigned char*>(out_msg));
-            if (statusHasError(fb_status)) { copyStatusToVector(fb_status, status_vector); fb_status->dispose(); return -1; }
-            fb_status->dispose();
+            fb::CheckStatusScope status(master);
+            int r = result_set_->fetchLast(status.get(), static_cast<unsigned char*>(out_msg));
+            if (status.hasError()) { copyStatusToVector(status.status(), status_vector);  return -1; }
+            
             return (r == Firebird::IStatus::RESULT_OK) ? 1 : 0;
         } catch (...) { return -1; }
     }
@@ -375,12 +361,10 @@ public:
     ) noexcept {
         if (!result_set_ || !master) return -1;
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
-            int r = result_set_->fetchAbsolute(&status, position, static_cast<unsigned char*>(out_msg));
-            if (statusHasError(fb_status)) { copyStatusToVector(fb_status, status_vector); fb_status->dispose(); return -1; }
-            fb_status->dispose();
+            fb::CheckStatusScope status(master);
+            int r = result_set_->fetchAbsolute(status.get(), position, static_cast<unsigned char*>(out_msg));
+            if (status.hasError()) { copyStatusToVector(status.status(), status_vector);  return -1; }
+            
             return (r == Firebird::IStatus::RESULT_OK) ? 1 : 0;
         } catch (...) { return -1; }
     }
@@ -397,12 +381,10 @@ public:
     ) noexcept {
         if (!result_set_ || !master) return -1;
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
-            int r = result_set_->fetchRelative(&status, offset, static_cast<unsigned char*>(out_msg));
-            if (statusHasError(fb_status)) { copyStatusToVector(fb_status, status_vector); fb_status->dispose(); return -1; }
-            fb_status->dispose();
+            fb::CheckStatusScope status(master);
+            int r = result_set_->fetchRelative(status.get(), offset, static_cast<unsigned char*>(out_msg));
+            if (status.hasError()) { copyStatusToVector(status.status(), status_vector);  return -1; }
+            
             return (r == Firebird::IStatus::RESULT_OK) ? 1 : 0;
         } catch (...) { return -1; }
     }
@@ -432,18 +414,16 @@ public:
             // RESULT_NO_DATA (EOF), the FB server implicitly closes the cursor.
             // If cursor_open_ is false, release() avoids a use-after-free crash.
             if (cursor_open_ && master_) {
-                Firebird::IStatus* fb_status_ptr = master_->getStatus();
-                fb_status_ptr->init();
-                Firebird::CheckStatusWrapper fb_status(fb_status_ptr);
-                result_set_->close(&fb_status);
+                fb::CheckStatusScope status(master_);
+                result_set_->close(status.get());
                 result_set_ = nullptr;  // close() released the interface
                 cursor_open_ = false;
-                if (statusHasError(fb_status_ptr)) {
-                    copyStatusToVector(fb_status_ptr, status_vector);
-                    fb_status_ptr->dispose();
+                if (status.hasError()) {
+                    copyStatusToVector(status.status(), status_vector);
+                    
                     return false;
                 }
-                fb_status_ptr->dispose();
+                
                 return true;
             }
             // EOF path or no master: release only (server already closed cursor)
@@ -491,18 +471,16 @@ public:
             // the prepared statement server-side and releases the interface.
             // Fixes #135 server RAM accumulation for DML via fbird_query().
             if (master_) {
-                Firebird::IStatus* fb_status_ptr = master_->getStatus();
-                fb_status_ptr->init();
-                Firebird::CheckStatusWrapper fb_status(fb_status_ptr);
-                statement_->free(&fb_status);
+                fb::CheckStatusScope status(master_);
+                statement_->free(status.get());
                 statement_ = nullptr;  // free() released the interface
                 prepared_ = false;
-                if (statusHasError(fb_status_ptr)) {
-                    copyStatusToVector(fb_status_ptr, status_vector);
-                    fb_status_ptr->dispose();
+                if (status.hasError()) {
+                    copyStatusToVector(status.status(), status_vector);
+                    
                     return false;
                 }
-                fb_status_ptr->dispose();
+                
                 return true;
             }
             // Fallback if no master: release only
@@ -534,19 +512,17 @@ public:
         if (!statement_ || !master) return nullptr;
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
-            auto* meta = statement_->getInputMetadata(&status);
+            auto* meta = statement_->getInputMetadata(status.get());
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return nullptr;
             }
 
-            fb_status->dispose();
+            
             return meta;
 
         } catch (...) {
@@ -565,19 +541,17 @@ public:
         if (!statement_ || !master) return nullptr;
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
-            auto* meta = statement_->getOutputMetadata(&status);
+            auto* meta = statement_->getOutputMetadata(status.get());
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return nullptr;
             }
 
-            fb_status->dispose();
+            
             return meta;
 
         } catch (...) {
@@ -596,19 +570,17 @@ public:
         if (!statement_ || !master) return 0;
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
-            unsigned stmt_type = statement_->getType(&status);
+            unsigned stmt_type = statement_->getType(status.get());
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return 0;
             }
 
-            fb_status->dispose();
+            
             return stmt_type;
 
         } catch (...) {
@@ -627,19 +599,17 @@ public:
         if (!statement_ || !master) return 0;
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
-            ISC_UINT64 count = statement_->getAffectedRecords(&status);
+            ISC_UINT64 count = statement_->getAffectedRecords(status.get());
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return 0;
             }
 
-            fb_status->dispose();
+            
             return count;
 
         } catch (...) {
@@ -662,19 +632,17 @@ public:
         if (!statement_ || !master) return false;
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
-            statement_->setTimeout(&status, ms);
+            statement_->setTimeout(status.get(), ms);
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return false;
             }
 
-            fb_status->dispose();
+            
             return true;
 
         } catch (...) {
@@ -691,19 +659,17 @@ public:
         if (!statement_ || !master) return 0;
 
         try {
-            Firebird::IStatus* fb_status = master->getStatus();
-            fb_status->init();
-            Firebird::CheckStatusWrapper status(fb_status);
+            fb::CheckStatusScope status(master);
 
-            unsigned int ms = statement_->getTimeout(&status);
+            unsigned int ms = statement_->getTimeout(status.get());
 
-            if (statusHasError(fb_status)) {
-                copyStatusToVector(fb_status, status_vector);
-                fb_status->dispose();
+            if (status.hasError()) {
+                copyStatusToVector(status.status(), status_vector);
+                
                 return 0;
             }
 
-            fb_status->dispose();
+            
             return ms;
 
         } catch (...) {


### PR DESCRIPTION
## Summary

Re-applies PR #542 (reverted by #548) with a root-cause fix for the 003.phpt CI regression.

## Part 1: IStatus leak fixes (PR #542, issues #520 + #521)

Migrated from manual `getStatus()/init()/dispose()` pattern to `fb::CheckStatusScope` (RAII) in:
- `fb_statement.hpp` (15 sites: prepare, execute, openCursor, fetch*, closeCursor, free, getMetadata, getType, getAffectedRecords, setTimeout, getTimeout)
- `firebird_utils.cpp` encoding helpers (6 sites: int128, decfloat16, decfloat34)

## Part 2: Root cause of 003.phpt regression (THE FIX)

PR #542 exposed a latent bug in `_php_fbird_insert_alias()` (`fbird_metadata.c:53`):
it used `zend_symtable_str_find_ptr()` to check for duplicate column aliases, but this function returns `NULL` for `IS_NULL` zvals (it only returns non-NULL for `IS_PTR` zvals).

Since `_php_fbird_insert_alias` stores `ZVAL_NULL` entries, the duplicate check ALWAYS returned NULL (not found), causing:
- First 'ID' inserted (hash size 0->1)
- Second 'ID': `find_ptr` returns NULL -> tries to insert 'ID' again -> `zend_symtable_str_update` overwrites existing entry (size stays 1)
- All 11 'ID' columns collapse to 1 entry, all 11 'CONSTANT' to 1 entry
- Result: 2 columns instead of 22

```
Before (broken):                     After (fixed):
insert 'ID' (before=0) -> after=1    insert 'ID' (before=0) -> after=1
insert 'ID' (before=1) -> after=1    insert 'ID' (before=1) -> find_ptr finds it
  ^ find_ptr returned NULL              -> dedup to 'ID_01' -> after=2
  -> update overwrites 'ID'           insert 'ID' (before=2) -> find_ptr finds it
  -> size stays 1                      -> dedup to 'ID_02' -> after=3
                                      ... 22 entries total
```

### Why it was latent before PR #542

This bug was latent because the server-side deduplication (FB4+ metadata returns `ID`, `ID_01`, `ID_02`, ...) masked it — all names were already unique, so the broken `find_ptr` check was never exercised.

PR #542 changed `IStatus` handling in `Statement::prepare()`, which changed how `out_metadata` is populated, which caused `fbm_get_alias()` to return undeduplicated names (`'ID'` for all 11 columns), exposing the `zend_symtable_str_find_ptr` bug.

### Fix

Use `zend_symtable_str_find()` (returns `zval*`, non-NULL = key exists) instead of `zend_symtable_str_find_ptr()` (returns `void*`, only non-NULL for `IS_PTR` zvals).

```c
// Before (broken - returns NULL for IS_NULL zvals):
while (zend_symtable_str_find_ptr(ht, alias, alias_len) != NULL) {

// After (correct - returns non-NULL for any existing key):
while (zend_symtable_str_find(ht, alias, alias_len) != NULL) {
```

## Verification (CI-exact repro environment)

Built and tested in environment matching CI exactly:
- **PHP build image**: `php:8.4-cli-bookworm`
- **FB client**: official tarball from GitHub releases (`Firebird-4.0.7.3271-0.amd64.tar.gz`, `FB_API_VER=40`)
- **FB4 server**: `firebirdsql/firebird:4` (CI service container)
- **FB5 server**: `firebirdsql/firebird:5` (CI service container)
- **Test env**: `ISC_USER=SYSDBA ISC_PASSWORD=masterkey FIREBIRD_HOST=firebird FIREBIRD_DB_DIR=/tmp FIREBIRD_DB_PATH=/var/lib/firebird/data/test.fdb NO_INTERACTION=1 REPORT_EXIT_STATUS=1`
- **Test command**: `php run-tests.php -d extension=... --set-timeout 15 tests/003.phpt`

Results:
- `tests/003.phpt` **PASS** on FB4 (was failing)
- `tests/003.phpt` **PASS** on FB5 (was failing)

Refs: #520, #521, #542, #548, #549