### PR TITLE
docs(transaction): #523/#541 - document sentinel head pattern + regression test

### DIFF
--- a/fbird_connection.c
+++ b/fbird_connection.c
@@ -83,6 +83,10 @@ void _php_fbird_commit_link(fbird_db_link *link)
 	fbird_event *e;
 	FBDEBUG("Checking transactions to close...");
 
+	/* Position-sensitive cleanup: relies on tr_list sentinel head node pattern.
+	 * Index 0 = default transaction (commit + efree directly, NOT a le_trans resource).
+	 * Index >0 = explicit transaction (rollback + leave to le_trans destructor).
+	 * The sentinel head (trans=NULL placeholder) is allocated at 5 sites — see issue #541. */
 	for (l = link->tr_list; l != NULL; ++i) {
 		fbird_tr_list *p = l;
 		if (p->trans != 0) {

--- a/fbird_query_exec.c
+++ b/fbird_query_exec.c
@@ -187,6 +187,11 @@ int _php_fbird_exec(INTERNAL_FUNCTION_PARAMETERS, fbird_query *fb_query, zval *a
 				trans->fbt_transaction = new_trans;
 				trans->db_link[0] = fb_query->link;
 
+				/* Sentinel head node: reserves index 0 for the default transaction.
+				 * _php_fbird_commit_link() uses i==0 to distinguish:
+				 *   - Default tx (index 0): commit + efree (not a registered resource)
+				 *   - Explicit tx (index >0): rollback + leave to le_trans destructor
+				 * Do NOT remove this placeholder — see issue #541 investigation. */
 				if (fb_query->link->tr_list == NULL) {
 					fb_query->link->tr_list = (fbird_tr_list *) emalloc(sizeof(fbird_tr_list));
 					fb_query->link->tr_list->trans = NULL;

--- a/fbird_transaction.c
+++ b/fbird_transaction.c
@@ -364,6 +364,11 @@ PHP_FUNCTION(fbird_trans_start)
 	fb_trans->affected_rows = 0;
 	fb_trans->db_link[0] = fb_link;
 
+	/* Sentinel head node: reserves index 0 for the default transaction.
+	 * _php_fbird_commit_link() uses i==0 to distinguish:
+	 *   - Default tx (index 0): commit + efree (not a registered resource)
+	 *   - Explicit tx (index >0): rollback + leave to le_trans destructor
+	 * Do NOT remove this placeholder — see issue #541 investigation. */
 	/* the first item in the connection-transaction list is reserved for the default transaction */
 	if (fb_link->tr_list == NULL) {
 		fb_link->tr_list = (fbird_tr_list *) emalloc(sizeof(fbird_tr_list));
@@ -933,6 +938,11 @@ register_trans:
 		fbird_tr_list **l;
 		fb_trans->db_link[i] = fb_link[i];
 
+		/* Sentinel head node: reserves index 0 for the default transaction.
+		 * _php_fbird_commit_link() uses i==0 to distinguish:
+		 *   - Default tx (index 0): commit + efree (not a registered resource)
+		 *   - Explicit tx (index >0): rollback + leave to le_trans destructor
+		 * Do NOT remove this placeholder — see issue #541 investigation. */
 		/* the first item in the connection-transaction list is reserved for the default transaction */
 		if (fb_link[i]->tr_list == NULL) {
 			fb_link[i]->tr_list = (fbird_tr_list *) emalloc(sizeof(fbird_tr_list));
@@ -959,6 +969,11 @@ int _php_fbird_def_trans(fbird_db_link *fb_link, fbird_transaction **trans)
 		return FAILURE;
 	}
 
+	/* Sentinel head node: reserves index 0 for the default transaction.
+	 * _php_fbird_commit_link() uses i==0 to distinguish:
+	 *   - Default tx (index 0): commit + efree (not a registered resource)
+	 *   - Explicit tx (index >0): rollback + leave to le_trans destructor
+	 * Do NOT remove this placeholder — see issue #541 investigation. */
 	/* the first item in the connection-transaction list is reserved for the default transaction */
 	if (fb_link->tr_list == NULL) {
 		fb_link->tr_list = (fbird_tr_list *) emalloc(sizeof(fbird_tr_list));

--- a/firebird.c
+++ b/firebird.c
@@ -1497,6 +1497,11 @@ PHP_FUNCTION(fbird_reconnect_transaction)
 	fb_trans->db_link[0] = fb_link;
 
 	/* Link into connection's transaction list */
+	/* Sentinel head node: reserves index 0 for the default transaction.
+	 * _php_fbird_commit_link() uses i==0 to distinguish:
+	 *   - Default tx (index 0): commit + efree (not a registered resource)
+	 *   - Explicit tx (index >0): rollback + leave to le_trans destructor
+	 * Do NOT remove this placeholder — see issue #541 investigation. */
 	if (fb_link->tr_list == NULL) {
 		fb_link->tr_list = (fbird_tr_list *)emalloc(sizeof(fbird_tr_list));
 		fb_link->tr_list->trans = NULL;

--- a/tests/transaction_default_slot.phpt
+++ b/tests/transaction_default_slot.phpt
@@ -1,0 +1,99 @@
+--TEST--
+Default transaction sentinel head slot pattern (issues #523, #541)
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+require("firebird.inc");
+
+/* Regression test for the sentinel head node pattern in tr_list.
+ *
+ * The first node in the connection's transaction list (tr_list[0]) is
+ * reserved for the default transaction. Explicit transactions are
+ * appended at index >= 1. _php_fbird_commit_link() uses this positional
+ * invariant to distinguish:
+ *   - Default tx (index 0): commit + efree (not a registered le_trans resource)
+ *   - Explicit tx (index >0): rollback + leave to le_trans destructor
+ *
+ * Removing the placeholder (trans=NULL sentinel) causes use-after-free:
+ * explicit transactions land at index 0 and get efree()'d directly,
+ * then the le_trans destructor touches freed memory. See issues #523, #541.
+ *
+ * This test covers:
+ *   1. fbird_trans_start() with no prior default transaction
+ *   2. fbird_query() creates default transaction
+ *   3. Both default + explicit transaction coexist
+ *   4. pconnect cached connection (issue119 regression)
+ *   5. Multiple trans_start cycles (issue307 regression)
+ */
+
+echo "Test 1: fbird_trans_start() with no prior default transaction\n";
+$conn = fbird_connect($test_base);
+if (!$conn) die("connect failed: " . fbird_errmsg() . "\n");
+$tx = fbird_trans_start($conn, [FBIRD_WRITE]);
+var_dump(is_resource($tx) || (is_object($tx) && $tx instanceof Firebird\Transaction));
+fbird_commit($tx);
+
+echo "\nTest 2: fbird_query() creates default transaction\n";
+$q = fbird_query($conn, "SELECT 1 FROM rdb\$database");
+$row = fbird_fetch_row($q);
+var_dump($row);
+fbird_free_result($q);
+
+echo "\nTest 3: Both default + explicit transaction coexist\n";
+$q2 = fbird_query($conn, "SELECT 2 FROM rdb\$database");
+$tx2 = fbird_trans_start($conn, [FBIRD_WRITE]);
+var_dump(is_resource($tx2) || (is_object($tx2) && $tx2 instanceof Firebird\Transaction));
+fbird_commit($tx2);
+fbird_free_result($q2);
+
+fbird_close($conn);
+
+echo "\nTest 4: pconnect cached connection (issue119 regression)\n";
+$conn1 = fbird_pconnect($test_base, $user, $password);
+if (!$conn1) die("pconnect 1 failed: " . fbird_errmsg() . "\n");
+$tr1 = fbird_trans_start($conn1, [FBIRD_WRITE]);
+var_dump(is_resource($tr1) || (is_object($tr1) && $tr1 instanceof Firebird\Transaction));
+fbird_commit($tr1);
+fbird_close($conn1);
+
+$conn2 = fbird_pconnect($test_base, $user, $password);
+if (!$conn2) die("pconnect 2 failed: " . fbird_errmsg() . "\n");
+$tr2 = fbird_trans_start($conn2, [FBIRD_WRITE]);
+var_dump(is_resource($tr2) || (is_object($tr2) && $tr2 instanceof Firebird\Transaction));
+fbird_commit($tr2);
+fbird_close($conn2);
+
+echo "\nTest 5: Multiple trans_start cycles (issue307 regression)\n";
+$conn3 = fbird_connect($test_base);
+for ($i = 0; $i < 3; $i++) {
+    $t = fbird_trans_start($conn3, [FBIRD_WRITE]);
+    if (!$t) die("trans_start cycle $i failed: " . fbird_errmsg() . "\n");
+    fbird_commit($t);
+}
+echo "3 cycles OK\n";
+fbird_close($conn3);
+
+echo "\nDone\n";
+?>
+--EXPECTF--
+Test 1: fbird_trans_start() with no prior default transaction
+bool(true)
+
+Test 2: fbird_query() creates default transaction
+array(1) {
+  [0]=>
+  int(1)
+}
+
+Test 3: Both default + explicit transaction coexist
+bool(true)
+
+Test 4: pconnect cached connection (issue119 regression)
+bool(true)
+bool(true)
+
+Test 5: Multiple trans_start cycles (issue307 regression)
+3 cycles OK
+
+Done


### PR DESCRIPTION
## Summary

Documents the `tr_list` sentinel head node pattern and adds a regression test to prevent future attempts to remove it.

## Background

The `tr_list` placeholder node (`trans=NULL`) is a **deliberate sentinel head node**, not a spurious allocation or memory leak. It reserves index 0 for the default transaction, which `_php_fbird_commit_link()` uses positionally (`i==0`) to distinguish:

| Index | Type | Cleanup |
|---|---|---|
| 0 | Default transaction | commit + `efree` directly (NOT a `le_trans` resource) |
| >0 | Explicit transaction | rollback + leave to `le_trans` destructor |

### Why removing it breaks things

PR #537 attempted to remove the placeholder. This caused use-after-free: explicit transactions landed at index 0 and got `efree()`'d directly, then the `le_trans` destructor touched freed memory. This broke `issue119.phpt` and `issue307_trans_start_nullable_options.phpt`.

### The 'memory leak' claim in #523 is incorrect

The placeholder is `sizeof(fbird_tr_list)` = 2 pointers = ~16 bytes on 64-bit. Allocated **once per connection** (when the first transaction is registered), freed in `_php_fbird_commit_link()` during connection close. No leak.

## Changes

### Documentation (6 sites)

Added sentinel-head template comment at all 5 allocation sites:
- `firebird.c:1500` (`fbird_reconnect_transaction`)
- `fbird_transaction.c:367` (`fbird_trans_start` single-link)
- `fbird_transaction.c:941` (`fbird_trans` multi-link `register_trans:`)
- `fbird_transaction.c:972` (`_php_fbird_def_trans` default tx creator)
- `fbird_query_exec.c:190` (`_php_fbird_exec` SET TRANSACTION SQL)

Added position-sensitive cleanup comment at destruction site:
- `fbird_connection.c:86` (`_php_fbird_commit_link`)

### Regression test (NEW)

`tests/transaction_default_slot.phpt` covers:
1. `fbird_trans_start()` with no prior default transaction
2. `fbird_query()` creates default transaction
3. Both default + explicit transaction coexist
4. `fbird_pconnect()` cached connection (issue119 regression)
5. Multiple `trans_start` cycles (issue307 regression)

## Verification

Local tests on CI-exact environment (php:8.4-cli-bookworm + official FB4 tarball):
- `tests/transaction_default_slot.phpt` PASS (FB4 + FB5)
- `tests/issue119.phpt` PASS (FB4 + FB5)
- `tests/issue307_trans_start_nullable_options.phpt` PASS (FB4 + FB5)

## Issue closure

After merge:
- **#523**: Close as "not a bug" — sentinel head is correct behavior
- **#541**: Close as completed — investigation done, Option A applied
- File v14 follow-up for Option B refactor (`is_default` flag)

Refs: #523, #541