### PR TITLE
fix(#565): switch APK build from CMake to autotools

### DIFF
--- a/.github/workflows/packages-linux.yml
+++ b/.github/workflows/packages-linux.yml
@@ -231,7 +231,7 @@ jobs:
               set -eu
 
               # Install build dependencies.
-              # jane: APKBUILD makedepends lists "ninja", not "samurai".
+              # jane: APKBUILD makedepends uses autotools (libtool, not cmake/ninja).
               #       sudo is needed by abuild-keygen -i to copy the public
               #       key to /etc/apk/keys/. Without sudo, abuild-keygen
               #       tries doas (not installed) and fails.
@@ -244,8 +244,7 @@ jobs:
                 automake \
                 re2c \
                 build-base \
-                cmake \
-                ninja \
+                libtool \
                 git \
                 icu-dev \
                 patchelf
@@ -316,7 +315,8 @@ jobs:
   #       draft:false after validating SLSA attestations).
   upload-release-assets:
     name: Upload packages to GitHub Release
-    # jane: build-apk is blocked on upstream Firebird #9122 (musl CMake).
+    # jane: build-apk previously blocked on upstream Firebird #7152 (broken CMake).
+    #       Fixed by switching to autotools build (configure + make).
     #       Use if: always() to upload deb+rpm even when apk fails.
     needs: [build-deb, build-rpm, build-apk]
     if: startsWith(github.ref, 'refs/tags/') && !cancelled()

--- a/packaging/apk/APKBUILD
+++ b/packaging/apk/APKBUILD
@@ -6,7 +6,9 @@
 #
 # Alpine uses musl libc, so the Firebird client library (libfbclient) must be
 # built from source - the official FB5 tarball is glibc-linked. The musl build
-# is handled by firebird-client-musl-build.sh (a separate source file).
+# uses autotools (configure + make --enable-client-only), NOT CMake, because
+# the CMake build references deleted bootstrap artifacts (makeHeader.cpp,
+# facilities2.sql - see FirebirdSQL/firebird#7152).
 #
 # Package naming: php84-firebird (NOT php84-pecl-firebird).
 # This extension is distributed via PIE (github.com/php/pie) and Packagist,
@@ -27,8 +29,9 @@ pkgver=13.2.0
 pkgrel=0
 pkgdesc="Modern Firebird database extension for PHP 8.4 (fbird_* API + OOP + PDO)"
 url="https://github.com/satwareAG/php-firebird"
-# jane: Firebird v5.0.4 CMake hardcodes -msse4 (x86 instruction set).
-#       aarch64 build fails until Firebird upstream removes this or we patch it.
+# jane: arch restricted to x86_64 pending aarch64 testing on Alpine/musl.
+#       The autotools build may support aarch64 (configure.ac has linux_arm64
+#       platform case), but this is untested. Add aarch64 after CI validation.
 arch="x86_64"
 license="PHP-3.01"
 depends="php84-common php84-pdo icu-libs"
@@ -39,8 +42,7 @@ makedepends="
 	build-base
 	re2c
 	git
-	cmake
-	ninja
+	libtool
 	icu-dev
 "
 # jane: provides/replaces php84-interbase if it existed on Alpine (legacy ext).

--- a/packaging/apk/firebird-client-musl-build.sh
+++ b/packaging/apk/firebird-client-musl-build.sh
@@ -7,6 +7,14 @@
 # libc (Alpine Linux). The official FB5 tarball is glibc-linked and cannot be
 # used on Alpine without this.
 #
+# Uses autotools (configure + make), NOT CMake. The CMake build is a broken
+# third-party effort: it references misc/makeHeader.cpp and src/msgs/
+# facilities2.sql, both deleted from the Firebird source tree in 2019/2021
+# (commits 45d5e3aa, ee088c22). The Firebird team does not use CMake
+# (see FirebirdSQL/firebird#7152). Autotools with --enable-client-only
+# builds only the yvalve (libfbclient) + headers, avoiding the missing
+# bootstrap artifacts entirely.
+#
 # Output: installs libfbclient.so + headers to $FB_ROOT
 #
 # Usage (inside alpine:3.21 container):
@@ -20,7 +28,7 @@ FB_ROOT="${FB_ROOT:-/tmp/fbclient}"
 FB_VERSION="${FB_VERSION:-5.0.4}"
 NPROC="${NPROC:-$(nproc 2>/dev/null || echo 2)}"
 
-echo ">>> Building Firebird client v${FB_VERSION} for musl (Alpine)..."
+echo ">>> Building Firebird client v${FB_VERSION} for musl (Alpine) via autotools..."
 
 mkdir -p "${FB_ROOT}"
 
@@ -31,45 +39,74 @@ if [ ! -d "${FBSRC}/.git" ]; then
         https://github.com/FirebirdSQL/firebird.git "${FBSRC}"
 fi
 
-# Build the yvalve target (produces libfbclient.so).
-# jane: Firebird v5.0.4 CMake does NOT support CLIENT_ONLY, install_client,
-#       or install_headers targets. The client library target is "yvalve".
-#       There are no CMake install() commands - must manually copy output.
-mkdir -p "${FBSRC}/build"
-cd "${FBSRC}/build"
+cd "${FBSRC}"
 
-cmake .. \
-    -G Ninja \
-    -DCMAKE_BUILD_TYPE=Release
+# Generate configure from configure.ac (git checkout has no pre-generated configure).
+# jane: autogen.sh runs autoreconf --install --force --verbose then configure.
+#       NOCONFIGURE=1 skips the configure step in autogen.sh so we can pass
+#       our own flags.
+export NOCONFIGURE=1
+./autogen.sh
 
-# Build only the yvalve (client library) target, not the full server.
-# jane: yvalve still pulls in some server build dependencies via CMake
-#       add_dependencies, so the full source tree compiles. This is heavier
-#       than ideal but is the only way to build libfbclient from source.
-ninja -j"${NPROC}" yvalve
+# Configure: client-only build, no server, no editline, no tomcrypt.
+# jane: --enable-client-only sets CLIENT_ONLY_FLG=Y in Makefile.in, which
+#       skips engine, fbintl, utilities, gpre, plugins, examples. Only
+#       yvalve (libfbclient) and include_generic (headers) are built.
+#       --without-tomcrypt avoids a dependency we don't need for the client.
+./configure \
+    --enable-client-only \
+    --without-tomcrypt \
+    --with-builtin-tommath \
+    --prefix="${FB_ROOT}"
+
+# Build the client library and headers.
+# jane: The full client-only build sequence is:
+#   make external               (cloop, decNumber, int128 - prerequisites)
+#   make updateCloopInterfaces  (generate IdlFbInterfaces.h from IDL)
+#   make yvalve                 (libfbclient.so)
+#   make include_generic        (copy public headers to build dir)
+#   make updateBuildNum         (writeBuildNum.h - needed by some headers)
+#   make export_lists           (linker symbol export lists)
+# We call them explicitly because `make` alone (master_process) also builds
+# the server when CLIENT_ONLY_FLG=N (the default if configure wasn't run
+# correctly). With --enable-client-only, the master_process skips server
+# targets, but calling prerequisites explicitly is safer and clearer.
+make -j"${NPROC}" external
+make -j"${NPROC}" updateCloopInterfaces
+make -j"${NPROC}" yvalve
+make -j"${NPROC}" include_generic
 
 # Manually copy the built library and headers to FB_ROOT.
-# jane: Firebird CMake has no install() targets. Output is in build/gen/.
+# jane: Firebird autotools has an install target but it tries to install
+#       the full server layout. We only need the client library + headers.
 mkdir -p "${FB_ROOT}/lib" "${FB_ROOT}/include"
 
-# Find the built library (output name is fbclient, symlinked as libfbclient)
-cp -a "${FBSRC}/build/gen/libfbclient.so"* "${FB_ROOT}/lib/" 2>/dev/null || true
-
-# If the library is elsewhere, search for it
-if [ ! -f "${FB_ROOT}/lib/libfbclient.so" ]; then
-    find "${FBSRC}/build" -name "libfbclient.so*" -exec cp -aL {} "${FB_ROOT}/lib/" \;
+# Find and copy the built library.
+# jane: autotools outputs to gen/Native/firebird/lib/ (TARGET=Native default).
+FB_BUILD_LIB="${FBSRC}/gen/Native/firebird/lib"
+if [ ! -f "${FB_BUILD_LIB}/libfbclient.so" ]; then
+    # Search alternative locations
+    # jane: guard with || true - set -e would exit silently if find returns empty
+    FB_BUILD_LIB=$(find "${FBSRC}/gen" -name "libfbclient.so" -print -quit 2>/dev/null | xargs -r dirname 2>/dev/null || true)
 fi
+cp -a "${FB_BUILD_LIB}/libfbclient.so"* "${FB_ROOT}/lib/" 2>/dev/null || true
 
-# Copy public headers
-cp -a "${FBSRC}/src/include/firebird" "${FB_ROOT}/include/"
-cp -a "${FBSRC}/src/include/iberror.h" "${FB_ROOT}/include/" 2>/dev/null || true
-# ibase.h is generated during build
-find "${FBSRC}/build" -name "ibase.h" -exec cp {} "${FB_ROOT}/include/" \; 2>/dev/null || true
+# Copy public headers from the build output directory.
+# jane: include_generic copies headers to gen/Native/firebird/include/.
+FB_BUILD_INC="${FBSRC}/gen/Native/firebird/include"
+if [ -d "${FB_BUILD_INC}/firebird" ]; then
+    cp -a "${FB_BUILD_INC}/firebird" "${FB_ROOT}/include/"
+fi
+cp -a "${FB_BUILD_INC}/iberror.h" "${FB_ROOT}/include/" 2>/dev/null || true
+cp -a "${FB_BUILD_INC}/ib_util.h" "${FB_ROOT}/include/" 2>/dev/null || true
+# ibase.h is in the firebird/ subdirectory (flattened by include_generic)
+cp -a "${FB_BUILD_INC}/firebird/ibase.h" "${FB_ROOT}/include/" 2>/dev/null || \
+    cp -a "${FBSRC}/src/include/ibase.h" "${FB_ROOT}/include/" 2>/dev/null || true
 
 # Verify
 if [ ! -f "${FB_ROOT}/lib/libfbclient.so" ]; then
     echo "ERROR: libfbclient.so not found after build" >&2
-    find "${FBSRC}/build" -name "*.so*" | head -20
+    find "${FBSRC}/gen" -name "*.so*" | head -20
     return 1
 fi
 

--- a/packaging/apk/firebird-client-musl-build.sh
+++ b/packaging/apk/firebird-client-musl-build.sh
@@ -60,45 +60,43 @@ export NOCONFIGURE=1
     --prefix="${FB_ROOT}"
 
 # Build the client library and headers.
-# jane: The full client-only build sequence is:
-#   make external               (cloop, decNumber, int128 - prerequisites)
-#   make updateCloopInterfaces  (generate IdlFbInterfaces.h from IDL)
-#   make yvalve                 (libfbclient.so)
-#   make include_generic        (copy public headers to build dir)
-#   make updateBuildNum         (writeBuildNum.h - needed by some headers)
-#   make export_lists           (linker symbol export lists)
-# We call them explicitly because `make` alone (master_process) also builds
-# the server when CLIENT_ONLY_FLG=N (the default if configure wasn't run
-# correctly). With --enable-client-only, the master_process skips server
-# targets, but calling prerequisites explicitly is safer and clearer.
-make -j"${NPROC}" external
-make -j"${NPROC}" updateCloopInterfaces
-make -j"${NPROC}" yvalve
-make -j"${NPROC}" include_generic
+# jane: Use `make` alone (not individual targets) because the Firebird
+#       build system requires the `all` -> `firebird` -> `master_process`
+#       chain to set TARGET=Release, create the autoconfig.h symlink, and
+#       run `rest` (generates iberror_c.h). Calling `make yvalve` directly
+#       skips these prerequisites and produces broken/missing output.
+#       With --enable-client-only, master_process skips all server targets
+#       (engine, fbintl, utilities, gpre, plugins, examples) and only builds
+#       yvalve (libfbclient) + include_generic (headers).
+make -j"${NPROC}"
 
 # Manually copy the built library and headers to FB_ROOT.
 # jane: Firebird autotools has an install target but it tries to install
 #       the full server layout. We only need the client library + headers.
+#       With TARGET=Release (set by master_process), output goes to
+#       gen/Release/firebird/. The gen/Native/ path is cross-compile only.
 mkdir -p "${FB_ROOT}/lib" "${FB_ROOT}/include"
 
 # Find and copy the built library.
-# jane: autotools outputs to gen/Native/firebird/lib/ (TARGET=Native default).
-FB_BUILD_LIB="${FBSRC}/gen/Native/firebird/lib"
+# jane: autotools outputs to gen/Release/firebird/lib/ on Linux.
+FB_BUILD_LIB="${FBSRC}/gen/Release/firebird/lib"
 if [ ! -f "${FB_BUILD_LIB}/libfbclient.so" ]; then
-    # Search alternative locations
+    # Search alternative locations (e.g. if TARGET differs)
     # jane: guard with || true - set -e would exit silently if find returns empty
     FB_BUILD_LIB=$(find "${FBSRC}/gen" -name "libfbclient.so" -print -quit 2>/dev/null | xargs -r dirname 2>/dev/null || true)
 fi
 cp -a "${FB_BUILD_LIB}/libfbclient.so"* "${FB_ROOT}/lib/" 2>/dev/null || true
 
 # Copy public headers from the build output directory.
-# jane: include_generic copies headers to gen/Native/firebird/include/.
-FB_BUILD_INC="${FBSRC}/gen/Native/firebird/include"
+# jane: include_generic copies headers to gen/Release/firebird/include/.
+FB_BUILD_INC="${FBSRC}/gen/Release/firebird/include"
 if [ -d "${FB_BUILD_INC}/firebird" ]; then
     cp -a "${FB_BUILD_INC}/firebird" "${FB_ROOT}/include/"
 fi
-cp -a "${FB_BUILD_INC}/iberror.h" "${FB_ROOT}/include/" 2>/dev/null || true
-cp -a "${FB_BUILD_INC}/ib_util.h" "${FB_ROOT}/include/" 2>/dev/null || true
+cp -a "${FB_BUILD_INC}/iberror.h" "${FB_ROOT}/include/" 2>/dev/null || \
+    cp -a "${FBSRC}/src/include/iberror.h" "${FB_ROOT}/include/" 2>/dev/null || true
+cp -a "${FB_BUILD_INC}/ib_util.h" "${FB_ROOT}/include/" 2>/dev/null || \
+    cp -a "${FBSRC}/src/include/ib_util.h" "${FB_ROOT}/include/" 2>/dev/null || true
 # ibase.h is in the firebird/ subdirectory (flattened by include_generic)
 cp -a "${FB_BUILD_INC}/firebird/ibase.h" "${FB_ROOT}/include/" 2>/dev/null || \
     cp -a "${FBSRC}/src/include/ibase.h" "${FB_ROOT}/include/" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes #565: Alpine APK build failed because CMake references deleted Firebird bootstrap artifacts.

### Root cause

CMake is a third-party build for Firebird that the core team does not maintain (FirebirdSQL/firebird#7152, open since 2022). Commit 45d5e3aa (2019) deleted misc/makeHeader.cpp and commit ee088c22 (2021) deleted src/msgs/facilities2.sql, but src/CMakeLists.txt was never updated. The autotools build (builds/posix/Makefile.in) never referenced these files.

### Fix

Switch from CMake+Ninja to autotools with --enable-client-only, which builds only the yvalve (libfbclient) + headers without needing the deleted bootstrap artifacts.

Files changed:
- firebird-client-musl-build.sh: autogen.sh + configure + make (replaces cmake + ninja). --with-builtin-tommath avoids missing system tommath on Alpine.
- APKBUILD: replace cmake+ninja makedepends with libtool. Update arch comment.
- packages-linux.yml: remove cmake/ninja from CI install, add libtool.

### Review

Reviewed by jane subagent. 4 issues found and fixed:
1. (High) Missing --with-builtin-tommath - configure unconditionally checks for tommath
2. (Low) set -e + empty find causes silent exit - guarded with || true
3. (Low) CI still installed cmake/ninja - removed
4. (Low) APKBUILD arch comment referenced CMake -msse4 - updated for autotools

### Test plan

- [ ] CI passes on this PR
- [ ] Next tag push: Build .apk CI job passes
- [ ] APK artifact produced and uploaded to GitHub Release